### PR TITLE
Deal with localisation breaking refs to nodenames

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -1,0 +1,64 @@
+name: simple_build_and_release
+on:
+  push:
+    branches: [ 'main' ]
+  pull_request:
+    branches: [ '**' ]
+  workflow_dispatch:
+  
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    steps:        
+      - name: Checkout
+        uses: actions/checkout@v2
+      
+      - name: Build addon
+        id: build
+        uses: blenderkit/blender-addon-build@main
+        with:
+          name: Cyberpunk Blender Plugin
+          name-suffix: "PR-time"
+          build-location: "./"
+          exclude-files: ".git;.github;README.md"
+      
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: cyberpunk_blender_plugin
+          path: ./
+          
+  Release:
+    runs-on: ubuntu-latest
+    needs: Build
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: cyberpunk_blender_plugin
+          path: ./
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Create Draft Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.sha }}
+          release_name: Release ${{ github.sha }}
+          draft: true
+          prerelease: false
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./
+          asset_name: cyberpunk_blender_plugin.zip
+          asset_content_type: application/zip

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -1,9 +1,4 @@
 name: simple_build_and_release
-on:
-  push:
-    branches: [ 'main' ]
-  pull_request:
-    branches: [ '**' ]
   workflow_dispatch:
   
 jobs:

--- a/.github/workflows/simple_release.yml
+++ b/.github/workflows/simple_release.yml
@@ -29,7 +29,7 @@ jobs:
     needs: Build
     steps:
       - name: Release addon
-        uses: Simarilius-uk/blender-addon-release@main
+        uses: blenderkit/blender-addon-release@main
         with:
           artifact_name: Cyberpunk-Blender-Add-on-
           release_name: Cyberpunk Blender Add on 

--- a/.github/workflows/simple_release.yml
+++ b/.github/workflows/simple_release.yml
@@ -29,7 +29,7 @@ jobs:
     needs: Build
     steps:
       - name: Release addon
-        uses: blenderkit/blender-addon-release@main
+        uses: Simarilius-UK/blender-addon-release@main
         with:
           artifact_name: Cyberpunk-Blender-Add-on-
           release_name: Cyberpunk Blender Add on 

--- a/i_scene_cp77_gltf/main/common.py
+++ b/i_scene_cp77_gltf/main/common.py
@@ -9,6 +9,9 @@ import bmesh
 from mathutils import Vector
 import json
 
+def loc(nodename):
+    return bpy.app.translations.pgettext(nodename)
+
 def normalize_paths(data):
     if isinstance(data, dict):
         for key, value in data.items():
@@ -286,6 +289,7 @@ def CreateRebildNormalGroup(curMat, x = 0, y = 0,name = 'Rebuild Normal Z'):
         VSub = group.nodes.new("ShaderNodeVectorMath")
         VSub.location = (-1000,-200)
         VSub.operation = 'SUBTRACT'
+        VSub.name = 'NormalSubtract'
         VSub.inputs[1].default_value[0] = 1.0
         VSub.inputs[1].default_value[1] = 1.0
     

--- a/i_scene_cp77_gltf/material_types/decal.py
+++ b/i_scene_cp77_gltf/material_types/decal.py
@@ -51,7 +51,7 @@ class Decal:
                 
 
         CurMat = Mat.node_tree
-        Prin_BSDF=CurMat.nodes['Principled BSDF']
+        Prin_BSDF=CurMat.nodes[loc('Principled BSDF')]
         sockets=bsdf_socket_names()
         Prin_BSDF.inputs[sockets['Specular']].default_value = 0.5
         TexCoordinate = CurMat.nodes.new("ShaderNodeTexCoord")
@@ -99,7 +99,7 @@ class Decal:
                 CurMat.links.new(dImgNode.outputs[1],mulNode1.inputs[1])
             CurMat.links.new(mulNode1.outputs[0],Prin_BSDF.inputs['Alpha'])
         else:
-            CurMat.nodes['Principled BSDF'].inputs['Alpha'].default_value = 0
+            CurMat.nodes[loc('Principled BSDF')].inputs['Alpha'].default_value = 0
             print(f"Texture is not found: {difftex}")
         if RoughnessTexture and os.path.exists(os.path.join(self.BasePath ,RoughnessTexture)):
             rImgNode = CreateShaderNodeTexImage(CurMat,os.path.join(self.BasePath ,RoughnessTexture),-800,0,'RoughnessTexture',self.image_format)

--- a/i_scene_cp77_gltf/material_types/decal_gradientmap_recolor.py
+++ b/i_scene_cp77_gltf/material_types/decal_gradientmap_recolor.py
@@ -38,7 +38,7 @@ class DecalGradientmapRecolor:
                     diffAsMask = Data["values"][i]["DiffuseTextureAsMaskTexture"]
 
         CurMat = Mat.node_tree
