### PR TITLE
openJSON: normalize paths to support loading materials on other OSes

### DIFF
--- a/i_scene_cp77_gltf/main/common.py
+++ b/i_scene_cp77_gltf/main/common.py
@@ -138,6 +138,10 @@ def json_ver_validate( json_data):
         return True
 
 def openJSON(path, mode='r',  ProjPath='', DepotPath=''):
+    path = path.replace('\\', os.sep)
+    ProjPath = ProjPath.replace('\\', os.sep)
+    DepotPath = DepotPath.replace('\\', os.sep)
+
     inproj=os.path.join(ProjPath,path)
     if os.path.exists(inproj):
         file = open(inproj,mode)


### PR DESCRIPTION
Even if Wolvenkit doesn't work on linux properly today, Blender does, and getting Blender to run in a VM is hard. So it's not crazy to end up running Wolvenkit in a VM and Blender on the Linux host.

In these situations, if you set up appropriate shared storage, you can make all the material files available on the Linux side, but the Material json produced by an export is using '\\' for the path separator.

This change normalises paths to use the current OS separator, so all the user has to do is adjust the depot path in the Material json to match the linux side, and then the materials will load.