### PR TITLE
Consistently add meshes to a named Collection regardless of materials.

### DIFF
--- a/i_scene_cp77_gltf/__init__.py
+++ b/i_scene_cp77_gltf/__init__.py
@@ -115,10 +115,15 @@ class CP77Import(bpy.types.Operator,ImportHelper):
                                         index = 0
                                         for rawmat in obj["Materials"]:
                                             if rawmat["Name"] == matname:
-                                                bpymat = Builder.create(index)
-                                                bpy.data.meshes[name].materials.append(bpymat)
-                                                usedMaterials.update( {matname: bpymat} )
-                                            index = index + 1
+                                                try:
+                                                    bpymat = Builder.create(index)
+                                                    bpy.data.meshes[name].materials.append(bpymat)
+                                                    usedMaterials.update( {matname: bpymat} )
+                                                    index = index + 1
+                                                except FileNotFoundError as fnfe:
+                                                    #Kwek -- finally, even if the Builder couldn't find the materials, keep calm and carry on - fixing the Builder is Out-of-scope
+                                                    print(str(fnfe))
+                                                    pass 
                                     else:
                                         bpy.data.meshes[name].materials.append(usedMaterials[matname])
                                 

--- a/i_scene_cp77_gltf/__init__.py
+++ b/i_scene_cp77_gltf/__init__.py
@@ -1,6 +1,6 @@
 bl_info = {
     "name": "Cyberpunk 2077 glTF Importer",
-    "author": "HitmanHimself, Turk, Jato, dragonzkiller",
+    "author": "HitmanHimself, Turk, Jato, dragonzkiller, kwekmaster",
     "version": (1, 0, 9),
     "blender": (3, 1, 0),
     "location": "File > Import-Export",
@@ -81,7 +81,7 @@ class CP77Import(bpy.types.Operator,ImportHelper):
             gltf_importer.read()
             gltf_importer.checks()
 
-
+            
             existingMeshes = bpy.data.meshes.keys()
             existingObjects = bpy.data.objects.keys()
             existingMaterials = bpy.data.materials.keys()
@@ -92,40 +92,46 @@ class CP77Import(bpy.types.Operator,ImportHelper):
                 if name not in existingMaterials:
                     bpy.data.materials.remove(bpy.data.materials[name], do_unlink=True, do_id_user=True, do_ui_user=True)
 
-            BasePath = os.path.splitext(filepath)[0]
-            file = open(BasePath + ".Material.json",mode='r')
-            obj = json.loads(file.read())
-            BasePath = str(obj["MaterialRepo"])  + "\\"
+            
 
-            Builder = MaterialBuilder(obj,BasePath,str(self.image_format))
+                BasePath = os.path.splitext(filepath)[0]
+                #Kwek: Gate this--do the block iff corresponding Material.json exist 
+                #Kwek: was tempted to do a try-catch, but that is just La-Z
+                if os.path.exists(BasePath + ".Material.json"):    
+                    file = open(BasePath + ".Material.json",mode='r')
+                    obj = json.loads(file.read())
+                    BasePath = str(obj["MaterialRepo"])  + "\\"
 
-            usedMaterials = {}
-            counter = 0
-            for name in bpy.data.meshes.keys():
-                if name not in existingMeshes:
-                    bpy.data.meshes[name].materials.clear()
-                    for matname in gltf_importer.data.meshes[counter].extras["materialNames"]:
-                        if matname not in usedMaterials.keys():
-                            index = 0
-                            for rawmat in obj["Materials"]:
-                                if rawmat["Name"] == matname:
-                                    bpymat = Builder.create(index)
-                                    bpy.data.meshes[name].materials.append(bpymat)
-                                    usedMaterials.update( {matname: bpymat} )
-                                index = index + 1
-                        else:
-                            bpy.data.meshes[name].materials.append(usedMaterials[matname])
-                        
-                    counter = counter + 1
+                    Builder = MaterialBuilder(obj,BasePath,str(self.image_format))
 
-            if not self.exclude_unused_mats:
-                index = 0
-                for rawmat in obj["Materials"]:
-                    if rawmat["Name"] not in usedMaterials:
-                        Builder.create(index)
-                    index = index + 1
+                    usedMaterials = {}
+                    counter = 0
+                    for name in bpy.data.meshes.keys():
+                        if name not in existingMeshes:
+                            bpy.data.meshes[name].materials.clear()
+                            if gltf_importer.data.meshes[counter].extras is not None: #Kwek: I also found that other material hiccups will cause the Collection to fail
+                                for matname in gltf_importer.data.meshes[counter].extras["materialNames"]:
+                                    if matname not in usedMaterials.keys():
+                                        index = 0
+                                        for rawmat in obj["Materials"]:
+                                            if rawmat["Name"] == matname:
+                                                bpymat = Builder.create(index)
+                                                bpy.data.meshes[name].materials.append(bpymat)
+                                                usedMaterials.update( {matname: bpymat} )
+                                            index = index + 1
+                                    else:
+                                        bpy.data.meshes[name].materials.append(usedMaterials[matname])
+                                
+                            counter = counter + 1
 
+                    if not self.exclude_unused_mats:
+                        index = 0
+                        for rawmat in obj["Materials"]:
+                            if rawmat["Name"] not in usedMaterials:
+                                Builder.create(index)
+                            index = index + 1
 
+            #Kwek: ..so we can continue adding this to a named collection..
             collection = bpy.data.collections.new(os.path.splitext(f.name)[0])
             bpy.context.scene.collection.children.link(collection)
 

--- a/i_scene_cp77_gltf/__init__.py
+++ b/i_scene_cp77_gltf/__init__.py
@@ -119,11 +119,12 @@ class CP77Import(bpy.types.Operator,ImportHelper):
                                                     bpymat = Builder.create(index)
                                                     bpy.data.meshes[name].materials.append(bpymat)
                                                     usedMaterials.update( {matname: bpymat} )
-                                                    index = index + 1
+                                                
                                                 except FileNotFoundError as fnfe:
-                                                    #Kwek -- finally, even if the Builder couldn't find the materials, keep calm and carry on - fixing the Builder is Out-of-scope
+                                                    #Kwek -- finally, even if the Builder couldn't find the materials, keep calm and carry on
                                                     print(str(fnfe))
                                                     pass 
+                                            index = index + 1
                                     else:
                                         bpy.data.meshes[name].materials.append(usedMaterials[matname])
                                 

--- a/i_scene_cp77_gltf/__init__.py
+++ b/i_scene_cp77_gltf/__init__.py
@@ -81,7 +81,7 @@ class CP77Import(bpy.types.Operator,ImportHelper):
             gltf_importer.read()
             gltf_importer.checks()
 
-            
+
             existingMeshes = bpy.data.meshes.keys()
             existingObjects = bpy.data.objects.keys()
             existingMaterials = bpy.data.materials.keys()
@@ -92,52 +92,51 @@ class CP77Import(bpy.types.Operator,ImportHelper):
                 if name not in existingMaterials:
                     bpy.data.materials.remove(bpy.data.materials[name], do_unlink=True, do_id_user=True, do_ui_user=True)
 
-            
+            BasePath = os.path.splitext(filepath)[0]
+            #Kwek: Gate this--do the block iff corresponding Material.json exist 
+            #Kwek: was tempted to do a try-catch, but that is just La-Z
+            if os.path.exists(BasePath + ".Material.json"):
+                file = open(BasePath + ".Material.json",mode='r')
+                obj = json.loads(file.read())
+                BasePath = str(obj["MaterialRepo"])  + "\\"
+                
+                
 
-                BasePath = os.path.splitext(filepath)[0]
-                #Kwek: Gate this--do the block iff corresponding Material.json exist 
-                #Kwek: was tempted to do a try-catch, but that is just La-Z
-                if os.path.exists(BasePath + ".Material.json"):    
-                    file = open(BasePath + ".Material.json",mode='r')
-                    obj = json.loads(file.read())
-                    BasePath = str(obj["MaterialRepo"])  + "\\"
+                Builder = MaterialBuilder(obj,BasePath,str(self.image_format))
 
-                    Builder = MaterialBuilder(obj,BasePath,str(self.image_format))
+                usedMaterials = {}
+                counter = 0
+                for name in bpy.data.meshes.keys():
+                    if name not in existingMeshes:
+                        bpy.data.meshes[name].materials.clear()
+                        if gltf_importer.data.meshes[counter].extras is not None: #Kwek: I also found that other material hiccups will cause the Collection to fail
+                            for matname in gltf_importer.data.meshes[counter].extras["materialNames"]:
+                                if matname not in usedMaterials.keys():
+                                    index = 0
+                                    for rawmat in obj["Materials"]:
+                                        if rawmat["Name"] == matname:
+                                            try:
+                                                bpymat = Builder.create(index)
+                                                bpy.data.meshes[name].materials.append(bpymat)
+                                                usedMaterials.update( {matname: bpymat} )
+                                            except FileNotFoundError as fnfe:
+                                                #Kwek -- finally, even if the Builder couldn't find the materials, keep calm and carry on
+                                                print(str(fnfe))
+                                                pass                                            
+                                        index = index + 1
+                                else:
+                                    bpy.data.meshes[name].materials.append(usedMaterials[matname])
+                            
+                        counter = counter + 1
 
-                    usedMaterials = {}
-                    counter = 0
-                    for name in bpy.data.meshes.keys():
-                        if name not in existingMeshes:
-                            bpy.data.meshes[name].materials.clear()
-                            if gltf_importer.data.meshes[counter].extras is not None: #Kwek: I also found that other material hiccups will cause the Collection to fail
-                                for matname in gltf_importer.data.meshes[counter].extras["materialNames"]:
-                                    if matname not in usedMaterials.keys():
-                                        index = 0
-                                        for rawmat in obj["Materials"]:
-                                            if rawmat["Name"] == matname:
-                                                try:
-                                                    bpymat = Builder.create(index)
-                                                    bpy.data.meshes[name].materials.append(bpymat)
-                                                    usedMaterials.update( {matname: bpymat} )
-                                                
-                                                except FileNotFoundError as fnfe:
-                                                    #Kwek -- finally, even if the Builder couldn't find the materials, keep calm and carry on
-                                                    print(str(fnfe))
-                                                    pass 
-                                            index = index + 1
-                                    else:
-                                        bpy.data.meshes[name].materials.append(usedMaterials[matname])
-                                
-                            counter = counter + 1
+                if not self.exclude_unused_mats:
+                    index = 0
+                    for rawmat in obj["Materials"]:
+                        if rawmat["Name"] not in usedMaterials:
+                            Builder.create(index)
+                        index = index + 1
 
-                    if not self.exclude_unused_mats:
-                        index = 0
-                        for rawmat in obj["Materials"]:
-                            if rawmat["Name"] not in usedMaterials:
-                                Builder.create(index)
-                            index = index + 1
 
-            #Kwek: ..so we can continue adding this to a named collection..
             collection = bpy.data.collections.new(os.path.splitext(f.name)[0])
             bpy.context.scene.collection.children.link(collection)
 


### PR DESCRIPTION
As of 1.0.9, only meshes with materials are put under a Collection. Meshes that have no materials gets put under the root of the scene (edit: Scene Collection) browser. This behavior is inconsistent.

During the course of testing this i found: When one forgets to clear their MaterialDepot, the import will err and fail to generate a Collection. I've addressed that as well. 

See comments for lines added and changed. I also added a newline at the end of the file. Old habits.