### PR TITLE
import/export .phys collisions

### DIFF
--- a/i_scene_cp77_gltf/__init__.py
+++ b/i_scene_cp77_gltf/__init__.py
@@ -54,6 +54,80 @@ def SetCyclesRenderer(set_gi_params=False):
         cycles.ao_bounces = 1
         cycles.ao_bounces_render = 1
 
+class CP77CollisionExport(bpy.types.Operator):
+    bl_idname = "export_scene.collisions"
+    bl_label = "Export Collisions to .JSON"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "CP77 Modding"
+    bl_parent_id = "CP77_PT_CollisionTools"
+    
+    filepath: bpy.props.StringProperty(subtype="FILE_PATH")
+
+    def execute(self, context):
+        cp77_collision_export(self.filepath)
+        return {'FINISHED'}
+        
+    def invoke(self, context, event):
+        context.window_manager.fileselect_add(self)
+        return {'RUNNING_MODAL'}
+
+    def draw(self, context):
+        layout = self.layout
+
+class CP77_PT_CollisionTools(bpy.types.Panel):
+    bl_parent_id = "CP77_PT_ModTools"
+    bl_label = "Collision Tools"
+    bl_idname = "CP77_PT_CollisionTools"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "CP77 Modding"
+
+    def draw(self, context):
+        layout = self.layout
+        layout.operator("export_scene.collisions")
+
+class CP77_PT_ModTools(bpy.types.Panel):
+    bl_label = "Cyberpunk Modding Tools"
+    bl_idname = "CP77_PT_ModTools"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_options = {"DEFAULT_CLOSED"}
+    bl_category = "CP77 Modding"
+
+    def draw(self, context):
+        layout = self.layout
+
+## these will be used later 
+# class CP77_PT_rigview(bpy.types.Panel):
+#     bl_parent_id = "CP77_PT_ModTools"
+#     bl_space_type = "VIEW_3D"
+#     bl_region_type = "UI"
+#     bl_label = "Cyberpunk Rigview"
+#     bl_category = "CP77 Modding"
+    
+    # def poll(cls, context):
+    #     return (context.active_object
+    #         and context.active_object.type == 'ARMATURE'
+    #         and context.mode in {'OBJECT', 'POSE', 'EDIT_ARMATURE'}
+    #         and cls.draw_funcs)
+
+#     def draw(self, context):
+#         layout = self.layout
+
+
+# class CP77_PT_AnimsPanel(bpy.types.Panel):
+#     bl_parent_id = "CP77_PT_ModTools"
+#     bl_idname = "CP77_PT_AnimsPanel"
+#     bl_space_type = "VIEW_3D"
+#     bl_label = "Animsets"
+#     bl_region_type = "UI"
+#     bl_category = "CP77 Modding"
+
+#     def draw(self, context):
+#         layout = self.layout
+
+
 ## adds a message box for the exporters to use for error notifications, will also be used later for redmod integration    
 class ShowMessageBox(bpy.types.Operator):
     bl_idname = "cp77.message_box"
@@ -412,6 +486,11 @@ classes = (
     CP77StreamingSectorImport,
     CP77GLBExport,
     ShowMessageBox,
+    CP77_PT_ModTools,
+    #CP77_PT_AnimsPanel,
+    #CP77_PT_rigview,
+    CP77_PT_CollisionTools,
+    CP77CollisionExport
 )
 
 def register():