-        pBSDF=CurMat.nodes['Principled BSDF']
+        pBSDF=CurMat.nodes[loc('Principled BSDF')]
 
         if self.found(difftex) and self.found(gradmap):
             diffImg = imageFromRelPath(difftex,self.image_format, DepotPath=self.BasePath, ProjPath=self.ProjPath)

--- a/i_scene_cp77_gltf/material_types/eye.py
+++ b/i_scene_cp77_gltf/material_types/eye.py
@@ -10,7 +10,7 @@ class Eye:
 
     def create(self,Data,Mat):
         CurMat = Mat.node_tree
-        pBSDF = CurMat.nodes['Principled BSDF']
+        pBSDF = CurMat.nodes[loc('Principled BSDF')]
         sockets=bsdf_socket_names()
 
         if "Specularity" in Data:

--- a/i_scene_cp77_gltf/material_types/eyegradient.py
+++ b/i_scene_cp77_gltf/material_types/eyegradient.py
@@ -23,7 +23,7 @@ class EyeGradient:
             return
         profile= profile["Data"]["RootChunk"]
         CurMat = Mat.node_tree
-        pBSDF = CurMat.nodes['Principled BSDF']
+        pBSDF = CurMat.nodes[loc('Principled BSDF')]
         sockets=bsdf_socket_names()
 
         if "RefractionIndex" in Data:

--- a/i_scene_cp77_gltf/material_types/eyeshadow.py
+++ b/i_scene_cp77_gltf/material_types/eyeshadow.py
@@ -11,7 +11,7 @@ class EyeShadow:
 
     def create(self,Data,Mat):
         CurMat = Mat.node_tree
-        pBSDF = CurMat.nodes['Principled BSDF']
+        pBSDF = CurMat.nodes[loc('Principled BSDF')]
         sockets=bsdf_socket_names()
         pBSDF.inputs['Roughness'].default_value = 0.01
         pBSDF.inputs[sockets['Transmission']].default_value = 1

--- a/i_scene_cp77_gltf/material_types/glass.py
+++ b/i_scene_cp77_gltf/material_types/glass.py
@@ -10,7 +10,7 @@ class Glass:
 
     def create(self,Data,Mat):
         CurMat = Mat.node_tree
-        pBDSF=CurMat.nodes['Principled BSDF']
+        pBDSF=CurMat.nodes[loc('Principled BSDF')]
         sockets=bsdf_socket_names()
         pBDSF.inputs[sockets['Transmission']].default_value = 1
 

--- a/i_scene_cp77_gltf/material_types/glassdeferred.py
+++ b/i_scene_cp77_gltf/material_types/glassdeferred.py
@@ -11,7 +11,7 @@ class GlassDeferred:
 
     def create(self,Data,Mat):
         CurMat = Mat.node_tree
-        pBSDF=CurMat.nodes['Principled BSDF']
+        pBSDF=CurMat.nodes[loc('Principled BSDF')]
         MatOutput=CurMat.nodes['Material Output']
         MatOutput.location=(780,300)
         

--- a/i_scene_cp77_gltf/material_types/hair.py
+++ b/i_scene_cp77_gltf/material_types/hair.py
@@ -30,9 +30,9 @@ class Hair:
 
         aImg=imageFromRelPath(hair["Strand_Alpha"],DepotPath=self.BasePath, ProjPath=self.ProjPath, image_format=self.image_format)            
         aImgNode = create_node(Ns,"ShaderNodeTexImage",  (-300,-150), label="Strand_Alpha", image=aImg)
-        CurMat.links.new(aImgNode.outputs[0],CurMat.nodes['Principled BSDF'].inputs['Alpha'])
+        CurMat.links.new(aImgNode.outputs[0],CurMat.nodes[loc('Principled BSDF')].inputs['Alpha'])
 
-        CurMat.nodes['Principled BSDF'].inputs[sockets['Specular']].default_value = 0
+        CurMat.nodes[loc('Principled BSDF')].inputs[sockets['Specular']].default_value = 0
 
         gImg=imageFromRelPath(hair["Strand_Gradient"],DepotPath=self.BasePath, ProjPath=self.ProjPath, image_format=self.image_format)            
         gImgNode = create_node(Ns,"ShaderNodeTexImage",  (-1100,50), label="Strand_Gradient", image=gImg)
@@ -84,7 +84,7 @@ class Hair:
         gamma0.inputs[1].default_value = 2.2
 
         CurMat.links.new(mulNode.outputs[0],gamma0.inputs[0])
