### PR TITLE
Update exporters.py

### DIFF
--- a/i_scene_cp77_gltf/main/exporters.py
+++ b/i_scene_cp77_gltf/main/exporters.py
@@ -63,6 +63,11 @@ def export_cyberpunk_glb(context, filepath, export_poses):
                 if len(submesh.vertices) > 65000:
                     bpy.ops.cp77.message_box('INVOKE_DEFAULT', message="Each submesh must have less than 65,000 vertices")
                     return {'CANCELLED'}
+                            #check that faces are triangulated, if not cancel and throw an error    
+            for face in mesh.data.polygons:
+                if len(face.vertices) != 3:
+                    bpy.ops.cp77.message_box('INVOKE_DEFAULT', message="All faces must be triangulated")
+                    return {'CANCELLED'}
         #use the right options for exporting a mesh
         options = default_cp77_options()
         options.update(cp77_mesh_options())

--- a/i_scene_cp77_gltf/main/exporters.py
+++ b/i_scene_cp77_gltf/main/exporters.py
@@ -16,6 +16,7 @@ def default_cp77_options():
 #make sure meshes are exported with tangents, morphs and vertex colors
 def cp77_mesh_options():
     options = {
+        'export_animations': False,
         'export_tangents': True,
         'export_normals': True,
         'export_morph_tangent': True,


### PR DESCRIPTION
fix for blender 3.4 and 3.5 issues due to default settings change. Add a check for triangulated faces, throw an error if they're not