--- a/i_scene_cp77_gltf/main/entity_import.py
+++ b/i_scene_cp77_gltf/main/entity_import.py
@@ -607,20 +607,20 @@ def importEnt( filepath='', appearances=[], exclude_meshes=[], with_materials=Tr
 
 # The above is  the code thats for the import plugin below is to allow testing/dev, you can run this file to import something
 
-# if __name__ == "__main__":
+if __name__ == "__main__":
 
-   # path = 'F:\\CPmod\\heist_hotel\\source\\raw'
-   # ent_name = 'single_door.ent'
+    path = 'F:\\CPmod\\heist_hotel\\source\\raw'
+    ent_name = 'single_door.ent'
     # The list below needs to be the appearanceNames for each ent that you want to import 
     # NOT the name in appearances list, expand it and its the property inside, also its name in the app file
-    # appearances =['kitsch_f']
+    appearances =['kitsch_f']
 
-    # jsonpath = glob.glob(path+"\**\*.ent.json", recursive = True)
-    # if len(jsonpath)==0:
-        # print('No jsons found')
+    jsonpath = glob.glob(path+"\**\*.ent.json", recursive = True)
+    if len(jsonpath)==0:
+        print('No jsons found')
         
-   # for i,e in enumerate(jsonpath):
-  #      if os.path.basename(e)== ent_name+'.json' :
-  #          filepath=e
+    for i,e in enumerate(jsonpath):
+        if os.path.basename(e)== ent_name+'.json' :
+            filepath=e
             
-   # importEnt( filepath, appearances )
+    importEnt( filepath, appearances )

--- a/i_scene_cp77_gltf/main/exporters.py
+++ b/i_scene_cp77_gltf/main/exporters.py
@@ -166,7 +166,8 @@ def cp77_collision_export(filepath):
                 elif colliderType == "physicsColliderCapsule":
                     i['Data']['radius'] = obj.dimensions.x / 2  # Divided by 2 because blender dimensions are diameter
                     i['Data']['height'] = obj.dimensions.z 
-
+                
+            bpy.ops.cp77.message_box('INVOKE_DEFAULT', message="Succesfully Exported Collisions")
         with open(output, 'w') as f:
             json.dump(data, f, indent=2)
 

--- a/i_scene_cp77_gltf/main/exporters.py
+++ b/i_scene_cp77_gltf/main/exporters.py
@@ -1,4 +1,8 @@
+import json
+import os
+import mathutils
 import bpy
+
 #setup the default options to be applied to all export types
 def default_cp77_options():
     options = {
@@ -109,3 +113,61 @@ def export_cyberpunk_glb(context, filepath, export_poses):
         armature.select_set(state["select"])
         armature.hide_set(state["hide"])
 
+
+def cp77_collision_export(filepath):
+    with open(filepath, 'r') as phys:
+        data = json.load(phys)
+        physJsonPath = filepath
+
+        dir_name, file_name = os.path.split(filepath)
+        new_file_name = 'new_' + file_name
+        output = os.path.join(dir_name, new_file_name)
+
+        collection_name = os.path.splitext(os.path.basename(physJsonPath))[0]
+        collection = bpy.data.collections.get(collection_name)
+
+        if collection is not None:
+            for index, obj in enumerate(collection.objects):
+                colliderType = obj.name.split('_')[1]
+                i = data['Data']['RootChunk']['bodies'][0]['Data']['collisionShapes'][index]
+
+                i['Data']['localToBody']['position']['X'] = obj.location.x
+                i['Data']['localToBody']['position']['Y'] = obj.location.y
+                i['Data']['localToBody']['position']['Z'] = obj.location.z
+                i['Data']['localToBody']['orientation']['i'] = obj.rotation_quaternion.z
+                i['Data']['localToBody']['orientation']['j'] = obj.rotation_quaternion.x
+                i['Data']['localToBody']['orientation']['k'] = obj.rotation_quaternion.y
+                i['Data']['localToBody']['orientation']['r'] = obj.rotation_quaternion.w
+
+                if colliderType == "physicsColliderConvex" or colliderType == "physicsColliderConcave":
+                    mesh = obj.data
+                    if 'vertices' in i['Data']:
+                        for j, vert in enumerate(mesh.vertices):
+                            i['Data']['vertices'][j]['X'] = vert.co.x
+                            i['Data']['vertices'][j]['Y'] = vert.co.y
+                            i['Data']['vertices'][j]['Z'] = vert.co.z
+
+                elif colliderType == "physicsColliderBox":
+                    # Calculate world-space bounding box vertices
+                    world_bounds = [obj.matrix_world @ mathutils.Vector(coord) for coord in obj.bound_box]
+
+                    # Get center of the box in world space
+                    center = sum(world_bounds, mathutils.Vector()) / 8
+
+                    # Update position in the json based on the center of the cube in world space
+                    i['Data']['localToBody']['position']['X'] = center.x
+                    i['Data']['localToBody']['position']['Y'] = center.y
+                    i['Data']['localToBody']['position']['Z'] = center.z
+                    # Update halfExtents
+                    i['Data']['halfExtents']['X'] = obj.dimensions.x / 2
+                    i['Data']['halfExtents']['Y'] = obj.dimensions.y / 2
+                    i['Data']['halfExtents']['Z'] = obj.dimensions.z / 2
+
+                elif colliderType == "physicsColliderCapsule":
+                    i['Data']['radius'] = obj.dimensions.x / 2  # Divided by 2 because blender dimensions are diameter
+                    i['Data']['height'] = obj.dimensions.z 
+
+        with open(output, 'w') as f:
+            json.dump(data, f, indent=2)
+
+    print(f'Finished exporting {new_file_name}')


### PR DESCRIPTION
initial support for importing and exporting collisions for vehicle modding. Capsules and boxes aren't 100% right at the moment but they're usable. Also lays the groundwork for full support of collision import/export from ents and meshes. 

.phys export is in a new "Cyberpunk Modding" tab in the toolbar on the side of the 3d viewport