### PR TITLE
Massive speed improvements, and Entity import

### DIFF
--- a/i_scene_cp77_gltf/__init__.py
+++ b/i_scene_cp77_gltf/__init__.py
@@ -101,18 +101,31 @@ class CP77Import(bpy.types.Operator,ImportHelper):
         
 
     def execute(self, context):
-        directory = self.directory
-
-        for f in self.files:
-            filepath = os.path.join(directory, f.name)
+        loadfiles=self.files
+        
+        
+        # prevent crash if no directory supplied when using filepath
+        if len(self.directory)>0:
+            directory = self.directory
+        else:
+            directory = os.path.dirname(self.filepath)
             
-            #kwekmaster: modified to reflect user choice
-            print(filepath + " Loaded; With materials: "+str(self.with_materials))
-
+        #if no files were supplied and a filepath is populate the files from the filepath
+        if len(loadfiles)==0 and len(self.filepath)>0:
+            f={}
+            f['name']=os.path.basename(self.filepath)
+            loadfiles=(f,)
+            
+        
+        for f in loadfiles:
+            filepath = os.path.join(directory, f['name'])
+                        
             gltf_importer = glTFImporter(filepath, { "files": None, "loglevel": 0, "import_pack_images" :True, "merge_vertices" :False, "import_shading" : 'NORMALS', "bone_heuristic":'TEMPERANCE', "guess_original_bind_pose" : False, "import_user_extensions": ""})
             gltf_importer.read()
             gltf_importer.checks()
-
+            
+            #kwekmaster: modified to reflect user choice
+            print(filepath + " Loaded; With materials: "+str(self.with_materials))
 
             existingMeshes = bpy.data.meshes.keys()
             existingObjects = bpy.data.objects.keys()
@@ -170,7 +183,7 @@ class CP77Import(bpy.types.Operator,ImportHelper):
                         index = index + 1
 
 
-            collection = bpy.data.collections.new(os.path.splitext(f.name)[0])
+            collection = bpy.data.collections.new(os.path.splitext(f['name'])[0])
             bpy.context.scene.collection.children.link(collection)
 
             for name in bpy.data.objects.keys():

--- a/i_scene_cp77_gltf/__init__.py
+++ b/i_scene_cp77_gltf/__init__.py
@@ -32,7 +32,7 @@ custom_icon_col = {}
 
 class CP77EntityImport(bpy.types.Operator,ImportHelper):
 