-        CurMat.links.new(gamma0.outputs[0],CurMat.nodes['Principled BSDF'].inputs['Base Color'])
+        CurMat.links.new(gamma0.outputs[0],CurMat.nodes[loc('Principled BSDF')].inputs['Base Color'])
 
         nMap = CreateShaderNodeNormalMap(CurMat,self.BasePath + hair["Flow"],-200,-250,'Flow',self.image_format)
-        CurMat.links.new(nMap.outputs[0],CurMat.nodes['Principled BSDF'].inputs['Normal'])
+        CurMat.links.new(nMap.outputs[0],CurMat.nodes[loc('Principled BSDF')].inputs['Normal'])

--- a/i_scene_cp77_gltf/material_types/meshdecal.py
+++ b/i_scene_cp77_gltf/material_types/meshdecal.py
@@ -13,7 +13,7 @@ class MeshDecal:
         CurMat = Mat.node_tree
         Ns=CurMat.nodes
         sockets=bsdf_socket_names()
-        CurMat.nodes['Principled BSDF'].inputs[sockets['Specular']].default_value = 0
+        CurMat.nodes[loc('Principled BSDF')].inputs[sockets['Specular']].default_value = 0
 
 #Diffuse
         mixRGB = CurMat.nodes.new("ShaderNodeMixRGB")
@@ -21,7 +21,7 @@ class MeshDecal:
         mixRGB.hide = True
         mixRGB.blend_type = 'MULTIPLY'
         mixRGB.inputs[0].default_value = 1
-        CurMat.links.new(mixRGB.outputs[0],CurMat.nodes['Principled BSDF'].inputs['Base Color'])
+        CurMat.links.new(mixRGB.outputs[0],CurMat.nodes[loc('Principled BSDF')].inputs['Base Color'])
 
         mulNode =create_node(Ns, "ShaderNodeMath", (-500,450), operation = 'MULTIPLY')
         #if "DiffuseAlpha" in Data:
@@ -60,7 +60,7 @@ class MeshDecal:
         UVNode = create_node(Ns,"ShaderNodeTexCoord", (-1200,300))
         CurMat.links.new(UVNode.outputs[2],dTexMapping.inputs[0])
 
-        CurMat.links.new(mulNode.outputs[0],CurMat.nodes['Principled BSDF'].inputs['Alpha'])
+        CurMat.links.new(mulNode.outputs[0],CurMat.nodes[loc('Principled BSDF')].inputs['Alpha'])
 
         if "DiffuseColor" in Data:
             dColor = CreateShaderNodeRGB(CurMat, Data["DiffuseColor"], -800, 650, "DiffuseColor")
@@ -72,7 +72,7 @@ class MeshDecal:
 
         if "NormalTexture" in Data:
             nMap = CreateShaderNodeNormalMap(CurMat,self.BasePath + Data["NormalTexture"],-200,-250,'NormalTexture',self.img_format)
-            CurMat.links.new(nMap.outputs[0],CurMat.nodes['Principled BSDF'].inputs['Normal'])
+            CurMat.links.new(nMap.outputs[0],CurMat.nodes[loc('Principled BSDF')].inputs['Normal'])
 
         if "NormalAlpha" in Data:
             norAlphaVal = CreateShaderNodeValue(CurMat, Data["NormalAlpha"], -1200,-450, "NormalAlpha")
@@ -87,7 +87,7 @@ class MeshDecal:
         else:
             mulNode1.inputs[0].default_value = 1
       
-        CurMat.links.new(mulNode1.outputs[0],CurMat.nodes['Principled BSDF'].inputs['Roughness'])
+        CurMat.links.new(mulNode1.outputs[0],CurMat.nodes[loc('Principled BSDF')].inputs['Roughness'])
         if "RoughnessTexture" in Data:
             rImg=imageFromRelPath(Data["RoughnessTexture"],DepotPath=self.BasePath, ProjPath=self.ProjPath, image_format=self.img_format)            
             rImgNode = create_node(Ns,"ShaderNodeTexImage",  (-800,-100), label="RoughnessTexture", image=rImg)
@@ -100,7 +100,7 @@ class MeshDecal:
         else:
             mulNode2.inputs[0].default_value = 1
         
-        CurMat.links.new(mulNode2.outputs[0],CurMat.nodes['Principled BSDF'].inputs['Metallic'])
+        CurMat.links.new(mulNode2.outputs[0],CurMat.nodes[loc('Principled BSDF')].inputs['Metallic'])
         if "MetalnessTexture" in Data:
             mImg=imageFromRelPath(Data["MetalnessTexture"],DepotPath=self.BasePath, ProjPath=self.ProjPath, image_format=self.img_format)            
             mImgNode = create_node(Ns,"ShaderNodeTexImage",  (-800,200), label="MetalnessTexture", image=mImg)

