### PR TITLE
Set default blend mode to hashed

### DIFF
--- a/i_scene_cp77_gltf/main/setup.py
+++ b/i_scene_cp77_gltf/main/setup.py
@@ -94,5 +94,6 @@ class MaterialBuilder:
         if rawMat["MaterialTemplate"] == "base\\materials\\glass_onesided.mt":
             glass = Glass(self.BasePath,self.image_format)
             glass.create(rawMat["Data"],bpyMat)
-
+        #set default to hashed to get rid of the black tattoos etc in eevee
+        bpyMat.blend_mode='HASHED'
         return bpyMat


### PR DESCRIPTION
Eliminates the black tattoos and cybergear etc. should only affect eevee. Have tested on Judy and works fine, shouldn't impact anything that doesn't have alpha.