### PR TITLE
Refactor UI with material header. Change polarity of With Material bool. Refactor register+unregister.

### DIFF
--- a/i_scene_cp77_gltf/__init__.py
+++ b/i_scene_cp77_gltf/__init__.py
@@ -1,6 +1,6 @@
 bl_info = {
     "name": "Cyberpunk 2077 glTF Importer",
-    "author": "HitmanHimself, Turk, Jato, dragonzkiller, kwek/kwekmaster, glitchered",
+    "author": "HitmanHimself, Turk, Jato, dragonzkiller, kwekmaster, glitchered",
     "version": (1, 0, 9),
     "blender": (3, 1, 0),
     "location": "File > Import-Export",


### PR DESCRIPTION
# Summary
per the discussion with @dragonzkiller on https://github.com/WolvenKit/Cyberpunk-Blender-add-on/pull/6 , as promised, here is the PR for the UI: a toggle materials header.

# Changes
- Proposed UI refactor for the Materials header:
  - Added a toggle switch based on user selection (**With Materials**)
  - Refactor UI code away from the operator 
  - Changed the name also the polarity of the variable from `exclude_all_mats` to `with_materials`
- (Also:) Tiny refactor of `register_class`/`unregister_class` to use a `classes` array instead

# Testing
- judy folder bulk import--checked and unchecked scenarios

# Preview
What it looks like. Of course the "With Materials" is **checked** by default:
![image](https://user-images.githubusercontent.com/70169069/196759007-0748f09a-77c5-40c5-b5ce-0f435db976bf.png)


unchecked:
![image](https://user-images.githubusercontent.com/70169069/196758867-ad20684d-f144-4618-a572-58f9be63e743.png)


As usual, I appreciate any comments/change suggestions.

Thanks!