--- a/i_scene_cp77_gltf/material_types/meshdecaldoublediffuse.py
+++ b/i_scene_cp77_gltf/material_types/meshdecaldoublediffuse.py
@@ -6,10 +6,12 @@ class MeshDecalDoubleDiffuse:
     def __init__(self, BasePath,image_format):
         self.BasePath = BasePath
         self.image_format = image_format
+
     def create(self,Data,Mat):
         CurMat = Mat.node_tree
         sockets=bsdf_socket_names()
-        CurMat.nodes['Principled BSDF'].inputs[sockets['Specular']].default_value = 0
+        pBSDF = CurMat.nodes[loc('Principled BSDF')]
+        pBSDF.inputs[sockets['Specular']].default_value = 0
 
 #Diffuse
         mixRGB = CurMat.nodes.new("ShaderNodeMixRGB")
@@ -17,7 +19,7 @@ class MeshDecalDoubleDiffuse:
         mixRGB.hide = True
         mixRGB.blend_type = 'OVERLAY'
         mixRGB.inputs[0].default_value = 1
-        CurMat.links.new(mixRGB.outputs[0],CurMat.nodes['Principled BSDF'].inputs['Base Color'])
+        CurMat.links.new(mixRGB.outputs[0],pBSDF.inputs['Base Color'])
 
         mulNode = CurMat.nodes.new("ShaderNodeMath")
         mulNode.operation = 'MULTIPLY'
@@ -54,7 +56,7 @@ class MeshDecalDoubleDiffuse:
         UVNode.location = (-1200,300)
         CurMat.links.new(UVNode.outputs[2],dTexMapping.inputs[0])
 
-        CurMat.links.new(mulNode.outputs[0],CurMat.nodes['Principled BSDF'].inputs['Alpha'])
+        CurMat.links.new(mulNode.outputs[0],pBSDF.inputs['Alpha'])
 
         if "DiffuseColor" in Data:
             dColor = CreateShaderNodeRGB(CurMat, Data["DiffuseColor"], -500, 700, "DiffuseColor")
@@ -68,7 +70,7 @@ class MeshDecalDoubleDiffuse:
 
         if "NormalTexture" in Data:
             nMap = CreateShaderNodeNormalMap(CurMat,self.BasePath + Data["NormalTexture"],-200,-250,'NormalTexture',self.image_format)
-            CurMat.links.new(nMap.outputs[0],CurMat.nodes['Principled BSDF'].inputs['Normal'])
+            CurMat.links.new(nMap.outputs[0],pBSDF.inputs['Normal'])
 
         if "NormalAlpha" in Data:
             norAlphaVal = CreateShaderNodeValue(CurMat, Data["NormalAlpha"], -1200,-450, "NormalAlpha")
@@ -84,7 +86,7 @@ class MeshDecalDoubleDiffuse:
 
         mulNode1.operation = 'MULTIPLY'
         mulNode1.location = (-500,-100)
-        CurMat.links.new(mulNode1.outputs[0],CurMat.nodes['Principled BSDF'].inputs['Roughness'])
+        CurMat.links.new(mulNode1.outputs[0],pBSDF.inputs['Roughness'])
         if "RoughnessTexture" in Data:
             rImgNode = CreateShaderNodeTexImage(CurMat,self.BasePath + Data["RoughnessTexture"],-800,100,'RoughnessTexture',self.image_format,True)
             CurMat.links.new(rImgNode.outputs[0],mulNode1.inputs[1])
@@ -97,7 +99,7 @@ class MeshDecalDoubleDiffuse:
             mulNode2.inputs[0].default_value = 1
         mulNode2.operation = 'MULTIPLY'
         mulNode2.location = (-500,200)
-        CurMat.links.new(mulNode2.outputs[0],CurMat.nodes['Principled BSDF'].inputs['Metallic'])
+        CurMat.links.new(mulNode2.outputs[0],pBSDF.inputs['Metallic'])
         if "MetalnessTexture" in Data:
             mImgNode = CreateShaderNodeTexImage(CurMat,self.BasePath + Data["MetalnessTexture"],-800,200,'MetalnessTexture',self.image_format,True)
             CurMat.links.new(mImgNode.outputs[0],mulNode2.inputs[1])

--- a/i_scene_cp77_gltf/material_types/meshdecalemissive.py
+++ b/i_scene_cp77_gltf/material_types/meshdecalemissive.py
@@ -10,7 +10,7 @@ class MeshDecalEmissive:
 
     def create(self,Data,Mat):
         CurMat = Mat.node_tree
