### PR TITLE
more checks

### DIFF
--- a/i_scene_cp77_gltf/main/exporters.py
+++ b/i_scene_cp77_gltf/main/exporters.py
@@ -62,6 +62,7 @@ def export_cyberpunk_glb(context, filepath, export_poses):
                 if len(submesh.vertices) > 65000:
                     bpy.ops.cp77.message_box('INVOKE_DEFAULT', message="Each submesh must have less than 65,000 vertices")
                     return {'CANCELLED'}
+            #check that faces are triangulated, if not cancel and throw an error
             for face in mesh.data.polygons:
                 if len(face.vertices) != 3:
                     bpy.ops.cp77.message_box('INVOKE_DEFAULT', message="All faces must be triangulated before exporting to glb")
@@ -87,11 +88,11 @@ def export_cyberpunk_glb(context, filepath, export_poses):
                 armature_states[armature] = {"hide": armature.hide_get(),
                                             "select": armature.select_get()}
 
-                # Make necessary changes for export
+                # Make necessary to armature visibility and selection state for export
                 armature.hide_set(False)
                 armature.select_set(True)
 
-                # Check for ungrouped vertices
+                # Check for ungrouped vertices, throw an error if any are found
                 ungrouped_vertices = [v for v in obj.data.vertices if not v.groups]
                 if ungrouped_vertices:
                     bpy.ops.cp77.message_box('INVOKE_DEFAULT', message="Some vertices are not assigned to any vertex group.")


### PR DESCRIPTION
removed duplicate option from mesh defaults, added a check for ungrouped verts if the mesh has an armature modifier - this prevents blender creating a neutral bone which causes problems on import 