-    bl_idname = "io_scene_glft.cp77entity"
+    bl_idname = "io_scene_gltf.cp77entity"
     bl_label = "Import Ent from JSON"
     
     filter_glob: StringProperty(
@@ -64,7 +64,7 @@ class CP77EntityImport(bpy.types.Operator,ImportHelper):
 
 class CP77StreamingSectorImport(bpy.types.Operator,ImportHelper):
 
-    bl_idname = "io_scene_glft.cp77sector"
+    bl_idname = "io_scene_gltf.cp77sector"
     bl_label = "Import StreamingSector"
     use_filter_folder = True
     filter_glob: StringProperty(
@@ -295,8 +295,8 @@ def menu_func_import(self, context):
 #kwekmaster - Minor Refactoring 
 classes = (
     CP77Import,
-    CP77ImportWithMaterial,
     CP77EntityImport,
+    CP77ImportWithMaterial,
 #    CP77StreamingSectorImport, #kwekmaster: keeping this in--to mimic previous structure.
 )
 

--- a/i_scene_cp77_gltf/__init__.py
+++ b/i_scene_cp77_gltf/__init__.py
@@ -169,6 +169,8 @@ class CP77Import(bpy.types.Operator,ImportHelper):
 
                 validmats={}
                 #appearances = ({'name':'short_hair'},{'name':'02_ca_limestone'},{'name':'ml_plastic_doll'},{'name':'03_ca_senna'})
+                #if appearances defined populate valid mats with the mats for them, otherwise populate with everything used.
+
                 if len(self.appearances)>0:
                     for key in json_apps.keys():
                         if key in [i['name'] for i in self.appearances]:
@@ -200,7 +202,7 @@ class CP77Import(bpy.types.Operator,ImportHelper):
                         if gltf_importer.data.meshes[counter].extras is not None: #Kwek: I also found that other material hiccups will cause the Collection to fail
                             for matname in gltf_importer.data.meshes[counter].extras["materialNames"]:
                                 if matname in validmats.keys():
-                                    print('matname: ',matname, validmats[matname])
+                                    #print('matname: ',matname, validmats[matname])
                                
                                     if matname in bpy.data.materials.keys() and bpy.data.materials[matname]['BaseMaterial']==validmats[matname] :
                                         bpy.data.meshes[name].materials.append(bpy.data.materials[matname])
@@ -220,7 +222,8 @@ class CP77Import(bpy.types.Operator,ImportHelper):
                                                         pass                                            
                                                 index = index + 1
                                 else:
-                                    print(matname, validmats.keys())
+                                    #print(matname, validmats.keys())
+                                    pass
                             
                         counter = counter + 1
 

--- a/i_scene_cp77_gltf/__init__.py
+++ b/i_scene_cp77_gltf/__init__.py
@@ -25,9 +25,41 @@ from bpy_extras.io_utils import ImportHelper
 from io_scene_gltf2.io.imp.gltf2_io_gltf import glTFImporter
 from io_scene_gltf2.blender.imp.gltf2_blender_gltf import BlenderGlTF
 from .main.setup import MaterialBuilder
+from .main.entity_import import *
 
 icons_dir = os.path.join(os.path.dirname(__file__), "icons")
 custom_icon_col = {}
+
+class CP77EntityImport(bpy.types.Operator,ImportHelper):
+
+    bl_idname = "io_scene_glft.cp77entity"
+    bl_label = "Import Cyberpunk2077 Entity from JSON"
+    
+    filter_glob: StringProperty(
+        default="*.json",
+        options={'HIDDEN'},
+        )
+
+    filepath: StringProperty(name= "Filepath",
+                             subtype = 'FILE_PATH')
+
+    appearances: StringProperty(name= "Appearances",
+                                description="Entity Appearances to extract.",
+                                default="",
+                                options={'HIDDEN'})
+    exclude_meshes: StringProperty(name= "Meshes_to_Exclude",
+                                description="Meshes to skip during import",
+                                default="",
+                                options={'HIDDEN'})
+
+    def execute(self, context):
+        apps=self.appearances.split(",")
+        excluded=self.appearances.split(",")
+        bob=self.filepath
+        print('Bob - ',bob)
+        importEnt( bob, apps, excluded)
+
+        return {'FINISHED'}
 
 class CP77StreamingSectorImport(bpy.types.Operator,ImportHelper):
 
@@ -256,12 +288,14 @@ class CP77Import(bpy.types.Operator,ImportHelper):
 
 def menu_func_import(self, context):
     self.layout.operator(CP77Import.bl_idname, text="Cyberpunk GLTF (.gltf/.glb)", icon_value=custom_icon_col["import"]['WKIT'].icon_id)
+    self.layout.operator(CP77EntityImport.bl_idname, text="Cyberpunk Entity (.json)", icon_value=custom_icon_col["import"]['WKIT'].icon_id)
     #self.layout.operator(CP77StreamingSectorImport.bl_idname, text="Cyberpunk StreamingSector (.json)")
 
 #kwekmaster - Minor Refactoring 
 classes = (
     CP77Import,
     CP77ImportWithMaterial,
+    CP77EntityImport,
 #    CP77StreamingSectorImport, #kwekmaster: keeping this in--to mimic previous structure.
 )
 

--- a/i_scene_cp77_gltf/__init__.py
+++ b/i_scene_cp77_gltf/__init__.py
@@ -9,11 +9,10 @@ bl_info = {
     "category": "Import-Export",
 }
 
-from pickle import TRUE
+
 import bpy
 import bpy.utils.previews
 import json
-from pprint import pprint
 import os
 
 from bpy.props import (

--- a/i_scene_cp77_gltf/__init__.py
+++ b/i_scene_cp77_gltf/__init__.py
@@ -95,7 +95,11 @@ class CP77Import(bpy.types.Operator,ImportHelper):
     files: CollectionProperty(type=bpy.types.OperatorFileListElement)
     directory: StringProperty()
     
-    appearances: CollectionProperty(type=bpy.types.OperatorFileListElement)
+    appearances: StringProperty(name= "Appearances",
+                                description="Appearances to extract with models",
+                                default="",
+                                options={'HIDDEN'}
+                                )
 
     #kwekmaster: refactor UI layout from the operator.
     def draw(self, context):
@@ -106,9 +110,9 @@ class CP77Import(bpy.types.Operator,ImportHelper):
 
     def execute(self, context):
         loadfiles=self.files
-        
-        for f in self.appearances:
-            print(f.name)
+        appearances=self.appearances.split(",")
+        for f in appearances:
+            print(f)
         
         # prevent crash if no directory supplied when using filepath
         if len(self.directory)>0:
@@ -171,9 +175,9 @@ class CP77Import(bpy.types.Operator,ImportHelper):
                 #appearances = ({'name':'short_hair'},{'name':'02_ca_limestone'},{'name':'ml_plastic_doll'},{'name':'03_ca_senna'})
                 #if appearances defined populate valid mats with the mats for them, otherwise populate with everything used.
 
-                if len(self.appearances)>0:
+                if len(appearances)>0:
                     for key in json_apps.keys():
-                        if key in [i['name'] for i in self.appearances]:
+                        if key in  appearances:
                             for m in json_apps[key]:
                                 validmats[m]=True
                 else:

--- a/i_scene_cp77_gltf/__init__.py
+++ b/i_scene_cp77_gltf/__init__.py
@@ -33,7 +33,7 @@ custom_icon_col = {}
 class CP77EntityImport(bpy.types.Operator,ImportHelper):
 
     bl_idname = "io_scene_glft.cp77entity"
-    bl_label = "Import Cyberpunk2077 Entity from JSON"
+    bl_label = "Import Ent from JSON"
     
     filter_glob: StringProperty(
         default="*.json",
@@ -44,9 +44,9 @@ class CP77EntityImport(bpy.types.Operator,ImportHelper):
                              subtype = 'FILE_PATH')
 
     appearances: StringProperty(name= "Appearances",
-                                description="Entity Appearances to extract.",
-                                default="",
-                                options={'HIDDEN'})
+                                description="Entity Appearances to extract. Needs appearanceName from ent. Comma seperate multiples",
+                                default="default",
+                                )
     exclude_meshes: StringProperty(name= "Meshes_to_Exclude",
                                 description="Meshes to skip during import",
                                 default="",
@@ -54,6 +54,7 @@ class CP77EntityImport(bpy.types.Operator,ImportHelper):
 
     def execute(self, context):
         apps=self.appearances.split(",")
+        print('apps - ',apps)
         excluded=self.appearances.split(",")
         bob=self.filepath
         print('Bob - ',bob)

--- a/i_scene_cp77_gltf/main/entity_import.py
+++ b/i_scene_cp77_gltf/main/entity_import.py
@@ -1,0 +1,125 @@
+# Blender Entity import script by Simarilius
+import json
+import glob
+import os
+import bpy
+import time
+C = bpy.context
+coll_scene = C.scene.collection
+start_time = time.time()
+path = 'F:\\CPmod\\tygers\\source\\raw'
+ent_name = 'gang__tyger_ma.ent'
+# The list below needs to be the appearanceNames for each ent that you want to import 
+# NOT the name in appearances list, expand it and its the property inside, also its name in the app file
+appearances =['biker__lvl1_05']
+
+
+
+def importEnt(path, entity, appearances): 
+    jsonpath = glob.glob(path+"\**\*.ent.json", recursive = True)
+    if len(jsonpath)==0:
+        print('No jsons found')
+    for i,e in enumerate(jsonpath):
+        if os.path.basename(e)== ent_name+'.json' :
+            filepath=e
+    with open(filepath,'r') as f: 
+        j=json.load(f) 
+    ent_apps= j['Data']['RootChunk']['appearances']
+    # if you've already imported the body/head and set the rig up you can exclude them by putting them in this list 
+    exclude_meshes= ['h_012_ma_a__young.mesh' ,'t_000_ma_base__full.mesh']      
+
+    app_path = glob.glob(path+"\**\*.app.json", recursive = True)
+    meshes =  glob.glob(path+"\**\*.glb", recursive = True)
+    glbnames = [ os.path.basename(x) for x in meshes]
+    meshnames = [ os.path.splitext(x)[0]+".mesh" for x in glbnames]
+    if len(meshnames)==0:
+        print('No Meshes found')
+
+    if len(meshnames)<1 or len(jsonpath)<1 or len(app_path)<1:
+        print("You need to export the meshes and convert app and ent to json")
+    else:
+        for x,app_name in enumerate(appearances):
+            ent_coll=bpy.data.collections.new(ent_name+'_'+app_name)
+            ent_coll['appearanceName']=app_name
+            ent_coll['depotPath']=ent_name
+            coll_scene.children.link(ent_coll)
+                  
+            comps=[]
+            
+            if len(ent_apps)>0:
+                app_idx=0
+                for i,a in enumerate(ent_apps):
+                    #print(i,a['appearanceName'])
+                    if a['appearanceName']==app_name:
+                        print('appearance matched, id = ',i)
+                        app_idx=i
+                app_file = ent_apps[app_idx]['appearanceResource']['DepotPath']
+                for i,e in enumerate(app_path):
+                    #print(os.path.basename(e))
+                    if os.path.basename(e)== os.path.basename(app_file)+'.json' :
+                        filepath=e
+                        
+                if len(filepath)>0:
+                    with open(filepath,'r') as a: 
+                        a_j=json.load(a)
+                app_idx=0
+                apps=a_j['Data']['RootChunk']['appearances']
+                for i,a in enumerate(apps):
+                    print(i,a['Data']['name'])
+                    if a['Data']['name']==app_name:
+                        print('appearance matched, id = ',i)
+                        app_idx=i
+                if 'Data' in a_j['Data']['RootChunk']['appearances'][app_idx].keys():
+                    comps= a_j['Data']['RootChunk']['appearances'][app_idx]['Data']['components']
+                        
+            if len(comps)<1:      
+                print('falling back to rootchunck comps')
+                comps= j['Data']['RootChunk']['components']
+            for c in comps:
+                if 'mesh' in c.keys():
+                    #print(c['mesh']['DepotPath'])
+                    app='default'
+                    meshname=os.path.basename(c['mesh']['DepotPath'])
+                    if meshname not in exclude_meshes:                
+                        if isinstance( c['mesh']['DepotPath'], str):       
+                            if os.path.exists(os.path.join(path, c['mesh']['DepotPath'][:-4]+'glb')):
+                                try:
+                                   meshApp='default'
+                                   if 'meshAppearance' in c.keys():
+                                       meshApp=c['meshAppearance']
+                                       #print(meshApp)
+                                   #print(os.path.join(path, c['mesh']['DepotPath'][:-4]+'glb')+' , '+impapps)
+                                   meshpath=os.path.join(path, c['mesh']['DepotPath'][:-4]+'glb')
+                                   bpy.ops.io_scene_gltf.cp77(filepath=meshpath, appearances=meshApp)
+                                   objs = C.selected_objects
+                                   x=c['localTransform']['Position']['x']['Bits']/131072
+                                   y=c['localTransform']['Position']['y']['Bits']/131072
+                                   z=c['localTransform']['Position']['z']['Bits']/131072
+                                   
+                                   for obj in objs:
+                                       #print(obj.name, obj.type)
+                                       obj.location.x = x
+                                       obj.location.y = y                     
+                                       obj.location.z = z 
+                                       obj.rotation_quaternion.x = c['localTransform']['Orientation']['i']
+                                       obj.rotation_quaternion.y = c['localTransform']['Orientation']['j']
+                                       obj.rotation_quaternion.z = c['localTransform']['Orientation']['k']
+                                       obj.rotation_quaternion.w = c['localTransform']['Orientation']['r']
+                                       if 'scale' in c['localTransform'].keys():    
+                                           obj.scale.x = c['localTransform']['scale']['X'] 
+                                           obj.scale.y = c['localTransform']['scale']['Y'] 
+                                           obj.scale.z = c['localTransform']['scale']['Z'] 
+
+                                   move_coll= coll_scene.children.get( objs[0].users_collection[0].name )
+                                   move_coll['depotPath']=c['mesh']['DepotPath']
+                                   move_coll['meshAppearance']=meshApp
+                                   ent_coll.children.link(move_coll) 
+                                   coll_scene.children.unlink(move_coll)
+                                except:
+                                    print("Failed on ",c['mesh']['DepotPath'])
+        print('Exported' ,app_name)
+    print("--- %s seconds ---" % (time.time() - start_time))
+
+#with all mats 280.71283984184265 seconds ---
+
+importEnt(path, ent_name, appearances)

--- a/i_scene_cp77_gltf/main/entity_import.py
+++ b/i_scene_cp77_gltf/main/entity_import.py
@@ -4,64 +4,70 @@ import glob
 import os
 import bpy
 import time
-C = bpy.context
-coll_scene = C.scene.collection
-start_time = time.time()
-path = 'F:\\CPmod\\tygers\\source\\raw'
-ent_name = 'gang__tyger_ma.ent'
-# The list below needs to be the appearanceNames for each ent that you want to import 
-# NOT the name in appearances list, expand it and its the property inside, also its name in the app file
-appearances =['biker__lvl1_05']
 
+# The appearance list needs to be the appearanceNames for each ent that you want to import, will import all if not specified
+# if you've already imported the body/head and set the rig up you can exclude them by putting them in the exclude_meshes list 
 
+def importEnt( filepath='', appearances=[], exclude_meshes=[] ): 
+    C = bpy.context
+    coll_scene = C.scene.collection
+    start_time = time.time()
 
-def importEnt(path, entity, appearances): 
-    jsonpath = glob.glob(path+"\**\*.ent.json", recursive = True)
-    if len(jsonpath)==0:
-        print('No jsons found')
-    for i,e in enumerate(jsonpath):
-        if os.path.basename(e)== ent_name+'.json' :
-            filepath=e
+    before,mid,after=filepath.partition('source\\raw')
+    path=before+mid
+
+    ent_name=os.path.basename(filepath)[:-9]
+
     with open(filepath,'r') as f: 
         j=json.load(f) 
     ent_apps= j['Data']['RootChunk']['appearances']
-    # if you've already imported the body/head and set the rig up you can exclude them by putting them in this list 
-    exclude_meshes= ['h_012_ma_a__young.mesh' ,'t_000_ma_base__full.mesh']      
 
+    # if no apps requested populate the list with all available.
+    if len(appearances)==0:
+        for app in ent_apps:
+            appearances.append(app['appearanceName'])
+
+    # find the appearance file jsons
     app_path = glob.glob(path+"\**\*.app.json", recursive = True)
-    meshes =  glob.glob(path+"\**\*.glb", recursive = True)
-    glbnames = [ os.path.basename(x) for x in meshes]
-    meshnames = [ os.path.splitext(x)[0]+".mesh" for x in glbnames]
-    if len(meshnames)==0:
-        print('No Meshes found')
+    if len(app_path)==0:
+        print('No Appearance file JSONs found in path')
 
-    if len(meshnames)<1 or len(jsonpath)<1 or len(app_path)<1:
+    # find the meshes
+    meshes =  glob.glob(path+"\**\*.glb", recursive = True)
+    if len(meshes)==0:
+        print('No Meshes found in path')
+
+    if len(meshes)<1 or len(app_path)<1:
         print("You need to export the meshes and convert app and ent to json")
+
     else:
         for x,app_name in enumerate(appearances):
+            # Put each appearance in a collector with the ent name and app name
             ent_coll=bpy.data.collections.new(ent_name+'_'+app_name)
+            # tag it with some custom properties.
             ent_coll['appearanceName']=app_name
             ent_coll['depotPath']=ent_name
+            #link it to the scene
             coll_scene.children.link(ent_coll)
                   
             comps=[]
             
             if len(ent_apps)>0:
-                app_idx=0
+                ent_app_idx=0
+                # Find the appearance in the entity app list
                 for i,a in enumerate(ent_apps):
-                    #print(i,a['appearanceName'])
                     if a['appearanceName']==app_name:
                         print('appearance matched, id = ',i)
-                        app_idx=i
-                app_file = ent_apps[app_idx]['appearanceResource']['DepotPath']
-                for i,e in enumerate(app_path):
-                    #print(os.path.basename(e))
-                    if os.path.basename(e)== os.path.basename(app_file)+'.json' :
-                        filepath=e
+                        ent_app_idx=i
+                app_file = ent_apps[ent_app_idx]['appearanceResource']['DepotPath']
+                filepath=os.path.join(path,app_file)+'.json'
                         
-                if len(filepath)>0:
+                if os.path.exists(filepath):
                     with open(filepath,'r') as a: 
                         a_j=json.load(a)
+                else:
+                    print('app file not found - ',filepath)
+                    
                 app_idx=0
                 apps=a_j['Data']['RootChunk']['appearances']
                 for i,a in enumerate(apps):
@@ -72,54 +78,50 @@ def importEnt(path, entity, appearances):
                 if 'Data' in a_j['Data']['RootChunk']['appearances'][app_idx].keys():
                     comps= a_j['Data']['RootChunk']['appearances'][app_idx]['Data']['components']
                         
-            if len(comps)<1:      
-                print('falling back to rootchunck comps')
+            if len(comps)==0:      
+                print('falling back to rootchunk comps')
                 comps= j['Data']['RootChunk']['components']
             for c in comps:
                 if 'mesh' in c.keys():
                     #print(c['mesh']['DepotPath'])
                     app='default'
                     meshname=os.path.basename(c['mesh']['DepotPath'])
+                    meshpath=os.path.join(path, c['mesh']['DepotPath'][:-4]+'glb')
                     if meshname not in exclude_meshes:                
                         if isinstance( c['mesh']['DepotPath'], str):       
-                            if os.path.exists(os.path.join(path, c['mesh']['DepotPath'][:-4]+'glb')):
+                            if os.path.exists(meshpath):
                                 try:
-                                   meshApp='default'
-                                   if 'meshAppearance' in c.keys():
-                                       meshApp=c['meshAppearance']
-                                       #print(meshApp)
-                                   #print(os.path.join(path, c['mesh']['DepotPath'][:-4]+'glb')+' , '+impapps)
-                                   meshpath=os.path.join(path, c['mesh']['DepotPath'][:-4]+'glb')
-                                   bpy.ops.io_scene_gltf.cp77(filepath=meshpath, appearances=meshApp)
-                                   objs = C.selected_objects
-                                   x=c['localTransform']['Position']['x']['Bits']/131072
-                                   y=c['localTransform']['Position']['y']['Bits']/131072
-                                   z=c['localTransform']['Position']['z']['Bits']/131072
+                                    meshApp='default'
+                                    if 'meshAppearance' in c.keys():
+                                        meshApp=c['meshAppearance']
+                                        #print(meshApp)
                                    
-                                   for obj in objs:
-                                       #print(obj.name, obj.type)
-                                       obj.location.x = x
-                                       obj.location.y = y                     
-                                       obj.location.z = z 
-                                       obj.rotation_quaternion.x = c['localTransform']['Orientation']['i']
-                                       obj.rotation_quaternion.y = c['localTransform']['Orientation']['j']
-                                       obj.rotation_quaternion.z = c['localTransform']['Orientation']['k']
-                                       obj.rotation_quaternion.w = c['localTransform']['Orientation']['r']
-                                       if 'scale' in c['localTransform'].keys():    
-                                           obj.scale.x = c['localTransform']['scale']['X'] 
-                                           obj.scale.y = c['localTransform']['scale']['Y'] 
-                                           obj.scale.z = c['localTransform']['scale']['Z'] 
+                                    bpy.ops.io_scene_gltf.cp77(filepath=meshpath, appearances=meshApp)
+                                    objs = C.selected_objects
+                                    x=c['localTransform']['Position']['x']['Bits']/131072
+                                    y=c['localTransform']['Position']['y']['Bits']/131072
+                                    z=c['localTransform']['Position']['z']['Bits']/131072
+                                   
+                                    for obj in objs:
+                                        #print(obj.name, obj.type)
+                                        obj.location.x = x
+                                        obj.location.y = y                     
+                                        obj.location.z = z 
+                                        obj.rotation_quaternion.x = c['localTransform']['Orientation']['i']
+                                        obj.rotation_quaternion.y = c['localTransform']['Orientation']['j']
+                                        obj.rotation_quaternion.z = c['localTransform']['Orientation']['k']
+                                        obj.rotation_quaternion.w = c['localTransform']['Orientation']['r']
+                                        if 'scale' in c['localTransform'].keys():    
+                                            obj.scale.x = c['localTransform']['scale']['X'] 
+                                            obj.scale.y = c['localTransform']['scale']['Y'] 
+                                            obj.scale.z = c['localTransform']['scale']['Z'] 
 
-                                   move_coll= coll_scene.children.get( objs[0].users_collection[0].name )
-                                   move_coll['depotPath']=c['mesh']['DepotPath']
-                                   move_coll['meshAppearance']=meshApp
-                                   ent_coll.children.link(move_coll) 
-                                   coll_scene.children.unlink(move_coll)
+                                    move_coll= coll_scene.children.get( objs[0].users_collection[0].name )
+                                    move_coll['depotPath']=c['mesh']['DepotPath']
+                                    move_coll['meshAppearance']=meshApp
+                                    ent_coll.children.link(move_coll) 
+                                    coll_scene.children.unlink(move_coll)
                                 except:
                                     print("Failed on ",c['mesh']['DepotPath'])
         print('Exported' ,app_name)
     print("--- %s seconds ---" % (time.time() - start_time))
-
-#with all mats 280.71283984184265 seconds ---
-
-importEnt(path, ent_name, appearances)

--- a/i_scene_cp77_gltf/main/entity_import.py
+++ b/i_scene_cp77_gltf/main/entity_import.py
@@ -23,10 +23,10 @@ def importEnt( filepath='', appearances=[], exclude_meshes=[] ):
     ent_apps= j['Data']['RootChunk']['appearances']
 
     # if no apps requested populate the list with all available.
-    if len(appearances)==0:
+    if len(appearances[0])==0:
         for app in ent_apps:
             appearances.append(app['appearanceName'])
-
+    
     # find the appearance file jsons
     app_path = glob.glob(path+"\**\*.app.json", recursive = True)
     if len(app_path)==0:

--- a/i_scene_cp77_gltf/main/setup.py
+++ b/i_scene_cp77_gltf/main/setup.py
@@ -17,6 +17,7 @@ from ..material_types.eyeshadow import EyeShadow
 from ..material_types.meshdecalemissive import MeshDecalEmissive
 from ..material_types.glass import Glass
 from ..material_types.signages import Signages
+from ..material_types.meshdecalparallax import MeshDecalParallax
 
 
 class MaterialBuilder:
@@ -26,6 +27,8 @@ class MaterialBuilder:
         self.obj = Obj
     def create(self,materialIndex):
         rawMat = self.obj["Materials"][materialIndex]
+        
+        
 
         verbose=True
 
@@ -99,12 +102,16 @@ class MaterialBuilder:
             case "base\\fx\\shaders\\signages.mt":
                 signages= Signages(self.BasePath,self.image_format)
                 signages.create(rawMat["Data"],bpyMat)
-
-        if rawMat["MaterialTemplate"] == "base\\materials\\glass_onesided.mt":
-            glass = Glass(self.BasePath,self.image_format)
-            glass.create(rawMat["Data"],bpyMat)
             
+            case "base\\materials\\glass_onesided.mt":
+                glass = Glass(self.BasePath,self.image_format)
+                glass.create(rawMat["Data"],bpyMat)
+            
+            case "base\\materials\\mesh_decal_parallax.mt":
+                meshDecalParallax = MeshDecalParallax(self.BasePath,self.image_format)
+                meshDecalParallax.create(rawMat["Data"],bpyMat)
+
         #set the viewport blend mode to hashed - no more black tattoos and cybergear
-        bpyMat.blend_mode='HASHED'
+        bpyMat.blend_method='HASHED'
         return bpyMat
 

--- a/i_scene_cp77_gltf/main/setup.py
+++ b/i_scene_cp77_gltf/main/setup.py
@@ -1,3 +1,4 @@
+
 import bpy
 import os
 from ..material_types.multilayered import Multilayered
@@ -26,80 +27,86 @@ class MaterialBuilder:
     def create(self,materialIndex):
         rawMat = self.obj["Materials"][materialIndex]
 
+        verbose=True
+
         bpyMat = bpy.data.materials.new(rawMat["Name"])
         bpyMat.use_nodes = True
+        match rawMat["MaterialTemplate"]:
+            case "engine\\materials\\multilayered.mt":
+                multilayered = Multilayered(self.BasePath,self.image_format)
+                multilayered.create(rawMat["Data"],bpyMat)
 
-        if rawMat["MaterialTemplate"] == "engine\\materials\\multilayered.mt":
-            multilayered = Multilayered(self.BasePath,self.image_format)
-            multilayered.create(rawMat["Data"],bpyMat)
+            case "base\\materials\\multilayered_clear_coat.mt":
+                multilayered = Multilayered(self.BasePath,self.image_format)
+                multilayered.create(rawMat["Data"],bpyMat)
 
-        if rawMat["MaterialTemplate"] == "base\\materials\\multilayered_clear_coat.mt":
-            multilayered = Multilayered(self.BasePath,self.image_format)
-            multilayered.create(rawMat["Data"],bpyMat)
+            case "base\\materials\\vehicle_destr_blendshape.mt":
+                vehicleDestrBlendshape = VehicleDestrBlendshape(self.BasePath,self.image_format)
+                vehicleDestrBlendshape.create(rawMat["Data"],bpyMat)
 
-        if rawMat["MaterialTemplate"] == "base\\materials\\vehicle_destr_blendshape.mt":
-            vehicleDestrBlendshape = VehicleDestrBlendshape(self.BasePath,self.image_format)
-            vehicleDestrBlendshape.create(rawMat["Data"],bpyMat)
+            case "base\\materials\\mesh_decal.mt":
+                meshDecal = MeshDecal(self.BasePath,self.image_format)
+                meshDecal.create(rawMat["Data"],bpyMat)
 
-        if rawMat["MaterialTemplate"] == "base\\materials\\mesh_decal.mt":
-            meshDecal = MeshDecal(self.BasePath,self.image_format)
-            meshDecal.create(rawMat["Data"],bpyMat)
+            case "base\\materials\\mesh_decal_double_diffuse.mt":
+                meshDecalDoubleDiffuse = MeshDecalDoubleDiffuse(self.BasePath,self.image_format)
+                meshDecalDoubleDiffuse.create(rawMat["Data"],bpyMat)
 
-        if rawMat["MaterialTemplate"] == "base\\materials\\mesh_decal_double_diffuse.mt":
-            meshDecalDoubleDiffuse = MeshDecalDoubleDiffuse(self.BasePath,self.image_format)
-            meshDecalDoubleDiffuse.create(rawMat["Data"],bpyMat)
+            case "base\\materials\\vehicle_mesh_decal.mt":
+                vehicleMeshDecal = VehicleMeshDecal(self.BasePath,self.image_format)
+                vehicleMeshDecal.create(rawMat["Data"],bpyMat)
 
-        if rawMat["MaterialTemplate"] == "base\\materials\\vehicle_mesh_decal.mt":
-            vehicleMeshDecal = VehicleMeshDecal(self.BasePath,self.image_format)
-            vehicleMeshDecal.create(rawMat["Data"],bpyMat)
+            case "base\\materials\\skin.mt":
+                skin = Skin(self.BasePath,self.image_format)
+                skin.create(rawMat["Data"],bpyMat)
 
-        if rawMat["MaterialTemplate"] == "base\\materials\\skin.mt":
-            skin = Skin(self.BasePath,self.image_format)
-            skin.create(rawMat["Data"],bpyMat)
+            case "engine\\materials\\metal_base.remt":
+                metalBase = MetalBase(self.BasePath,self.image_format)
+                metalBase.create(rawMat["Data"],bpyMat)
 
-        if rawMat["MaterialTemplate"] == "engine\\materials\\metal_base.remt":
-            metalBase = MetalBase(self.BasePath,self.image_format)
-            metalBase.create(rawMat["Data"],bpyMat)
+            case "base\\materials\\hair.mt":
+                hair = Hair(self.BasePath,self.image_format)
+                hair.create(rawMat["Data"],bpyMat)
 
-        if rawMat["MaterialTemplate"] == "base\\materials\\hair.mt":
-            hair = Hair(self.BasePath,self.image_format)
-            hair.create(rawMat["Data"],bpyMat)
+            case "base\\materials\\mesh_decal_gradientmap_recolor.mt":
+                meshDecalGradientMapReColor = MeshDecalGradientMapReColor(self.BasePath,self.image_format)
+                meshDecalGradientMapReColor.create(rawMat["Data"],bpyMat)
 
-        if rawMat["MaterialTemplate"] == "base\\materials\\mesh_decal_gradientmap_recolor.mt":
-            meshDecalGradientMapReColor = MeshDecalGradientMapReColor(self.BasePath,self.image_format)
-            meshDecalGradientMapReColor.create(rawMat["Data"],bpyMat)
+            case "base\\materials\\eye.mt":
+                eye = Eye(self.BasePath,self.image_format)
+                eye.create(rawMat["Data"],bpyMat)
 
-        if rawMat["MaterialTemplate"] == "base\\materials\\eye.mt":
-            eye = Eye(self.BasePath,self.image_format)
-            eye.create(rawMat["Data"],bpyMat)
+            case "base\\materials\\eye_gradient.mt":
+                eyeGradient = EyeGradient(self.BasePath,self.image_format)
+                eyeGradient.create(rawMat["Data"],bpyMat)
 
-        if rawMat["MaterialTemplate"] == "base\\materials\\eye_gradient.mt":
-            eyeGradient = EyeGradient(self.BasePath,self.image_format)
-            eyeGradient.create(rawMat["Data"],bpyMat)
+            case "base\\materials\\eye_shadow.mt":
+                eyeShadow = EyeShadow(self.BasePath,self.image_format)
+                eyeShadow.create(rawMat["Data"],bpyMat)
 
-        if rawMat["MaterialTemplate"] == "base\\materials\\eye_shadow.mt":
-            eyeShadow = EyeShadow(self.BasePath,self.image_format)
-            eyeShadow.create(rawMat["Data"],bpyMat)
+            case "base\\materials\\mesh_decal_emissive.mt":
+                meshDecalEmissive = MeshDecalEmissive(self.BasePath,self.image_format)
+                meshDecalEmissive.create(rawMat["Data"],bpyMat)
 
-        if rawMat["MaterialTemplate"] == "base\\materials\\mesh_decal_emissive.mt":
-            meshDecalEmissive = MeshDecalEmissive(self.BasePath,self.image_format)
-            meshDecalEmissive.create(rawMat["Data"],bpyMat)
+            case "base\\materials\\mesh_decal_wet_character.mt":
+                meshDecal = MeshDecal(self.BasePath,self.image_format)
+                meshDecal.create(rawMat["Data"],bpyMat)
 
-        if rawMat["MaterialTemplate"] == "base\\materials\\mesh_decal_wet_character.mt":
-            meshDecal = MeshDecal(self.BasePath,self.image_format)
-            meshDecal.create(rawMat["Data"],bpyMat)
-
-        if rawMat["MaterialTemplate"] == "base\\materials\\glass.mt":
-            glass = Glass(self.BasePath,self.image_format)
-            glass.create(rawMat["Data"],bpyMat)
+            case "base\\materials\\glass.mt":
+                glass = Glass(self.BasePath,self.image_format)
+                glass.create(rawMat["Data"],bpyMat)
             
-        if rawMat["MaterialTemplate"] == "base\\fx\\shaders\\signages.mt":
-            signages= Signages(self.BasePath,self.image_format)
-            signages.create(rawMat["Data"],bpyMat)
+            case "base\\fx\\shaders\\signages.mt":
+                signages= Signages(self.BasePath,self.image_format)
+                signages.create(rawMat["Data"],bpyMat)
 
-        if rawMat["MaterialTemplate"] == "base\\materials\\glass_onesided.mt":
-            glass = Glass(self.BasePath,self.image_format)
-            glass.create(rawMat["Data"],bpyMat)
+            case "base\\materials\\glass_onesided.mt":
+                glass = Glass(self.BasePath,self.image_format)
+                glass.create(rawMat["Data"],bpyMat)
 
+            case _:
+                if verbose:
+                    print(rawMat["MaterialTemplate"], ' not processed.')
+        bpyMat.blend_mode='HASHED'
         return bpyMat
 

--- a/i_scene_cp77_gltf/main/setup.py
+++ b/i_scene_cp77_gltf/main/setup.py
@@ -15,6 +15,8 @@ from ..material_types.eyegradient import EyeGradient
 from ..material_types.eyeshadow import EyeShadow
 from ..material_types.meshdecalemissive import MeshDecalEmissive
 from ..material_types.glass import Glass
+from ..material_types.signages import Signages
+
 
 class MaterialBuilder:
     def __init__(self,Obj,BasePath,image_format):
@@ -90,5 +92,9 @@ class MaterialBuilder:
         if rawMat["MaterialTemplate"] == "base\\materials\\glass.mt":
             glass = Glass(self.BasePath,self.image_format)
             glass.create(rawMat["Data"],bpyMat)
+            
+        if rawMat["MaterialTemplate"] == "base\\fx\\shaders\\signages.mt":
+            signages= Signages(self.BasePath,self.image_format)
+            signages.create(rawMat["Data"],bpyMat)
 
         return bpyMat

--- a/i_scene_cp77_gltf/material_types/eyegradient.py
+++ b/i_scene_cp77_gltf/material_types/eyegradient.py
@@ -67,7 +67,7 @@ class EyeGradient:
             igradNode.color_ramp.elements.remove(igradNode.color_ramp.elements[0])
             counter = 0
             for Entry in profile["gradientEntries"]:
-                if counter is 0:
+                if counter == 0:
                     igradNode.color_ramp.elements[0].position = Entry.get("value",0)
                     colr = Entry["color"]
                     igradNode.color_ramp.elements[0].color = (float(colr["Red"])/255,float(colr["Green"])/255,float(colr["Blue"])/255,float(1))

--- a/i_scene_cp77_gltf/material_types/hair.py
+++ b/i_scene_cp77_gltf/material_types/hair.py
@@ -34,7 +34,7 @@ class Hair:
         RootToTip.color_ramp.elements.remove(RootToTip.color_ramp.elements[0])
         counter = 0
         for Entry in profile["gradientEntriesRootToTip"]:
-            if counter is 0:
+            if counter == 0:
                 RootToTip.color_ramp.elements[0].position = Entry.get("value",0)
                 colr = Entry["color"]
                 RootToTip.color_ramp.elements[0].color = (float(colr["Red"])/255,float(colr["Green"])/255,float(colr["Blue"])/255,float(1))

--- a/i_scene_cp77_gltf/material_types/meshdecalparallax.py
+++ b/i_scene_cp77_gltf/material_types/meshdecalparallax.py
@@ -93,7 +93,7 @@ class MeshDecalParallax:
         if "MetalnessTexture" in Data:
             mImgNode = CreateShaderNodeTexImage(CurMat,self.BasePath + Data["MetalnessTexture"],-800,200,'MetalnessTexture',self.image_format,True)
             CurMat.links.new(mImgNode.outputs[0],mulNode2.inputs[1])
-                
+'''     
         if "SecondaryMask"in Data:
             print('SecondaryMask detected', Data['SecondaryMask'])
             
@@ -121,3 +121,4 @@ class MeshDecalParallax:
             print('HeightTexture detected', Data['HeightTexture'])
         if "HeightStrength"in Data:
             print('HeightStrength detected', Data['HeightStrength'])
+'''

--- a/i_scene_cp77_gltf/material_types/meshdecalparallax.py
+++ b/i_scene_cp77_gltf/material_types/meshdecalparallax.py
@@ -1,0 +1,123 @@
+import bpy
+import os
+from ..main.common import *
+
+class MeshDecalParallax:
+    def __init__(self, BasePath,image_format):
+        self.BasePath = BasePath
+        self.image_format = image_format
+    def create(self,Data,Mat):
+        CurMat = Mat.node_tree
+        CurMat.nodes['Principled BSDF'].inputs['Specular'].default_value = 0
+#Diffuse
+        mixRGB = CurMat.nodes.new("ShaderNodeMixRGB")
+        mixRGB.location = (-500,500)
+        mixRGB.hide = True
+        mixRGB.blend_type = 'MULTIPLY'
+        mixRGB.inputs[0].default_value = 1
+        CurMat.links.new(mixRGB.outputs[0],CurMat.nodes['Principled BSDF'].inputs['Base Color'])
+
+        mulNode = CurMat.nodes.new("ShaderNodeMath")
+        mulNode.operation = 'MULTIPLY'
+        mulNode.location = (-500,450)
+        if "DiffuseAlpha" in Data:
+            mulNode.inputs[0].default_value = float(Data["DiffuseAlpha"])
+        else:
+            mulNode.inputs[0].default_value = 1
+
+
+        dTexMapping = CurMat.nodes.new("ShaderNodeMapping")
+        dTexMapping.label = "UVMapping"
+        dTexMapping.location = (-1000,300)
+
+        if "DiffuseTexture" in Data:
+            dImgNode = CreateShaderNodeTexImage(CurMat,self.BasePath + Data["DiffuseTexture"],-800,500,'DiffuseTexture',self.image_format)
+            CurMat.links.new(dTexMapping.outputs[0],dImgNode.inputs[0])
+            CurMat.links.new(dImgNode.outputs[0],mixRGB.inputs[2])
+            CurMat.links.new(dImgNode.outputs[1],mulNode.inputs[1])
+
+        if "UVOffsetX" in Data:
+            dTexMapping.inputs[1].default_value[0] = Data["UVOffsetX"]
+        if "UVOffsetY" in Data:
+            dTexMapping.inputs[1].default_value[1] = Data["UVOffsetY"]
+        if "UVRotation" in Data:
+            dTexMapping.inputs[2].default_value[0] = Data["UVRotation"]
+            dTexMapping.inputs[2].default_value[1] = Data["UVRotation"]
+        if "UVScaleX" in Data:
+            dTexMapping.inputs[3].default_value[0] = Data["UVScaleX"]
+        if "UVScaleY" in Data:
+            dTexMapping.inputs[3].default_value[1] = Data["UVScaleY"]
+
+        UVNode = CurMat.nodes.new("ShaderNodeTexCoord")
+        UVNode.location = (-1200,300)
+        CurMat.links.new(UVNode.outputs[2],dTexMapping.inputs[0])
+
+        CurMat.links.new(mulNode.outputs[0],CurMat.nodes['Principled BSDF'].inputs['Alpha'])
+
+        if "DiffuseColor" in Data:
+            dColor = CreateShaderNodeRGB(CurMat, Data["DiffuseColor"], -700, 550, "DiffuseColor")
+            CurMat.links.new(dColor.outputs[0],mixRGB.inputs[1])
+
+        if "NormalTexture" in Data:
+            nMap = CreateShaderNodeNormalMap(CurMat,self.BasePath + Data["NormalTexture"],-200,-250,'NormalTexture',self.image_format)
+            CurMat.links.new(nMap.outputs[0],CurMat.nodes['Principled BSDF'].inputs['Normal'])
+
+        if "NormalAlpha" in Data:
+            norAlphaVal = CreateShaderNodeValue(CurMat, Data["NormalAlpha"], -1200,-450, "NormalAlpha")
+
+        if "NormalAlphaTex" in Data:
+            nAImgNode = CreateShaderNodeTexImage(CurMat,self.BasePath + Data["NormalAlphaTex"],-1200,-500,'NormalAlphaTex',self.image_format,True)
+
+        mulNode1 = CurMat.nodes.new("ShaderNodeMath")
+        if "RoughnessScale" in Data:
+            mulNode1.inputs[0].default_value = float(Data["RoughnessScale"])
+        else:
+            mulNode1.inputs[0].default_value = 1
+
+        mulNode1.operation = 'MULTIPLY'
+        mulNode1.location = (-500,-100)
+        CurMat.links.new(mulNode1.outputs[0],CurMat.nodes['Principled BSDF'].inputs['Roughness'])
+        if "RoughnessTexture" in Data:
+            rImgNode = CreateShaderNodeTexImage(CurMat,self.BasePath + Data["RoughnessTexture"],-800,100,'RoughnessTexture',self.image_format,True)
+            CurMat.links.new(rImgNode.outputs[0],mulNode1.inputs[1])
+
+
+        mulNode2 = CurMat.nodes.new("ShaderNodeMath")
+        if "MetalnessScale" in Data:
+            mulNode2.inputs[0].default_value = float(Data["MetalnessScale"])
+        else:
+            mulNode2.inputs[0].default_value = 1
+        mulNode2.operation = 'MULTIPLY'
+        mulNode2.location = (-500,200)
+        CurMat.links.new(mulNode2.outputs[0],CurMat.nodes['Principled BSDF'].inputs['Metallic'])
+        if "MetalnessTexture" in Data:
+            mImgNode = CreateShaderNodeTexImage(CurMat,self.BasePath + Data["MetalnessTexture"],-800,200,'MetalnessTexture',self.image_format,True)
+            CurMat.links.new(mImgNode.outputs[0],mulNode2.inputs[1])
+                
+        if "SecondaryMask"in Data:
+            print('SecondaryMask detected', Data['SecondaryMask'])
+            
+        if "SecondaryMaskUVScale"in Data:
+            print('SecondaryMaskUVScale detected - ', Data['SecondaryMaskUVScale'])
+            
+        if "SecondaryMaskInfluence"in Data:
+            print('SecondaryMaskInfluence detected', Data['SecondaryMaskInfluence'])
+            
+        if "UseNormalAlphaTex"in Data:
+            print('UseNormalAlphaTex detected', Data['UseNormalAlphaTex'])
+        if "NormalsBlendingMode"in Data:
+            print('NormalsBlendingMode detected', Data['NormalsBlendingMode'])
+        
+        if "AlphaMaskContrast"in Data:
+            print('NormalsBlendingMode detected', Data['NormalsBlendingMode'])
+
+        if "RoughnessMetalnessAlpha"in Data:
+            print('RoughnessMetalnessAlpha detected', Data['NormalsBlendingMode'])
+
+        if "DepthThreshold"in Data:
+            print('DepthThreshold detected', Data['DepthThreshold'])
+
+        if "HeightTexture"in Data:
+            print('HeightTexture detected', Data['HeightTexture'])
+        if "HeightStrength"in Data:
+            print('HeightStrength detected', Data['HeightStrength'])

--- a/i_scene_cp77_gltf/material_types/signages.py
+++ b/i_scene_cp77_gltf/material_types/signages.py
@@ -1,0 +1,68 @@
+import bpy
+import os
+from ..main.common import *
+
+class Signages:
+    def __init__(self, BasePath,image_format):
+        self.BasePath = BasePath
+        self.image_format = image_format
+    def create(self,Data,Mat):
+        CurMat = Mat.node_tree
+        CurMat.nodes['Principled BSDF'].inputs['Specular'].default_value = 0
+        print('Creating neon sign')
+        if "ColorOneStart" in Data:
+            dCol = CreateShaderNodeRGB(CurMat, Data["ColorOneStart"], -800, 250, "ColorOneStart")    
+        else:
+            dCol = CreateShaderNodeRGB(CurMat,{'Red': 255, 'Green': 255, 'Blue': 255, 'Alpha': 255}, -800, 250, "ColorOneStart")
+        CurMat.links.new(dCol.outputs[0],CurMat.nodes['Principled BSDF'].inputs['Base Color'])
+          
+        alphaNode = CurMat.nodes.new("ShaderNodeMath")
+        alphaNode.operation = 'MULTIPLY'
+        alphaNode.location = (-300, -250)
+        if "DiffuseAlpha" in Data:
+            aThreshold = CreateShaderNodeValue(CurMat, Data["DiffuseAlpha"], -550, -400, "DiffuseAlpha")
+            CurMat.links.new(aThreshold.outputs[0],alphaNode.inputs[1])
+        else:
+            alphaNode.inputs[1].default_value = 1
+
+        mulNode = CurMat.nodes.new("ShaderNodeMixRGB")
+        mulNode.inputs[0].default_value = 0.5
+        mulNode.blend_type = 'MULTIPLY'
+        mulNode.location = (-300, -50)
+        CurMat.links.new(dCol.outputs[0],mulNode.inputs[1])
+
+        if "MainTexture" in Data:
+            emTexNode = CreateShaderNodeTexImage(CurMat, self.BasePath + Data["MainTexture"], -700, -250,'MainTexture',self.image_format)
+            CurMat.links.new(emTexNode.outputs[0],mulNode.inputs[2])
+            CurMat.links.new(emTexNode.outputs[1],alphaNode.inputs[0])
+
+
+        CurMat.links.new(alphaNode.outputs[0], CurMat.nodes['Principled BSDF'].inputs['Alpha'])
+        CurMat.links.new(mulNode.outputs[0], CurMat.nodes['Principled BSDF'].inputs['Emission'])
+        
+        if "EmissiveEV" in Data:
+            CurMat.nodes['Principled BSDF'].inputs['Emission Strength'].default_value =  Data["EmissiveEV"]*10
+
+        if "Roughness" in Data:
+            CurMat.nodes['Principled BSDF'].inputs['Roughness'].default_value =  Data["Roughness"]
+
+        if "FresnelAmount" in Data:   
+            CurMat.nodes['Principled BSDF'].inputs['Specular'].default_value =  Data["FresnelAmount"]
+        
+        if "ColorOneStart" in Data:
+            dCol = CreateShaderNodeRGB(CurMat, Data["ColorOneStart"], -850, 250, "ColorOneStart")    
+
+        if "ColorTwo" in Data:
+            dCol = CreateShaderNodeRGB(CurMat, Data["ColorTwo"], -900, 250, "ColorTwo")    
+
+        if "ColorThree" in Data:
+            dCol = CreateShaderNodeRGB(CurMat, Data["ColorThree"], -950, 250, "ColorThree")    
+
+        if "ColorFour" in Data:
+            dCol = CreateShaderNodeRGB(CurMat, Data["ColorFour"], -1000, 250, "ColorFour")    
+                    
+        if "ColorFive" in Data:
+            dCol = CreateShaderNodeRGB(CurMat, Data["ColorFive"], -1050, 250, "ColorFive")  
+        
+        if "ColorSix" in Data:
+            dCol = CreateShaderNodeRGB(CurMat, Data["ColorSix"], -1100, 250, "ColorSix")

--- a/i_scene_cp77_gltf/material_types/skin.py
+++ b/i_scene_cp77_gltf/material_types/skin.py
@@ -138,6 +138,7 @@ class Skin:
 
         if "Normal" in Data:
             nMap = CreateShaderNodeTexImage(CurMat, self.BasePath + Data["Normal"], -1800,-300, "Normal",self.image_format,True)
+            nMap.image.colorspace_settings.name='Non-Color'
 	
         if "DetailNormal" in Data:
             dnMap = CreateShaderNodeTexImage(CurMat, self.BasePath + Data["DetailNormal"], -1800,-450, "DetailNormal",self.image_format,True)


### PR DESCRIPTION
Have changed around the logic of the material import, it now doesn't import duplicates of the same material name that's referencing the same mi. Can also provide an appearance list and it will only import the materials required to support them.

Switched the main common.py to a match case rather than tonnes of ifs, as it makes it clearer and also allows you to put a catch case at the bottom if your wanting to track what the importers trying to create that we're not supporting.

Added entity import from json, if you export the json for the ent and app you can tell it which appearance(s) you want and it will import them, each to their own group.

Also has initial stab at parallax decals and the signages emissive material files.

edit - also moved the bit that puts them in their group to happen before material import, that way if anything does go wrong with it they still have their group, no more orphan meshes