-        pBSDF = CurMat.nodes['Principled BSDF']
+        pBSDF = CurMat.nodes[loc('Principled BSDF')]
         sockets=bsdf_socket_names()
         pBSDF.inputs[sockets['Specular']].default_value = 0
 

--- a/i_scene_cp77_gltf/material_types/meshdecalgradientmaprecolor.py
+++ b/i_scene_cp77_gltf/material_types/meshdecalgradientmaprecolor.py
@@ -12,7 +12,7 @@ class MeshDecalGradientMapReColor:
         Mat.blend_method = 'HASHED'
         Mat.shadow_method = 'HASHED'
         CurMat = Mat.node_tree
-        pBSDF = CurMat.nodes['Principled BSDF']
+        pBSDF = CurMat.nodes[loc('Principled BSDF')]
         sockets=bsdf_socket_names()
         pBSDF.inputs[sockets['Specular']].default_value = 0
 

--- a/i_scene_cp77_gltf/material_types/meshdecalparallax.py
+++ b/i_scene_cp77_gltf/material_types/meshdecalparallax.py
@@ -9,7 +9,7 @@ class MeshDecalParallax:
         self.image_format = image_format
     def create(self,Data,Mat):
         CurMat = Mat.node_tree
-        pBSDF=CurMat.nodes['Principled BSDF']
+        pBSDF=CurMat.nodes[loc('Principled BSDF')]
         sockets=bsdf_socket_names()
         pBSDF.inputs[sockets['Specular']].default_value = 0
         #Diffuse

--- a/i_scene_cp77_gltf/material_types/metalbase.py
+++ b/i_scene_cp77_gltf/material_types/metalbase.py
@@ -11,7 +11,7 @@ class MetalBase:
 
     def create(self,Data,Mat):
         CurMat = Mat.node_tree
-        pBSDF = CurMat.nodes['Principled BSDF']
+        pBSDF = CurMat.nodes[loc('Principled BSDF')]
         sockets=bsdf_socket_names()
 
         mixRGB = create_node(CurMat.nodes,"ShaderNodeMixRGB", (-450,400) , blend_type = 'MULTIPLY')
@@ -75,7 +75,7 @@ class MetalBase:
             CurMat.links.new(bColNode.outputs[1],alphclamp.inputs['Value'])
         else:
             CurMat.links.new(bColNode.outputs[0],alphclamp.inputs['Value'])
-       
+
         
         Clamp2 = create_node(CurMat.nodes,"ShaderNodeClamp",(-538., 476.))
         
@@ -84,9 +84,11 @@ class MetalBase:
        
         CurMat.links.new(alphclamp.outputs[0],Clamp2.inputs['Value'])
         
+
         if "Normal" in Data:
             nMap = CreateShaderNodeNormalMap(CurMat,self.BasePath + Data["Normal"],-200,-300,'Normal',self.image_format)
             CurMat.links.new(nMap.outputs[0],pBSDF.inputs['Normal'])
+
 
         mulNode = CurMat.nodes.new("ShaderNodeMixRGB")
         mulNode.inputs[0].default_value = 1

--- a/i_scene_cp77_gltf/material_types/metalbasedet.py
+++ b/i_scene_cp77_gltf/material_types/metalbasedet.py
@@ -9,7 +9,7 @@ class MetalBaseDet:
         self.image_format = image_format
     def create(self,Data,Mat):
         CurMat = Mat.node_tree
-        pBSDF = CurMat.nodes['Principled BSDF']
+        pBSDF = CurMat.nodes[loc('Principled BSDF')]
 
         # TEXTURES
         if "BaseColor" in Data:

--- a/i_scene_cp77_gltf/material_types/multilayered.py
+++ b/i_scene_cp77_gltf/material_types/multilayered.py
@@ -232,6 +232,7 @@ class Multilayered:
             LastLayer="Layer_"+str(LayerCount-2)
             # Remove the links already made between 10 & 11
             for out in CurMat.nodes[Layer10].outputs:
+            #    if out.type != 'RGBA':
                 for l in out.links:
                     CurMat.links.remove(l)
             CurMat.links.new(CurMat.nodes[Layer10].outputs[0],MixLayerStacks.inputs[0])
@@ -244,22 +245,23 @@ class Multilayered:
             CurMat.links.new(CurMat.nodes[LastLayer].outputs[3],MixLayerStacks.inputs[7])
             factor=CreateShaderNodeValue(CurMat, 0.5, -1100,-250, "Factor")
             CurMat.links.new(factor.outputs[0],MixLayerStacks.inputs[8])
-            
+                        
             # replace the connections from the bottom of the stack with these
-            CurMat.links.new(MixLayerStacks.outputs[0],CurMat.nodes['Principled BSDF'].inputs['Base Color'])
-            CurMat.links.new(MixLayerStacks.outputs[1],CurMat.nodes['Principled BSDF'].inputs['Metallic'])
-            CurMat.links.new(MixLayerStacks.outputs[2],CurMat.nodes['Principled BSDF'].inputs['Roughness'])            
+            CurMat.links.new(MixLayerStacks.outputs[0],CurMat.nodes[loc('Principled BSDF')].inputs['Base Color'])
+            #CurMat.links.new(CurMat.nodes[targetLayer].outputs[0],CurMat.nodes[loc('Principled BSDF')].inputs['Base Color'])
+            CurMat.links.new(MixLayerStacks.outputs[1],CurMat.nodes[loc('Principled BSDF')].inputs['Metallic'])
+            CurMat.links.new(MixLayerStacks.outputs[2],CurMat.nodes[loc('Principled BSDF')].inputs['Roughness'])            
             targetLayer="MixLayerStacks"
         else:
-            CurMat.links.new(CurMat.nodes[targetLayer].outputs[0],CurMat.nodes['Principled BSDF'].inputs['Base Color'])
-            CurMat.links.new(CurMat.nodes[targetLayer].outputs[2],CurMat.nodes['Principled BSDF'].inputs['Roughness'])
-            CurMat.links.new(CurMat.nodes[targetLayer].outputs[1],CurMat.nodes['Principled BSDF'].inputs['Metallic'])
+            CurMat.links.new(CurMat.nodes[targetLayer].outputs[0],CurMat.nodes[loc('Principled BSDF')].inputs['Base Color'])
+            CurMat.links.new(CurMat.nodes[targetLayer].outputs[2],CurMat.nodes[loc('Principled BSDF')].inputs['Roughness'])
+            CurMat.links.new(CurMat.nodes[targetLayer].outputs[1],CurMat.nodes[loc('Principled BSDF')].inputs['Metallic'])
 
         if normalimgpath:
             yoink = self.setGlobNormal(normalimgpath,CurMat,CurMat.nodes[targetLayer].outputs[3])
-            CurMat.links.new(yoink,CurMat.nodes['Principled BSDF'].inputs['Normal'])
+            CurMat.links.new(yoink,CurMat.nodes[loc('Principled BSDF')].inputs['Normal'])
         else:
-            CurMat.links.new(CurMat.nodes[targetLayer].outputs[3],CurMat.nodes['Principled BSDF'].inputs['Normal'])
+            CurMat.links.new(CurMat.nodes[targetLayer].outputs[3],CurMat.nodes[loc('Principled BSDF')].inputs['Normal'])
         return
 
 
@@ -659,4 +661,4 @@ class Multilayered:
         else:
             LayerNormal=Data["GlobalNormal"]
 
-        self.createLayerMaterial(os.path.basename(Data["MultilayerSetup"])[:-8]+"_Layer_",LayerCount,CurMat,Data["MultilayerMask"],Data["GlobalNormal"])
+        self.createLayerMaterial(os.path.basename(Data["MultilayerSetup"])[:-8]+"_Layer_",LayerCount,CurMat,Data["MultilayerMask"],LayerNormal)

--- a/i_scene_cp77_gltf/material_types/parallaxscreen.py
+++ b/i_scene_cp77_gltf/material_types/parallaxscreen.py
@@ -88,7 +88,7 @@ class ParallaxScreen:
 
     def create(self,Data,Mat):
         CurMat = Mat.node_tree
-        pBSDF=CurMat.nodes['Principled BSDF']
+        pBSDF=CurMat.nodes[loc('Principled BSDF')]
         sockets=bsdf_socket_names()
         pBSDF.inputs[sockets['Specular']].default_value = 0
         vers=bpy.app.version

--- a/i_scene_cp77_gltf/material_types/parallaxscreentransparent.py
+++ b/i_scene_cp77_gltf/material_types/parallaxscreentransparent.py
@@ -45,7 +45,7 @@ class ParallaxScreenTransparent:
     def create(self,Data,Mat):
         CurMat = Mat.node_tree
         vers=bpy.app.version
-        pBSDF=CurMat.nodes['Principled BSDF']
+        pBSDF=CurMat.nodes[loc('Principled BSDF')]
         sockets=bsdf_socket_names()
         pBSDF.inputs[sockets['Specular']].default_value = 0
 

--- a/i_scene_cp77_gltf/material_types/signages.py
+++ b/i_scene_cp77_gltf/material_types/signages.py
@@ -10,7 +10,7 @@ class Signages:
     
     def create(self,Data,Mat):
         CurMat = Mat.node_tree
-        pBSDF=CurMat.nodes['Principled BSDF']
+        pBSDF=CurMat.nodes[loc('Principled BSDF')]
         sockets=bsdf_socket_names()
         pBSDF.inputs[sockets['Specular']].default_value = 0
         print('Creating neon sign')
@@ -18,7 +18,7 @@ class Signages:
             dCol = CreateShaderNodeRGB(CurMat, Data["ColorOneStart"], -800, 250, "ColorOneStart")    
         else:
             dCol = CreateShaderNodeRGB(CurMat,{'Red': 255, 'Green': 255, 'Blue': 255, 'Alpha': 255}, -800, 250, "ColorOneStart")
-        CurMat.links.new(dCol.outputs[0],CurMat.nodes['Principled BSDF'].inputs['Base Color'])
+        CurMat.links.new(dCol.outputs[0],pBSDF.inputs['Base Color'])
           
         alphaNode = create_node(CurMat.nodes,"ShaderNodeMath", (-300, -250) ,operation = 'MULTIPLY')
                                 
@@ -45,13 +45,13 @@ class Signages:
         CurMat.links.new(mulNode.outputs[0], pBSDF.inputs[sockets['Emission']])
         
         if "EmissiveEV" in Data:
-            CurMat.nodes['Principled BSDF'].inputs['Emission Strength'].default_value =  Data["EmissiveEV"]*10
+            pBSDF.inputs['Emission Strength'].default_value =  Data["EmissiveEV"]*10
 
         if "Roughness" in Data:
-            CurMat.nodes['Principled BSDF'].inputs['Roughness'].default_value =  Data["Roughness"]
+            pBSDF.inputs['Roughness'].default_value =  Data["Roughness"]
 
         if "FresnelAmount" in Data:   
-            CurMat.nodes['Principled BSDF'].inputs[sockets['Specular']].default_value =  Data["FresnelAmount"]
+            pBSDF.inputs[sockets['Specular']].default_value =  Data["FresnelAmount"]
         
         if "ColorOneStart" in Data:
             dCol = CreateShaderNodeRGB(CurMat, Data["ColorOneStart"], -850, 250, "ColorOneStart")    

--- a/i_scene_cp77_gltf/material_types/skin.py
+++ b/i_scene_cp77_gltf/material_types/skin.py
@@ -9,7 +9,7 @@ class Skin:
         self.image_format = image_format
     def create(self,Data,Mat):
         CurMat = Mat.node_tree
-        pBSDF = CurMat.nodes['Principled BSDF']
+        pBSDF = CurMat.nodes[loc('Principled BSDF')]
         sockets=bsdf_socket_names()
         #SSS/s
 

--- a/i_scene_cp77_gltf/material_types/speedtree.py
+++ b/i_scene_cp77_gltf/material_types/speedtree.py
@@ -10,7 +10,7 @@ class SpeedTree:
         self.image_format = image_format
     def create(self,Data,Mat):
         CurMat = Mat.node_tree
-        pBSDF=CurMat.nodes['Principled BSDF']
+        pBSDF=CurMat.nodes[loc('Principled BSDF')]
         sockets=bsdf_socket_names()
         pBSDF.inputs[sockets['Specular']].default_value = 0
         

--- a/i_scene_cp77_gltf/material_types/televisionad.py
+++ b/i_scene_cp77_gltf/material_types/televisionad.py
@@ -13,7 +13,7 @@ class TelevisionAd:
     def create(self,Data,Mat):
         vers=bpy.app.version
         CurMat = Mat.node_tree
-        pBSDF = CurMat.nodes['Principled BSDF']
+        pBSDF = CurMat.nodes[loc('Principled BSDF')]
         sockets=bsdf_socket_names()
         pBSDF.inputs[sockets["Specular"]].default_value = 0
 

--- a/i_scene_cp77_gltf/material_types/vehicledestrblendshape.py
+++ b/i_scene_cp77_gltf/material_types/vehicledestrblendshape.py
@@ -225,14 +225,14 @@ class VehicleDestrBlendshape:
             NG.links.new(MetalMixN.outputs[0],GroupOutN.inputs[1])
         print(LayerCount)
         if LayerCount>1:
-            CurMat.links.new(CurMat.nodes["Layer_"+str(LayerCount-2)].outputs[0],CurMat.nodes['Principled BSDF'].inputs['Base Color'])
+            CurMat.links.new(CurMat.nodes["Layer_"+str(LayerCount-2)].outputs[0],CurMat.nodes[loc('Principled BSDF')].inputs['Base Color'])
             if normalimgpath:
                 yoink = self.setGlobNormal(normalimgpath,CurMat,CurMat.nodes["Layer_"+str(LayerCount-2)].outputs[3])
-                CurMat.links.new(yoink,CurMat.nodes['Principled BSDF'].inputs['Normal'])
+                CurMat.links.new(yoink,CurMat.nodes[loc('Principled BSDF')].inputs['Normal'])
             else:
-                CurMat.links.new(CurMat.nodes["Layer_"+str(LayerCount-2)].outputs[3],CurMat.nodes['Principled BSDF'].inputs['Normal'])
-            CurMat.links.new(CurMat.nodes["Layer_"+str(LayerCount-2)].outputs[2],CurMat.nodes['Principled BSDF'].inputs['Roughness'])
-            CurMat.links.new(CurMat.nodes["Layer_"+str(LayerCount-2)].outputs[1],CurMat.nodes['Principled BSDF'].inputs['Metallic'])
+                CurMat.links.new(CurMat.nodes["Layer_"+str(LayerCount-2)].outputs[3],CurMat.nodes[loc('Principled BSDF')].inputs['Normal'])
+            CurMat.links.new(CurMat.nodes["Layer_"+str(LayerCount-2)].outputs[2],CurMat.nodes[loc('Principled BSDF')].inputs['Roughness'])
+            CurMat.links.new(CurMat.nodes["Layer_"+str(LayerCount-2)].outputs[1],CurMat.nodes[loc('Principled BSDF')].inputs['Metallic'])
         return
 
 

--- a/i_scene_cp77_gltf/material_types/vehiclelights.py
+++ b/i_scene_cp77_gltf/material_types/vehiclelights.py
@@ -33,7 +33,7 @@ class VehicleLights:
 
     def create(self,Data,Mat):
         CurMat = Mat.node_tree
-        pBSDF = CurMat.nodes['Principled BSDF']
+        pBSDF = CurMat.nodes[loc('Principled BSDF')]
         sockets=bsdf_socket_names()
         pBSDF.inputs[sockets['Specular']].default_value = 0
 

--- a/i_scene_cp77_gltf/material_types/vehiclemeshdecal.py
+++ b/i_scene_cp77_gltf/material_types/vehiclemeshdecal.py
@@ -11,7 +11,7 @@ class VehicleMeshDecal:
 
     def create(self,Data,Mat):
         CurMat = Mat.node_tree
-        pBSDF = CurMat.nodes['Principled BSDF']
+        pBSDF = CurMat.nodes[loc('Principled BSDF')]
         sockets=bsdf_socket_names()
         pBSDF.inputs[sockets['Specular']].default_value = 0
         
@@ -82,8 +82,8 @@ class VehicleMeshDecal:
         if "DirtOpacity" in Data:
             dirtOpacVal = CreateShaderNodeValue(CurMat, Data["DirtOpacity"], -1200,350, "DirtOpacity")
 
-       ## if "DamageInfluence" in Data:
-        #    dmgInfVal = CreateShaderNodeValue(CurMat, Data["DamageInfluence"]["Value"], -1200, 550, "DamageInfluence")
+       # if "DamageInfluence" in Data:
+       #     dmgInfVal = CreateShaderNodeValue(CurMat, Data["DamageInfluence"]["Value"], -1200, 550, "DamageInfluence")
 
         if "UseGradientMap" in Data:
             gradMapVal = CreateShaderNodeValue(CurMat, Data["UseGradientMap"], -1200, 750, "UseGradientMap")

--- a/i_scene_cp77_gltf/material_types/window_parallax_interior_proxy.py
+++ b/i_scene_cp77_gltf/material_types/window_parallax_interior_proxy.py
@@ -11,7 +11,7 @@ class windowParallaxIntProx:
         self.image_format = image_format
     def create(self,Data,Mat):
         CurMat = Mat.node_tree
-        pBSDF=CurMat.nodes['Principled BSDF']
+        pBSDF=CurMat.nodes[loc('Principled BSDF')]
         CurMat.nodes.remove(pBSDF)
         AspectRatio=1
         # Aspect ratios is in the filename

--- a/i_scene_cp77_gltf/resources/scripts/export_deletions.py
+++ b/i_scene_cp77_gltf/resources/scripts/export_deletions.py
@@ -1,6 +1,12 @@
 import bpy
 import re
 import os
+#
+# If you want your deletions archive.xl to be yaml not json you need to install pyyaml
+# Following worked for me
+# import pip
+# pip.main(['install', 'pyyaml'])
+#
 yamlavail=False
 try:
     import yaml


### PR DESCRIPTION
Fixes issue 125

If you change the UI language then it changes the names of things like the Principal BSDF nodes, and the Child Of constraints when created, we had them hard coded to english, so things broke if you tried importing things when your gui was set to french or whatever. added loc(string) to common which looks up the localised version of the English string passed to it so you can wrap wherever your calling a name that you havent explicitly created yourself to get what the version on the current language should be. If your set to english it just returns the same.