### PR TITLE
fixed import errors; renamed color attributes

### DIFF
--- a/i_scene_cp77_gltf/__init__.py
+++ b/i_scene_cp77_gltf/__init__.py
@@ -1258,6 +1258,7 @@ class CP77GLBExport(Operator,ExportHelper):
 
     def execute(self, context):
         export_cyberpunk_glb(context,
+                             filepath=self.filepath,
                              export_poses=self.export_poses,
                              export_visible=self.export_visible,
                              limit_selected=self.limit_selected,

--- a/i_scene_cp77_gltf/__init__.py
+++ b/i_scene_cp77_gltf/__init__.py
@@ -7,7 +7,7 @@ def install_dependency(dependency_name):
         print(f"Successfully installed {dependency_name}")
     except Exception as e:
         print(f"Failed to install {dependency_name}: {e}")
-        
+
 print('-------------------- Cyberpunk IO Suite Starting--------------------')
 print()
 
@@ -122,12 +122,12 @@ class CP77IOSuitePreferences(AddonPreferences):
     default=True,
     )
 
-    def draw(self, context):           
+    def draw(self, context):
         layout = self.layout
         box = layout.box()
 
         row = box.row()
-        row.prop(self, "show_modtools",toggle=1) 
+        row.prop(self, "show_modtools",toggle=1)
         row.prop(self, "experimental_features",toggle=1)
         if self.experimental_features:
             row = box.row()
@@ -146,8 +146,8 @@ class CP77IOSuitePreferences(AddonPreferences):
             col.prop(self, "show_meshtools")
             col.prop(self, "show_collisiontools")
             col.prop(self, "show_animtools")
-            
-            
+
+
 class CP77ScriptManager(Panel):
     bl_label = "Script Manager"
     bl_idname = "CP77_PT_ScriptManagerPanel"
@@ -162,7 +162,6 @@ class CP77ScriptManager(Panel):
         # List available scripts
         script_files = [f for f in os.listdir(script_dir) if f.endswith(".py")]
 
-        
         for script_file in script_files:
             row = col.row(align=True)
             row.operator("script_manager.save_script", text="", icon="APPEND_BLEND").script_file = script_file
@@ -194,13 +193,13 @@ class CP77CreateScript(Operator):
             f.write("# New Script")
 
         return {'FINISHED'}
-        
+
 
 class CP77LoadScript(Operator):
     bl_idname = "script_manager.load_script"
     bl_label = "Load Script"
     bl_description = "Click to load or switch to this script, ctrl+click to rename"
-    
+
     script_file: StringProperty()
     new_name: StringProperty(name="New name", default=".py")
 
@@ -223,7 +222,7 @@ class CP77LoadScript(Operator):
             script_text = bpy.data.texts.get(script_name)
             # Switch to the loaded script if present
             if script_text is not None:
-                context.space_data.text = script_text  
+                context.space_data.text = script_text
             else:
                 # If the script is not loaded, load it
                 script_path = os.path.join(script_dir, script_name)
@@ -233,8 +232,8 @@ class CP77LoadScript(Operator):
                         text_data = bpy.data.texts.new(name=script_name)
                         text_data.from_string(f.read())
                         # Set the loaded script as active
-                        context.space_data.text = text_data  
-        
+                        context.space_data.text = text_data
+
         return {'FINISHED'}
 
     def invoke(self, context, event):
@@ -254,7 +253,7 @@ class CP77SaveScript(Operator):
     bl_idname = "script_manager.save_script"
     bl_label = "Save Script"
     bl_description = "Press to save this script"
-    
+
     script_file: StringProperty()
 
     def execute(self, context):
@@ -271,7 +270,7 @@ class CP77DeleteScript(Operator):
     bl_idname = "script_manager.delete_script"
     bl_label = "Delete Script"
     bl_description = "Press to delete this script"
-    
+
     script_file: StringProperty()
 
     def execute(self, context):
@@ -316,7 +315,7 @@ class CP77_PT_PanelProps(PropertyGroup):
         ('WORLD', "worldCollisionNode", "Generate worldCollisionNode")
         ],
         default='VEHICLE'
-    ) 
+    )
 
     physics_material: EnumProperty(
         items= enum_items,
@@ -334,7 +333,7 @@ class CP77_PT_PanelProps(PropertyGroup):
         ],
         default='CONVEX'
     )
-    
+
     simulation_type: EnumProperty(
         name="Simulation Type",
         items=[
@@ -345,7 +344,7 @@ class CP77_PT_PanelProps(PropertyGroup):
         default='Kinematic'
     )
 
-    matchSize: BoolProperty(        
+    matchSize: BoolProperty(
         name="Match the Shape of Existing Mesh",
         description="Match the size of the selected Mesh",
         default=True,
@@ -384,14 +383,14 @@ class CP77_PT_PanelProps(PropertyGroup):
         default=False,
         description="Insert a keyframe on every frame of the active action"
     )
-    
+
     body_list: EnumProperty(
         items=[(name, name, '') for name in cp77riglist(None)[1]],
         name="Rig GLB"
     )
-    
+
 # mesh panel props
-    
+
     fbx_rot: BoolProperty(
         name="",
         default=False,
@@ -409,7 +408,7 @@ class CP77_PT_PanelProps(PropertyGroup):
 
     mesh_source: EnumProperty(
         items=CP77CollectionList
-    ) 
+    )
 
     mesh_target: EnumProperty(
         items=CP77CollectionList
@@ -417,15 +416,15 @@ class CP77_PT_PanelProps(PropertyGroup):
 
     merge_distance: FloatProperty(
         name="Merge Distance",
-        default=0.0001, 
-        min=0.0, 
+        default=0.0001,
+        min=0.0,
         max=1.0
     )
 
     smooth_factor: FloatProperty(
-        name="Smooth Factor", 
-        default=0.5, 
-        min=0.0, 
+        name="Smooth Factor",
+        default=0.5,
+        min=0.0,
         max=1.0
     )
 
@@ -439,7 +438,7 @@ class CP77CollisionGenerator(Operator):
     bl_idname = "generate_cp77.collisions"
     bl_label = "Generate Collider"
     bl_options = {'REGISTER', "UNDO"}
-    bl_description = "Generate Colliders for use with Cyberpunk 2077" 
+    bl_description = "Generate Colliders for use with Cyberpunk 2077"
 
 
 
@@ -450,7 +449,7 @@ class CP77CollisionGenerator(Operator):
         props = context.scene.cp77_panel_props
         CP77CollisionGen(self, context,props.matchSize, props.collision_type, props.collision_shape, props.sampleverts, props.radius, props.height, props.physics_material)
         return {"FINISHED"}
-    
+
     def draw(self, context):
         props = context.scene.cp77_panel_props
         layout = self.layout
@@ -502,24 +501,7 @@ class CP77CollisionExport(Operator):
     def invoke(self, context, event):
         context.window_manager.fileselect_add(self)
         return {"RUNNING_MODAL"}
-        
-        
-class CP7PhysImport(Operator):
-    bl_idname = "import_scene.phys"
-    bl_label = "Import .phys Collisions"
-    bl_options = {'REGISTER', 'UNDO'}
-    bl_description = "Import collisions from an exported .phys.json"
 
-    filepath: StringProperty(subtype="FILE_PATH")
-
-    def execute(self, context):
-        cp77_phys_import(self.filepath)
-        return {"FINISHED"}
-
-    def invoke(self, context, event):
-        context.window_manager.fileselect_add(self)
-        return {"RUNNING_MODAL"}
-        
 
 class CP7PhysImport(Operator):
     bl_idname = "import_scene.phys"
@@ -536,7 +518,24 @@ class CP7PhysImport(Operator):
     def invoke(self, context, event):
         context.window_manager.fileselect_add(self)
         return {"RUNNING_MODAL"}
-        
+
+
+class CP7PhysImport(Operator):
+    bl_idname = "import_scene.phys"
+    bl_label = "Import .phys Collisions"
+    bl_options = {'REGISTER', 'UNDO'}
+    bl_description = "Import collisions from an exported .phys.json"
+
+    filepath: StringProperty(subtype="FILE_PATH")
+
+    def execute(self, context):
+        cp77_phys_import(self.filepath)
+        return {"FINISHED"}
+
+    def invoke(self, context, event):
+        context.window_manager.fileselect_add(self)
+        return {"RUNNING_MODAL"}
+
 class CP77PhysMatAssign(Operator):
     bl_idname = "object.set_physics_material"
     bl_label = "Set Physics Properties"
@@ -550,7 +549,7 @@ class CP77PhysMatAssign(Operator):
         physmat_data = next((mat for mat in physmats_data if mat["Name"] == selected_physmat), None)
 
         if physmat_data is not None:
-        
+
             # Set custom properties on the object
             obj = context.object
             props = context.scene.cp77_panel_props
@@ -575,9 +574,9 @@ class CP77PhysMatAssign(Operator):
             obj["inertia_X"] = Ix
             obj["inertia_Y"] = Iy
             obj["inertia_Z"] = Iz
-            
+
         return {'FINISHED'}
-    
+
 
 class CP77_PT_CollisionTools(Panel):
     bl_label = "Collision Tools"
@@ -591,7 +590,7 @@ class CP77_PT_CollisionTools(Panel):
     def poll(cls, context):
         cp77_addon_prefs = context.preferences.addons[__name__].preferences
         if cp77_addon_prefs.context_only:
-            return context.active_object and context.active_object.type == 'MESH' 
+            return context.active_object and context.active_object.type == 'MESH'
         else:
             return context
 
@@ -640,7 +639,7 @@ class CP77_PT_CollisionTools(Panel):
                     split.label(text=f"Z: {obj.get('inertia_Z', 0):.0f}")
                     row = box.row()
                     row.operator('object.set_physics_material')
-                    
+
 
 def CP77AnimsList(self, context):
     for action in bpy.data.actions:
@@ -667,7 +666,7 @@ class CP77AnimsDelete(Operator):
         return{'FINISHED'}
 
 
-# this class is where most of the function is so far - play/pause 
+# this class is where most of the function is so far - play/pause
 # Todo: fix renaming actions from here
 class CP77Animset(Operator):
     bl_idname = 'cp77.set_animset'
@@ -718,7 +717,7 @@ class CP77Animset(Operator):
         else:
             self.new_name = ""
             return self.execute(context)
-            
+
 
 
 class CP77BoneHider(Operator):
@@ -727,7 +726,7 @@ class CP77BoneHider(Operator):
     bl_options = {'REGISTER', 'UNDO'}
     bl_label = "Toggle Deform Bone Visibilty"
     bl_description = "Hide deform bones in the selected armature"
-    
+
     def execute(self, context):
         hide_extra_bones(self, context)
         return{'FINISHED'}
@@ -739,7 +738,7 @@ class CP77BoneUnhider(Operator):
     bl_options = {'REGISTER', 'UNDO'}
     bl_label = "Toggle Deform Bone Visibilty"
     bl_description = "Unhide deform bones in the selected armature"
-    
+
     def execute(self, context):
         unhide_extra_bones(self, context)
         return{'FINISHED'}
@@ -759,7 +758,7 @@ class CP77Keyframe(Operator):
         props = context.scene.cp77_panel_props
         cp77_keyframe(props, context, props.frameall)
         return {"FINISHED"}
-    
+
     def draw(self, context):
         layout = self.layout
         props = context.scene.cp77_panel_props
@@ -768,7 +767,7 @@ class CP77Keyframe(Operator):
         row = layout.row(align=True)
         row.prop(props, "frameall", text="")
 
-    
+
 class CP77ResetArmature(Operator):
     bl_idname = "reset_armature.cp77"
     bl_parent_id = "CP77_PT_animspanel"
@@ -785,7 +784,7 @@ class CP77NewAction(Operator):
     bl_idname = 'cp77.new_action'
     bl_label = "Add Action"
     bl_options = {'INTERNAL', 'UNDO'}
-    bl_description = "Add a new action to the list" 
+    bl_description = "Add a new action to the list"
 
     name: StringProperty(default="New action")
 
@@ -806,12 +805,12 @@ class CP77NewAction(Operator):
         reset_armature(obj, context)
         obj.animation_data.action = new_action
         return {'FINISHED'}
-    
+
 
 class CP77RigLoader(Operator):
     bl_idname = "cp77.rig_loader"
     bl_label = "Load rigs from .glb"
-    bl_description = "Load Cyberpunk 2077 deform rigs from plugin resources" 
+    bl_description = "Load Cyberpunk 2077 deform rigs from plugin resources"
 
     files: CollectionProperty(type=OperatorFileListElement)
     appearances: StringProperty(name="Appearances", default="")
@@ -827,7 +826,7 @@ class CP77RigLoader(Operator):
             # Find the corresponding .glb file and load it
             selected_rig = rig_files[rig_names.index(selected_rig_name)]
             self.filepath = selected_rig
-            CP77GLBimport(self, exclude_unused_mats=True, image_format='PNG', with_materials=False, 
+            CP77GLBimport(self, exclude_unused_mats=True, image_format='PNG', with_materials=False,
                           filepath=selected_rig, hide_armatures=False, import_garmentsupport=False, files=[], directory='', appearances="ALL", remap_depot=False)
             if props.fbx_rot:
                 rotate_quat_180(self,context)
@@ -849,13 +848,13 @@ class CP77_PT_AnimsPanel(Panel):
     def poll(cls, context):
         cp77_addon_prefs = context.preferences.addons[__name__].preferences
         if cp77_addon_prefs.context_only:
-            return context.active_object and context.active_object.type == 'ARMATURE' 
+            return context.active_object and context.active_object.type == 'ARMATURE'
         else:
             return context
-        
-## make sure the context is unrestricted as possible, ensure there's an armature selected 
+
+## make sure the context is unrestricted as possible, ensure there's an armature selected
     def draw(self, context):
-        layout = self.layout 
+        layout = self.layout
 
         cp77_addon_prefs = context.preferences.addons[__name__].preferences
 
@@ -911,7 +910,7 @@ class CP77_PT_AnimsPanel(Panel):
                                 row.prop(active_action, 'frame_end', text="")
                     row = box.row(align=True)
                     row.operator('insert_keyframe.cp77')
-               
+
                     box = layout.box()
                     row = box.row(align=True)
                     row.label(text='Animsets', icon_value=custom_icon_col["import"]['WKIT'].icon_id)
@@ -959,20 +958,20 @@ class CollectionAppearancePanel(Panel):
         collection = context.collection
         layout.prop(collection, "appearanceName")
 
-    
+
 class CP77Autofitter(Operator):
     bl_idname = "cp77.auto_fitter"
     bl_label = "Auto Fit"
-    bl_description = "Use to automatically fit your mesh to a selection of modified bodies" 
+    bl_description = "Use to automatically fit your mesh to a selection of modified bodies"
     bl_options = {'REGISTER', 'UNDO'}
 
     def execute(self, context):
         props = context.scene.cp77_panel_props
         target_body_name = props.refit_json
         target_body_paths, target_body_names = CP77RefitList(context)
-        refitter = CP77RefitChecker(self, context)  
+        refitter = CP77RefitChecker(self, context)
 
-        if target_body_name in target_body_names:          
+        if target_body_name in target_body_names:
             target_body_path = target_body_paths[target_body_names.index(target_body_name)]
             CP77Refit(context, refitter, target_body_path, target_body_name, props.fbx_rot)
 
@@ -1011,12 +1010,12 @@ class CP77UVCheckRemover(Operator):
     @classmethod
     def poll(cls, context):
         return context.object.active_material.name and context.object.active_material.name == 'UV_Checker'
-        
+
     def execute(self, context):
         CP77UvUnChecker(self, context)
         return {"FINISHED"}
 
-        
+
 class CP77HairProfileExport(Operator):
     bl_idname = "export_scene.hp"
     bl_label = "Export Hair Profile"
@@ -1034,10 +1033,10 @@ class CP77MlSetupExport(Operator):
     bl_idname = "export_scene.mlsetup"
     bl_label = "Export MLSetup"
     bl_parent_id = "CP77_PT_MeshTools"
-    bl_description = "EXPERIMENTAL: Export material changes to mlsetup files" 
+    bl_description = "EXPERIMENTAL: Export material changes to mlsetup files"
 
     filepath: StringProperty(subtype="FILE_PATH")
-  
+
     def execute(self, context):
         cp77_mlsetup_export(self, context)
         return {"FINISHED"}
@@ -1047,8 +1046,8 @@ class CP77SetArmature(Operator):
     bl_idname = "cp77.set_armature"
     bl_label = "Change Armature Target"
     bl_parent_id = "CP77_PT_MeshTools"
-    bl_description = "Change the armature modifier on selected meshes to the target" 
-    
+    bl_description = "Change the armature modifier on selected meshes to the target"
+
     def execute(self, context):
         CP77ArmatureSet(self,context)
         return {'FINISHED'}
@@ -1059,7 +1058,7 @@ class CP77_OT_submesh_prep(Operator):
     bl_label = "Prep. It!"
     bl_idname = "cp77.submesh_prep"
     bl_parent_id = "CP77_PT_MeshTools"
-    bl_description = "Marking seams based on edges boundary loops, merging vertices, correcting and smoothening the normals based on the direction of the faces" 
+    bl_description = "Marking seams based on edges boundary loops, merging vertices, correcting and smoothening the normals based on the direction of the faces"
 
     def execute(self, context):
         props= context.scene.cp77_panel_props
@@ -1072,22 +1071,22 @@ class CP77GroupVerts(Operator):
     bl_parent_id = "CP77_PT_MeshTools"
     bl_label = "Assign to Nearest Group"
     bl_options = {'REGISTER', 'UNDO'}
-    bl_description = "Assign ungrouped vertices to their nearest group" 
+    bl_description = "Assign ungrouped vertices to their nearest group"
 
     def execute(self, context):
         CP77GroupUngroupedVerts(self, context)
         return {'FINISHED'}
-    
+
 
 class CP77RotateObj(Operator):
     bl_label = "Change Orientation"
     bl_idname = "cp77.rotate_obj"
     bl_description = "rotate the selected object"
-    
+
     def execute(self, context):
         rotate_quat_180(self, context)
         return {'FINISHED'}
-    
+
 
 class CP77_PT_MeshTools(Panel):
     bl_label = "Mesh Tools"
@@ -1096,14 +1095,14 @@ class CP77_PT_MeshTools(Panel):
     bl_region_type = "UI"
     bl_category = "CP77 Modding"
     bl_options = {'DEFAULT_CLOSED'}
-   
+
     @classmethod
     def poll(cls, context):
         cp77_addon_prefs = context.preferences.addons[__name__].preferences
         if cp77_addon_prefs.context_only:
             return context.active_object and context.active_object.type == 'MESH'
         else:
-            return context  
+            return context
 
     def draw(self, context):
         layout = self.layout
@@ -1166,9 +1165,9 @@ class CP77_PT_MeshTools(Panel):
                 box.label(text="Material Export", icon="MATERIAL")
                 box.operator("export_scene.hp")
                 box.operator("export_scene.mlsetup")
-        
 
-## adds a message box for the exporters to use for error notifications, will also be used later for redmod integration    
+
+## adds a message box for the exporters to use for error notifications, will also be used later for redmod integration
 class ShowMessageBox(Operator):
     bl_idname = "cp77.message_box"
     bl_label = "Message"
@@ -1183,18 +1182,18 @@ class ShowMessageBox(Operator):
         return context.window_manager.invoke_props_dialog(self, width=300)
 
     def draw(self, context):
-        wrapp = textwrap.TextWrapper(width=50) #50 = maximum length       
-        wList = wrapp.wrap(text=self.message) 
-        for text in wList: 
+        wrapp = textwrap.TextWrapper(width=50) #50 = maximum length
+        wList = wrapp.wrap(text=self.message)
+        for text in wList:
             row = self.layout.row(align = True)
             row.alignment = 'EXPAND'
-            row.label(text=text)     
+            row.label(text=text)
 
 class CP77StreamingSectorExport(Operator,ExportHelper):
     bl_idname = "export_scene.cp77_sector"
     bl_label = "Export Sector Updates for Cyberpunk"
     bl_options = {'REGISTER','UNDO'}
-    bl_description = "Export changes to Sectors back to project" 
+    bl_description = "Export changes to Sectors back to project"
     filename_ext = ".cpmodproj"
     filter_glob: StringProperty(default="*.cpmodproj", options={'HIDDEN'})
 
@@ -1202,36 +1201,59 @@ class CP77StreamingSectorExport(Operator,ExportHelper):
         exportSectors(self.filepath)
         return {'FINISHED'}
 
+class ExportSettings:
+    def __init__(self, filepath, export_poses, export_visible, limit_selected, static_prop, red_garment_col):
+        self.filepath = filepath
+        self.export_poses = export_poses
+        self.export_visible = export_visible
+        self.limit_selected = limit_selected
+        self.static_prop = static_prop
+        self.red_garment_col = red_garment_col
+
 class CP77GLBExport(Operator,ExportHelper):
   ### cleaned this up and moved most code to exporters.py
     bl_idname = "export_scene.cp77_glb"
     bl_label = "Export for Cyberpunk"
     bl_options = {'REGISTER','UNDO'}
-    bl_description = "Export to GLB with optimized settings for use with Wolvenkit for Cyberpunk 2077" 
+    bl_description = "Export to GLB with optimized settings for use with Wolvenkit for Cyberpunk 2077"
     filename_ext = ".glb"
    ### adds a checkbox for anim export settings
-    
+
+
+    def createExportSettings(self):
+        return ExportSettings(
+            filepath=self.filepath,
+            export_poses=self.export_poses,
+            export_visible=self.export_visible,
+            limit_selected=self.limit_selected,
+            static_prop=self.static_prop,
+            red_garment_col=self.red_garment_col
+        )
+
     filter_glob: StringProperty(default="*.glb", options={'HIDDEN'})
-   
-    
+
     limit_selected: BoolProperty(
         name="Limit to Selected Meshes",
         default=True,
         description="Only Export the Selected Meshes. This is probably the setting you want to use"
     )
-    
+    # TODO: This should probably be a button in the mesh tools somewhere, but I needed to add this to 40+ meshes with 5 submeshes each
+    # Yes, I was making socks -.-
+    red_garment_col: BoolProperty(
+        name="Add red GarmentCol layer",
+        default=False,
+        description="Adds a red GarmentCol layer for all selected meshes. Read https://tinyurl.com/cyberpunkgarmentcol for more info"
+    )
     static_prop: BoolProperty(
         name="Export as Static Prop",
         default=False,
         description="No armature export, only use this for exporting props and objects which do not need to move"
     )
-
     export_poses: BoolProperty(
         name="Animations",
         default=False,
         description="Use this option if you are exporting anims to be imported into wkit as .anim"
     )
-
     export_visible: BoolProperty(
         name="Export Visible Meshes",
         default=False,
@@ -1240,20 +1262,23 @@ class CP77GLBExport(Operator,ExportHelper):
 
     def draw(self, context):
         layout = self.layout
-        row = layout.row(align=True) 
+        row = layout.row(align=True)
         row.prop(self, "export_poses")
-        if not self.export_poses:
+        if self.export_poses:
+            return
+        row = layout.row(align=True)
+        row.prop(self, "limit_selected")
+        row = layout.row(align=True)
+        row.prop(self, "red_garment_col")
+        if not self.limit_selected:
             row = layout.row(align=True)
-            row.prop(self, "limit_selected")
-            if not self.limit_selected:
-                row = layout.row(align=True)
-                row.prop(self, "export_visible")
-            else: 
-                row = layout.row(align=True)
-                row.prop(self, "static_prop")
-        
+            row.prop(self, "export_visible")
+        else:
+            row = layout.row(align=True)
+            row.prop(self, "static_prop")
+
     def execute(self, context):
-        export_cyberpunk_glb(context, self.filepath, self.export_poses, self.export_visible, self.limit_selected, self.static_prop)
+        export_cyberpunk_glb(context, settings=self.createExportSettings())
         return {'FINISHED'}
 
 
@@ -1261,8 +1286,8 @@ class CP77EntityImport(Operator,ImportHelper):
 
     bl_idname = "io_scene_gltf.cp77entity"
     bl_label = "Import Ent from JSON"
-    bl_description = "Import Characters and Vehicles from Cyberpunk 2077 Entity Files" 
-    
+    bl_description = "Import Characters and Vehicles from Cyberpunk 2077 Entity Files"
+
     filter_glob: StringProperty(
         default="*.json",
         options={'HIDDEN'},
@@ -1280,18 +1305,18 @@ class CP77EntityImport(Operator,ImportHelper):
                                 default="",
                                 options={'HIDDEN'})
 
-    use_cycles: BoolProperty(name="Use Cycles",default=True,description="Use Cycles")  
+    use_cycles: BoolProperty(name="Use Cycles",default=True,description="Use Cycles")
     update_gi: BoolProperty(name="Update Global Illumination",default=False,description="Update Cycles global illumination options for transparency fixes and higher quality renders")
-    with_materials: BoolProperty(name="With Materials",default=True,description="Import Wolvenkit-exported materials")   
+    with_materials: BoolProperty(name="With Materials",default=True,description="Import Wolvenkit-exported materials")
     include_collisions: BoolProperty(name="Include Collisions",default=False,description="Use this option to import collision bodies with this entity")
     include_phys: BoolProperty(name="Include .phys Collisions",default=False,description="Use this option if you want to import the .phys collision bodies. Useful for vehicle modding")
     include_entCollider: BoolProperty(name="Include Collision Components",default=False,description="Use this option to import entColliderComponent and entSimpleColliderComponent")
-    remap_depot: BoolProperty(name="Remap Depot",default=False,description="replace the json depot path with the one in prefs")  
+    remap_depot: BoolProperty(name="Remap Depot",default=False,description="replace the json depot path with the one in prefs")
     inColl: StringProperty(name= "Collector to put the imported entity in",
                                 description="Collector to put the imported entity in",
                                 default='',
                                 options={'HIDDEN'})
-        
+
     def draw(self, context):
         cp77_addon_prefs = bpy.context.preferences.addons[__name__].preferences
         layout = self.layout
@@ -1316,7 +1341,7 @@ class CP77EntityImport(Operator,ImportHelper):
             if not hasattr(self, "_collisions_initialized") or not self._collisions_initialized:
                 self.include_phys = True
                 self.include_entCollider = True
-                self._collisions_initialized = True  # Flag to indicate initialization            
+                self._collisions_initialized = True  # Flag to indicate initialization
             row.prop(self, "include_collisions")
             row = layout.row(align=True)
             row.prop(self, "include_phys")
@@ -1341,28 +1366,28 @@ class CP77StreamingSectorImport(Operator,ImportHelper):
 
     bl_idname = "io_scene_gltf.cp77sector"
     bl_label = "Import All StreamingSectors from project"
-    bl_description = "Load Cyberpunk 2077 Streaming Sectors" 
-    
+    bl_description = "Load Cyberpunk 2077 Streaming Sectors"
+
     filter_glob: StringProperty(
         default="*.cpmodproj",
         options={'HIDDEN'},
         )
-    
+
     filepath: StringProperty(name= "Filepath",
                              subtype = 'FILE_PATH')
 
     want_collisions: BoolProperty(name="Import Collisions",default=False,description="Import Box and Capsule Collision objects (mesh not yet supported)")
     am_modding: BoolProperty(name="Generate New Collectors",default=False,description="Generate _new collectors for sectors to allow modifications to be saved back to game")
     with_materials: BoolProperty(name="With Materials",default=False,description="Import Wolvenkit-exported materials")
-    with_lights: BoolProperty(name="With Lights",default=False,description="Import Lights from the sector")    
-    remap_depot: BoolProperty(name="Remap Depot",default=False,description="replace the json depot path with the one in prefs")  
+    with_lights: BoolProperty(name="With Lights",default=False,description="Import Lights from the sector")
+    remap_depot: BoolProperty(name="Remap Depot",default=False,description="replace the json depot path with the one in prefs")
 
 
     def draw(self, context):
-        cp77_addon_prefs = bpy.context.preferences.addons[__name__].preferences 
+        cp77_addon_prefs = bpy.context.preferences.addons[__name__].preferences
         layout = self.layout
         box = layout.box()
-        row = box.row(align=True) 
+        row = box.row(align=True)
         row.prop(self, "want_collisions",)
         row = layout.row(align=True)
         row.prop(self, "am_modding")
@@ -1385,8 +1410,8 @@ class CP77StreamingSectorImport(Operator,ImportHelper):
 class CP77_PT_ImportWithMaterial(Panel):
     bl_space_type = 'FILE_BROWSER'
     bl_region_type = 'TOOL_PROPS'
-    bl_label = "With Materials"  
-    
+    bl_label = "With Materials"
+
     @classmethod
     def poll(cls, context):
         operator = context.space_data.active_operator
@@ -1395,7 +1420,7 @@ class CP77_PT_ImportWithMaterial(Panel):
     def draw_header(self, context):
         operator = context.space_data.active_operator
         self.layout.prop(operator, "with_materials", text="")
-    
+
     def draw(self, context):
         cp77_addon_prefs = bpy.context.preferences.addons[__name__].preferences
         props = context.scene.cp77_panel_props
@@ -1450,14 +1475,14 @@ class CP77Import(Operator,ImportHelper):
     update_gi: BoolProperty(name="Update Global Illumination",default=False,description="Update Cycles global illumination options for transparency fixes and higher quality renders")
 
     import_garmentsupport: BoolProperty(name="Import Garment Support (Experimental)",default=True,description="Imports Garment Support mesh data as color attributes")
-    
-    remap_depot: BoolProperty(name="Remap Depot",default=False,description="replace the json depot path with the one in prefs")  
-    
+
+    remap_depot: BoolProperty(name="Remap Depot",default=False,description="replace the json depot path with the one in prefs")
+
     filepath: StringProperty(subtype = 'FILE_PATH')
 
     files: CollectionProperty(type=OperatorFileListElement)
     directory: StringProperty()
-    
+
     appearances: StringProperty(name= "Appearances",
                                 description="Appearances to extract with models",
                                 default="ALL"
@@ -1482,8 +1507,8 @@ def menu_func_import(self, context):
 def menu_func_export(self, context):
     self.layout.operator(CP77GLBExport.bl_idname, text="Cyberpunk GLB", icon_value=custom_icon_col["import"]['WKIT'].icon_id)
     self.layout.operator(CP77StreamingSectorExport.bl_idname, text="Cyberpunk StreamingSector", icon_value=custom_icon_col["import"]['WKIT'].icon_id)
-    
-#kwekmaster - Minor Refactoring 
+
+#kwekmaster - Minor Refactoring
 classes = (
     CP77Import,
     CP77EntityImport,
@@ -1550,28 +1575,28 @@ def register():
     custom_icon_col["sculpt"] = sculpt_icon
     custom_icon_col["refit"] = refit_icon
 
-    #kwekmaster - Minor Refactoring 
+    #kwekmaster - Minor Refactoring
     for cls in classes:
         bpy.utils.register_class(cls)
 
     Scene.cp77_panel_props = PointerProperty(type=CP77_PT_PanelProps)
     TOPBAR_MT_file_import.append(menu_func_import)
-    TOPBAR_MT_file_export.append(menu_func_export) 
-    
+    TOPBAR_MT_file_export.append(menu_func_export)
+
 def unregister():
     del Scene.cp77_panel_props
     for icon_key in custom_icon_col.keys():
         bpy.utils.previews.remove(custom_icon_col[icon_key])
 
 
-    #kwekmaster - Minor Refactoring 
+    #kwekmaster - Minor Refactoring
     for cls in classes:
         bpy.utils.unregister_class(cls)
 
-    
+
     TOPBAR_MT_file_import.remove(menu_func_import)
     TOPBAR_MT_file_export.remove(menu_func_export)
     custom_icon_col.clear()
-                
+
 if __name__ == "__main__":
     register()

--- a/i_scene_cp77_gltf/__init__.py
+++ b/i_scene_cp77_gltf/__init__.py
@@ -1200,16 +1200,6 @@ class CP77StreamingSectorExport(Operator,ExportHelper):
     def execute(self, context):
         exportSectors(self.filepath)
         return {'FINISHED'}
-
-class ExportSettings:
-    def __init__(self, filepath, export_poses, export_visible, limit_selected, static_prop, red_garment_col):
-        self.filepath = filepath
-        self.export_poses = export_poses
-        self.export_visible = export_visible
-        self.limit_selected = limit_selected
-        self.static_prop = static_prop
-        self.red_garment_col = red_garment_col
-
 class CP77GLBExport(Operator,ExportHelper):
   ### cleaned this up and moved most code to exporters.py
     bl_idname = "export_scene.cp77_glb"
@@ -1218,17 +1208,6 @@ class CP77GLBExport(Operator,ExportHelper):
     bl_description = "Export to GLB with optimized settings for use with Wolvenkit for Cyberpunk 2077"
     filename_ext = ".glb"
    ### adds a checkbox for anim export settings
-
-
-    def createExportSettings(self):
-        return ExportSettings(
-            filepath=self.filepath,
-            export_poses=self.export_poses,
-            export_visible=self.export_visible,
-            limit_selected=self.limit_selected,
-            static_prop=self.static_prop,
-            red_garment_col=self.red_garment_col
-        )
 
     filter_glob: StringProperty(default="*.glb", options={'HIDDEN'})
 
@@ -1278,7 +1257,12 @@ class CP77GLBExport(Operator,ExportHelper):
             row.prop(self, "static_prop")
 
     def execute(self, context):
-        export_cyberpunk_glb(context, settings=self.createExportSettings())
+        export_cyberpunk_glb(context,
+                             export_poses=self.export_poses,
+                             export_visible=self.export_visible,
+                             limit_selected=self.limit_selected,
+                             static_prop=self.static_prop,
+                             red_garment_col=self.red_garment_col )
         return {'FINISHED'}
 
 

--- a/i_scene_cp77_gltf/exporters/glb_export.py
+++ b/i_scene_cp77_gltf/exporters/glb_export.py
@@ -95,7 +95,7 @@ def add_garment_cap(mesh):
 
 # setup the actual exporter - rewrote almost all of this, much quicker now
 # mana: by assigning default attributes, we make this update-safe (some older scripts broke). Just don't re-name them!
-def export_cyberpunk_glb(context, filepath=None, export_poses=False, export_visible=False, limit_selected=True, static_prop=False, red_garment_col=False):
+def export_cyberpunk_glb(context, filepath, export_poses=False, export_visible=False, limit_selected=True, static_prop=False, red_garment_col=False):
 
     groupless_bones = set()
     bone_names = []

--- a/i_scene_cp77_gltf/exporters/glb_export.py
+++ b/i_scene_cp77_gltf/exporters/glb_export.py
@@ -77,6 +77,8 @@ def add_garment_cap(mesh):
     if cap_layer == None:
         bpy.context.view_layer.objects.active = mesh
         bpy.ops.geometry.color_attribute_add(name=garment_cap_name, domain='CORNER', data_type='BYTE_COLOR')
+    # else:
+        # TODO Presto show a warning
 
     # do not overwrite already-existing garment weight layers. Newly-created layer will be black anyway, nothing to do here.
     if weight_layer == None:
@@ -93,14 +95,7 @@ def add_garment_cap(mesh):
 
 # setup the actual exporter - rewrote almost all of this, much quicker now
 # mana: by assigning default attributes, we make this update-safe (some older scripts broke). Just don't re-name them!
-def export_cyberpunk_glb(context, filepath=None, export_poses=False, export_visible=False, limit_selected=True, static_prop=False, red_garment_col=False, settings=None):
-    if settings != None:
-        filepath = settings.filepath
-        export_poses = settings.export_poses
-        export_visible = settings.export_visible
-        limit_selected = settings.limit_selected
-        static_prop = settings.static_prop
-        red_garment_col = settings.red_garment_col
+def export_cyberpunk_glb(context, filepath=None, export_poses=False, export_visible=False, limit_selected=True, static_prop=False, red_garment_col=False):
 
     groupless_bones = set()
     bone_names = []

--- a/i_scene_cp77_gltf/exporters/sectors_export.py
+++ b/i_scene_cp77_gltf/exporters/sectors_export.py
@@ -1,13 +1,13 @@
-# Script to export CP2077 streaming sectors from Blender 
+# Script to export CP2077 streaming sectors from Blender
 # Just does changes to existing bits so far
 # By Simarilius Jan 2023
 # last updated 17/4/24
 # latest version in the plugin from https://github.com/WolvenKit/Cyberpunk-Blender-add-on
 #
-#  __       __   ___  __   __  .  . .  . .   .       __   ___  __  ___  __   __      ___  __  . ___ . .  .  __  
-# /  ` \ / |__) |__  |__) |__) |  | |\ | |__/       /__` |__  /  `  |  /  \ |__)    |__  |  \ |  |  | |\ | / _` 
-# \__,  |  |__) |___ |  \ |    \__/ | \| |  \       .__/ |___ \__,  |  \__/ |  \    |___ |__/ |  |  | | \| \__/ 
-#                                                                                                              
+#  __       __   ___  __   __  .  . .  . .   .       __   ___  __  ___  __   __      ___  __  . ___ . .  .  __
+# /  ` \ / |__) |__  |__) |__) |  | |\ | |__/       /__` |__  /  `  |  /  \ |__)    |__  |  \ |  |  | |\ | / _`
+# \__,  |  |__) |___ |  \ |    \__/ | \| |  \       .__/ |___ \__,  |  \__/ |  \    |___ |__/ |  |  | | \| \__/
+#
 # Havent written a tutorial for this yet so thought I should add some instructions
 # 1) Import the sector you want to edit using the Cyberpunk blender plugin (link above).
 # 2) You can move the existing objects around and this will be exported
@@ -17,7 +17,7 @@
 # 5) If its stuff already in the sector it will create nodeData nodes to instance it, if its from another imported sector it will copy the main node too
 #    Its assuming it can find the json for the sector its copying from in the project, dont be clever merging blends or whatever.
 # 6) not all nodetypes are supported yet, have a look at the case statements to see which are
-# 
+#
 # Ask in world-editing on the discord (https://discord.gg/redmodding) if you have any trouble
 
 # TODO
@@ -26,25 +26,17 @@
 # - Add collisions
 # - sort out instanced bits
 
-import mathutils
+from mathutils import Vector, Matrix, Quaternion
 def are_matrices_equal(mat1, mat2, tolerance=0.01):
     if len(mat1) != len(mat2):
         return False
-    
+
     for i in range(len(mat1)):
         for j in range(len(mat1[i])):
             if abs(mat1[i][j] - mat2[i][j]) > tolerance:
                 return False
-    
+
     return True
-
-
-
-
-
-
-
-
 
 
 import json
@@ -53,8 +45,11 @@ import os
 import bpy
 import copy
 from ..main.common import *
+
+from os.path import join
+
 #
-# If you want your deletions archive.xl to be yaml not json you need to install pyyaml
+# If you want your deletions archive.xl to be yaml not json, you need to install pyyaml
 # Following worked for me
 # import pip
 # pip.main(['install', 'pyyaml'])
@@ -64,9 +59,29 @@ try:
     import yaml
     yamlavail=True
 except:
-    print('pyyaml not available')
-from mathutils import Vector, Matrix, Quaternion
+    messages = [
+        "pyyaml not available. Please start Blender as administrator."
+        "If that doesn't help, switch to Blender's scripting perspective, create a new file, and put the following code in it (no indentation):",
+        "\timport pip",
+        "\tpip.main(['install', 'pyyaml'])",
+    ]
+
+    blender_install_path = next(iter(bpy.utils.script_paths()), None)
+
+    if blender_install_path is not None:
+        blender_install_path = join(blender_install_path, "..")
+        blender_python_path =  join(blender_install_path, "python", "bin", "python.exe")
+        blender_module_path =  join(blender_install_path, "python", "lib", "site-packages")
+
+        messages.append("If that doesn't help either, run the following command from an administrator command prompt:")
+        messages.append(f"\t\"{blender_python_path}\" -m pip install pyyaml -t \"{blender_module_path}\"")
+
+    messages.apppend("You can learn more about running Blender scripts under https://tinyurl.com/cp2077blenderpython")
+    for message in messages:
+        print(message)
+
 C = bpy.context
+
 
 # function to recursively count nested collections
 def countChildNodes(collection):
@@ -82,7 +97,7 @@ def to_archive_xl(xlfilename, deletions, expectedNodes):
     for sectorPath in deletions:
         if sectorPath =='Decals' or sectorPath=='Collisions':
             continue
-        
+
         if sectorPath == projectsector:
             continue
         new_sector={}
@@ -93,20 +108,20 @@ def to_archive_xl(xlfilename, deletions, expectedNodes):
         currentNodeIndex = -1
         currentNodeComment = ''
         currentNodeType = ''
-        for empty_collection in sectorData:                           
+        for empty_collection in sectorData:
             currentNodeIndex = empty_collection['nodeDataIndex']
             currentNodeComment = empty_collection.name
-            currentNodeType = empty_collection['nodeType']    
-            if currentNodeIndex>-1:         
+            currentNodeType = empty_collection['nodeType']
+            if currentNodeIndex>-1:
                 new_sector['nodeDeletions'].append({'index':currentNodeIndex,'type':currentNodeType,'debugName':currentNodeComment})
-            # set instance variables       
+            # set instance variables
         for decal in deletions['Decals'][sectorPath]:
-            print('Deleting ', decal)     
+            print('Deleting ', decal)
             new_sector['nodeDeletions'].append({'index':decal['nodeIndex'],'type':decal['NodeType'],'debugName':decal['NodeComment']})
         for collision in deletions['Collisions'][sectorPath].keys():
             print('Deleting ',collision,' Actors ',deletions['Collisions'][sectorPath][collision])
             new_sector['nodeDeletions'].append({'index':collision,"actorDeletions":deletions['Collisions'][sectorPath][collision] ,'type':'worldCollisionNode','debugName':collision,'expectedActors':expectedNodes[sectorPath+'_NI_'+str(collision)]})
-        sectors.append(new_sector)   
+        sectors.append(new_sector)
     with open(xlfilename, "w") as filestream:
         if yamlavail:
             yaml.dump(xlfile, filestream, indent=4, sort_keys=False)
@@ -124,61 +139,61 @@ def get_pos(inst):
     pos=[0,0,0]
     if 'Position' in inst.keys():
         if 'Properties' in inst['Position'].keys():
-            pos[0] = inst['Position']['Properties']['X'] 
-            pos[1] = inst['Position']['Properties']['Y'] 
-            pos[2] = inst['Position']['Properties']['Z']           
+            pos[0] = inst['Position']['Properties']['X']
+            pos[1] = inst['Position']['Properties']['Y']
+            pos[2] = inst['Position']['Properties']['Z']
         else:
             if 'X' in inst['Position'].keys():
-                pos[0] = inst['Position']['X'] 
-                pos[1] = inst['Position']['Y'] 
-                pos[2] = inst['Position']['Z'] 
+                pos[0] = inst['Position']['X']
+                pos[1] = inst['Position']['Y']
+                pos[2] = inst['Position']['Z']
             else:
-                pos[0] = inst['Position']['x'] 
-                pos[1] = inst['Position']['y'] 
-                pos[2] = inst['Position']['z'] 
+                pos[0] = inst['Position']['x']
+                pos[1] = inst['Position']['y']
+                pos[2] = inst['Position']['z']
     elif 'position' in inst.keys():
         if 'X' in inst['position'].keys():
-                pos[0] = inst['position']['X'] 
-                pos[1] = inst['position']['Y'] 
-                pos[2] = inst['position']['Z'] 
+                pos[0] = inst['position']['X']
+                pos[1] = inst['position']['Y']
+                pos[2] = inst['position']['Z']
     elif 'translation' in inst.keys():
-        pos[0] = inst['translation']['X'] 
-        pos[1] = inst['translation']['Y'] 
-        pos[2] = inst['translation']['Z'] 
+        pos[0] = inst['translation']['X']
+        pos[1] = inst['translation']['Y']
+        pos[2] = inst['translation']['Z']
     return pos
 
 def get_rot(inst):
     rot=[0,0,0,0]
     if 'Orientation' in inst.keys():
         if 'Properties' in inst['Orientation'].keys():
-            rot[0] = inst['Orientation']['Properties']['r']  
-            rot[1] = inst['Orientation']['Properties']['i'] 
-            rot[2] = inst['Orientation']['Properties']['j'] 
-            rot[3] = inst['Orientation']['Properties']['k']            
+            rot[0] = inst['Orientation']['Properties']['r']
+            rot[1] = inst['Orientation']['Properties']['i']
+            rot[2] = inst['Orientation']['Properties']['j']
+            rot[3] = inst['Orientation']['Properties']['k']
         else:
-            rot[0] = inst['Orientation']['r'] 
-            rot[1] = inst['Orientation']['i'] 
-            rot[2] = inst['Orientation']['j'] 
-            rot[3] = inst['Orientation']['k'] 
+            rot[0] = inst['Orientation']['r']
+            rot[1] = inst['Orientation']['i']
+            rot[2] = inst['Orientation']['j']
+            rot[3] = inst['Orientation']['k']
     elif 'orientation' in inst.keys():
-            rot[0] = inst['orientation']['r'] 
-            rot[1] = inst['orientation']['i'] 
-            rot[2] = inst['orientation']['j'] 
-            rot[3] = inst['orientation']['k'] 
+            rot[0] = inst['orientation']['r']
+            rot[1] = inst['orientation']['i']
+            rot[2] = inst['orientation']['j']
+            rot[3] = inst['orientation']['k']
     elif 'Rotation' in inst.keys():
-            rot[0] = inst['Rotation']['r'] 
-            rot[1] = inst['Rotation']['i'] 
-            rot[2] = inst['Rotation']['j'] 
-            rot[3] = inst['Rotation']['k'] 
+            rot[0] = inst['Rotation']['r']
+            rot[1] = inst['Rotation']['i']
+            rot[2] = inst['Rotation']['j']
+            rot[3] = inst['Rotation']['k']
     elif 'rotation' in inst.keys():
-            rot[0] = inst['rotation']['r'] 
-            rot[1] = inst['rotation']['i'] 
-            rot[2] = inst['rotation']['j'] 
-            rot[3] = inst['rotation']['k'] 
+            rot[0] = inst['rotation']['r']
+            rot[1] = inst['rotation']['i']
+            rot[2] = inst['rotation']['j']
+            rot[3] = inst['rotation']['k']
     return rot
 
-def set_pos(inst,obj):  
-    #print(inst)  
+def set_pos(inst,obj):
+    #print(inst)
     if 'Position'in inst.keys():
         if 'Properties' in inst['Position'].keys():
             inst['Position']['Properties']['X']= float("{:.9g}".format(obj.location[0]))
@@ -202,8 +217,8 @@ def set_pos(inst,obj):
         inst['translation']['Y'] = float("{:.9g}".format(obj.location[1]))
         inst['translation']['Z'] = float("{:.9g}".format(obj.location[2]))
 
-def set_z_pos(inst,obj):  
-    #print(inst)  
+def set_z_pos(inst,obj):
+    #print(inst)
     if 'Position'in inst.keys():
         if 'Properties' in inst['Position'].keys():
             inst['Position']['Properties']['Z'] = float("{:.9g}".format(obj.location[2]))
@@ -221,9 +236,9 @@ def set_rot(inst,obj):
     if 'Orientation' in inst.keys():
         if 'Properties' in inst['Orientation'].keys():
             inst['Orientation']['Properties']['r'] = float("{:.9g}".format(obj.rotation_quaternion[0] ))
-            inst['Orientation']['Properties']['i'] = float("{:.9g}".format(obj.rotation_quaternion[1] )) 
-            inst['Orientation']['Properties']['j'] = float("{:.9g}".format(obj.rotation_quaternion[2] ))  
-            inst['Orientation']['Properties']['k'] = float("{:.9g}".format(obj.rotation_quaternion[3] ))        
+            inst['Orientation']['Properties']['i'] = float("{:.9g}".format(obj.rotation_quaternion[1] ))
+            inst['Orientation']['Properties']['j'] = float("{:.9g}".format(obj.rotation_quaternion[2] ))
+            inst['Orientation']['Properties']['k'] = float("{:.9g}".format(obj.rotation_quaternion[3] ))
         else:
             inst['Orientation']['r'] = float("{:.9g}".format(obj.rotation_quaternion[0] ))
             inst['Orientation']['i'] = float("{:.9g}".format(obj.rotation_quaternion[1] ))
@@ -231,17 +246,17 @@ def set_rot(inst,obj):
             inst['Orientation']['k'] = float("{:.9g}".format(obj.rotation_quaternion[3] ))
     elif 'Rotation' in inst.keys():
             inst['Rotation']['r'] = float("{:.9g}".format(obj.rotation_quaternion[0] ))
-            inst['Rotation']['i'] = float("{:.9g}".format(obj.rotation_quaternion[1] )) 
+            inst['Rotation']['i'] = float("{:.9g}".format(obj.rotation_quaternion[1] ))
             inst['Rotation']['j'] = float("{:.9g}".format(obj.rotation_quaternion[2] ))
             inst['Rotation']['k'] = float("{:.9g}".format(obj.rotation_quaternion[3] ))
     elif 'rotation' in inst.keys():
             inst['rotation']['r'] = float("{:.9g}".format(obj.rotation_quaternion[0] ))
-            inst['rotation']['i'] = float("{:.9g}".format(obj.rotation_quaternion[1] )) 
+            inst['rotation']['i'] = float("{:.9g}".format(obj.rotation_quaternion[1] ))
             inst['rotation']['j'] = float("{:.9g}".format(obj.rotation_quaternion[2] ))
             inst['rotation']['k'] = float("{:.9g}".format(obj.rotation_quaternion[3] ))
     elif 'orientation' in inst.keys():
             inst['orientation']['r'] = float("{:.9g}".format(obj.rotation_quaternion[0] ))
-            inst['orientation']['i'] = float("{:.9g}".format(obj.rotation_quaternion[1] )) 
+            inst['orientation']['i'] = float("{:.9g}".format(obj.rotation_quaternion[1] ))
             inst['orientation']['j'] = float("{:.9g}".format(obj.rotation_quaternion[2] ))
             inst['orientation']['k'] = float("{:.9g}".format(obj.rotation_quaternion[3] ))
 
@@ -275,7 +290,7 @@ def find_col(NodeIndex,Inst_idx,Sector_coll):
         return None
     elif len(col)==1:
         return col[0]
-    else: 
+    else:
         inst=[x for x in col if x['instance_idx']==Inst_idx]
         if len(inst)>0:
             return inst[0]
@@ -288,7 +303,7 @@ def find_wIDMN_col(NodeIndex,tl_inst_idx, sub_inst_idx,Sector_coll):
         return None
     elif len(col)==1:
         return col[0]
-    else: 
+    else:
         inst=[x for x in col if x['tl_instance_idx']==tl_inst_idx and x['sub_instance_idx']==sub_inst_idx]
         if len(inst)>0:
             return inst[0]
@@ -301,7 +316,7 @@ def find_decal(NodeIndex,Inst_idx,Sector_coll):
         return None
     elif len(col)==1:
         return col[0]
-    else: 
+    else:
         inst=[x for x in col if x['instance_idx']==Inst_idx]
         if len(inst)>0:
             return inst[0]
@@ -319,7 +334,7 @@ def createNodeData(t, col, nodeIndex, obj, ID):
     new['Bounds']['Min']={'$type': 'Vector4','X':float("{:.9g}".format(obj.location[0])),'Y':float("{:.9g}".format(obj.location[1])),'Z':float("{:.9g}".format(obj.location[2]))}
     new['Orientation']={'$type': 'Quaternion','r':float("{:.9g}".format(obj.rotation_quaternion[0])),'i':float("{:.9g}".format(obj.rotation_quaternion[1])),'j':float("{:.9g}".format(obj.rotation_quaternion[2])),'k':float("{:.9g}".format(obj.rotation_quaternion[3]))}
     new['Scale']= {'$type': 'Vector3', 'X':  float("{:.9g}".format(obj.scale[0])), 'Y':  float("{:.9g}".format(obj.scale[1])), 'Z':  float("{:.9g}".format(obj.scale[2]))}
-    
+
 
 
 
@@ -345,8 +360,8 @@ def exportSectors( filename):
     # Open the blank template streaming sector
     resourcepath=get_resources_dir()
 
-    with open(os.path.join(resourcepath,'empty.streamingsector.json'),'r') as f: 
-        template_json=json.load(f) 
+    with open(os.path.join(resourcepath,'empty.streamingsector.json'),'r') as f:
+        template_json=json.load(f)
     template_nodes = template_json["Data"]["RootChunk"]["nodes"]
     template_nodeData = template_json['Data']['RootChunk']['nodeData']['Data']
     ID=0
@@ -354,28 +369,28 @@ def exportSectors( filename):
     # If anythings tagged from last time you exported, clear it
     for col in bpy.data.collections:
         col['exported']=False
-    
+
     for obj in bpy.data.objects:
         if 'exported' in obj.keys():
             obj['exported']=False
     coll_scene = bpy.context.scene.collection
     Inst_bufferIDs={}
-    # .  .  __ .    .. .  .  __      __  ___ .  .  ___  ___ 
-    # |\/| /  \ \  / | |\ | / _`    /__`  |  |  | |__  |__  
-    # |  | \__/  \/  | | \| \__/    .__/  |  \__/ |    |    
+    # .  .  __ .    .. .  .  __      __  ___ .  .  ___  ___
+    # |\/| /  \ \  / | |\ | / _`    /__`  |  |  | |__  |__
+    # |  | \__/  \/  | | \| \__/    .__/  |  \__/ |    |
     #
     deletions = {}
     deletions['Decals']={}
     deletions['Collisions']={}
-    expectedNodes = {}                                                      
+    expectedNodes = {}
     for filepath in jsons:
         projectjson = os.path.join( projpath , os.path.splitext(os.path.basename(filename))[0]+'.streamingsector.json')
         print(projectjson)
         print(filepath)
         if filepath==os.path.join(projpath,projectjson):
             continue
-        with open(filepath,'r') as f: 
-            j=json.load(f) 
+        with open(filepath,'r') as f:
+            j=json.load(f)
         nodes = j["Data"]["RootChunk"]["nodes"]
         t=j['Data']['RootChunk']['nodeData']['Data']
         # add nodeDataIndex props to all the nodes in t
@@ -389,7 +404,7 @@ def exportSectors( filename):
         if sectorName not in bpy.data.collections.keys():
             continue
         print('Updating sector ',sectorName)
-        Sector_coll=bpy.data.collections.get(sectorName)    
+        Sector_coll=bpy.data.collections.get(sectorName)
         expectedNodes[sectorName] = countChildNodes(Sector_coll)
         if 'filepath' not in Sector_coll.keys():
             Sector_coll['filepath']=filepath
@@ -401,17 +416,17 @@ def exportSectors( filename):
         for i,e in enumerate(nodes):
             data = e['Data']
             type = data['$type']
-            match type:       
+            match type:
                 case 'worldInstancedMeshNode' :
                     wIMNs+=1
                     #print(wIMNs)
-                    meshname = data['mesh']['DepotPath']['$value'].replace('\\', os.sep) 
+                    meshname = data['mesh']['DepotPath']['$value'].replace('\\', os.sep)
                     #if 'chopstick' in meshname:
                     #    print('worldInstancedMeshNode - ',meshname)
                     if not checkexists(meshname, Masters):
                         print(meshname, ' not found in masters')
                         continue
-                    
+
                     num=data['worldTransformsBuffer']['numElements']
                     start=data['worldTransformsBuffer']['startIndex']
                     if(meshname != 0):
@@ -419,7 +434,7 @@ def exportSectors( filename):
                             bufferID=0
                             if 'Data' in data['worldTransformsBuffer']['sharedDataBuffer'].keys():
                                     inst_trans=data['worldTransformsBuffer']['sharedDataBuffer']['Data']['buffer']['Data']['Transforms'][idx]
-                                        
+
                             elif 'HandleRefId' in data['worldTransformsBuffer']['sharedDataBuffer'].keys():
                                 bufferID = int(data['worldTransformsBuffer']['sharedDataBuffer']['HandleRefId'])
                                 ref=e
@@ -430,7 +445,7 @@ def exportSectors( filename):
                         # store the bufferID for when we add new stuff.
                             if Sector_additions_coll:
                                 Sector_additions_coll['Inst_bufferID']=bufferID
-                            obj_col=find_col(i,idx,Sector_coll)    
+                            obj_col=find_col(i,idx,Sector_coll)
                             if obj_col and inst_trans:
                                 if len(obj_col.objects)>0:
                                     obj=obj_col.objects[0]
@@ -445,7 +460,7 @@ def exportSectors( filename):
                                 else:
                                     if obj_col:
                                         deletions[sectorName].append(obj_col)
-                                    
+
                 case 'worldStaticDecalNode':
                     #print('worldStaticDecalNode')
                     instances = [(x,y) for y,x in enumerate(t) if x['NodeIndex'] == i]
@@ -461,9 +476,9 @@ def exportSectors( filename):
                                 ID+=1
                         else:
                             deletions['Decals'][sectorName].append({'nodeIndex':instNid,'NodeComment' :'DELETED Decal nid:'+str(inst['NodeIndex'])+' ndid:'+str(instNid), 'NodeType' : 'worldStaticDecalNode'})
-                        
 
-                case   'worldStaticMeshNode' | 'worldBuildingProxyMeshNode' | 'worldGenericProxyMeshNode'| 'worldTerrainProxyMeshNode': 
+
+                case   'worldStaticMeshNode' | 'worldBuildingProxyMeshNode' | 'worldGenericProxyMeshNode'| 'worldTerrainProxyMeshNode':
                     if isinstance(e, dict) and 'mesh' in data.keys():
                         meshname = data['mesh']['DepotPath']['$value'].replace('\\', os.sep)
                         #print('Mesh name is - ',meshname, e['HandleId'])
@@ -480,7 +495,7 @@ def exportSectors( filename):
                                             deletions[sectorName].append(obj_col)
                                             new_ni=len(template_nodes)
                                             template_nodes.append(copy.deepcopy(nodes[obj_col['nodeIndex']]))
-                                            
+
                                             createNodeData(template_nodeData, obj_col, new_ni, obj,ID)
                                             ID+=1
                                     else:
@@ -489,8 +504,8 @@ def exportSectors( filename):
 
                 case  'worldEntityNode':
                     if isinstance(e, dict) and 'entityTemplate' in data.keys():
-                        entname = data['entityTemplate']['DepotPath']['$value'].replace('\\', os.sep) 
-                        
+                        entname = data['entityTemplate']['DepotPath']['$value'].replace('\\', os.sep)
+
                         if(entname != 0):
                             instances = [x for x in t if x['NodeIndex'] == i]
                             for idx,inst in enumerate(instances):
@@ -505,16 +520,16 @@ def exportSectors( filename):
                                             deletions[sectorName].append(obj_col)
                                             new_ni=len(template_nodes)
                                             template_nodes.append(copy.deepcopy(nodes[obj_col['nodeIndex']]))
-                                            
+
                                             createNodeData(template_nodeData, obj_col, new_ni, obj,ID)
                                             ID+=1
-                                        
+
                                 else:
                                     if obj_col:
-                                        deletions[sectorName].append(obj_col)                                   
-                                        
-                                        
-                                        
+                                        deletions[sectorName].append(obj_col)
+
+
+
                 case 'worldInstancedDestructibleMeshNode':
                     #print('worldInstancedDestructibleMeshNode',i)
                     if isinstance(e, dict) and 'mesh' in data.keys():
@@ -530,22 +545,22 @@ def exportSectors( filename):
                                 if 'Data' in data['cookedInstanceTransforms']['sharedDataBuffer'].keys():
                                     basic_trans=data['cookedInstanceTransforms']['sharedDataBuffer']['Data']['buffer']['Data']['Transforms'][idx]
 
-                                # Transforms are in a shared buffer in another node, so get the reference and find the transform data                    
+                                # Transforms are in a shared buffer in another node, so get the reference and find the transform data
                                 elif 'HandleRefId' in data['cookedInstanceTransforms']['sharedDataBuffer'].keys():
                                     bufferID = int(data['cookedInstanceTransforms']['sharedDataBuffer']['HandleRefId'])
                                     ref=e
                                     for n in nodes:
                                         if n['HandleId']==str(bufferID-1):
                                             ref=n
-                                    basic_trans = ref['Data']['cookedInstanceTransforms']['sharedDataBuffer']['Data']['buffer']['Data']['Transforms'][idx]   
-                                    #print(basic_trans)                  
+                                    basic_trans = ref['Data']['cookedInstanceTransforms']['sharedDataBuffer']['Data']['buffer']['Data']['Transforms'][idx]
+                                    #print(basic_trans)
                                 else :
                                     print(e)
                                 # store the bufferID for when we add new stuff.
                                 if Sector_additions_coll:
                                     Sector_additions_coll['Dest_bufferID']=bufferID
                                     #print('Setting Dest_bufferID to ',bufferID)
-                                
+
                                 # the Transforms are stored as 2 parts, a basic transform applied to all the instances and individual ones per instance
                                 # lets get the basic one so we can calculate the instance one.
                                 basic_pos =Vector(get_pos(basic_trans))
@@ -553,13 +568,13 @@ def exportSectors( filename):
                                 basic_scale =Vector((1,1,1))
                                 basic_matr=Matrix.LocRotScale(basic_pos,basic_rot,basic_scale)
                                 basic_matr_inv=basic_matr.inverted()
-                                
+
                                 # Never modify the basic on as other nodes may be referencing it. (its normally 0,0,0 anyway)
                                 inst_pos =Vector(get_pos(inst))
                                 inst_rot =Quaternion(get_rot(inst))
                                 inst_scale =Vector((1,1,1))
                                 inst_m=Matrix.LocRotScale(inst_pos,inst_rot,inst_scale)
-                                
+
 
                                 obj_col=find_wIDMN_col(i,tlidx,idx,Sector_coll)
                                 if obj_col:
@@ -570,15 +585,15 @@ def exportSectors( filename):
                                             deletions[sectorName].append(obj_col)
                                             new_ni=len(template_nodes)
                                             template_nodes.append(copy.deepcopy(nodes[obj_col['nodeIndex']]))
-                                            
+
                                             createNodeData(template_nodeData, obj_col, new_ni, obj,ID)
                                             ID+=1
-                                        
+
                                     else:
                                         if obj_col:
                                             deletions[sectorName].append(obj_col)
                 case 'worldCollisionNode':
-                    # need to process the sector_coll sectors and look for deleted collision bodies - this is almost identical to import, refactor them to have it in one place                    
+                    # need to process the sector_coll sectors and look for deleted collision bodies - this is almost identical to import, refactor them to have it in one place
                     if sector_Collisions in coll_scene.children.keys():
                         print('collisions')
                         sector_Collisions_coll=bpy.data.collections.get(sector_Collisions)
@@ -586,19 +601,19 @@ def exportSectors( filename):
                         Actors=e['Data']['compiledData']['Data']['Actors']
                         expectedNodes[sectorName+'_NI_'+str(inst['nodeDataIndex'])] = len(Actors)
                         for idx,act in enumerate(Actors):
-                            x=act['Position']['x']['Bits']/131072  
+                            x=act['Position']['x']['Bits']/131072
                             y=act['Position']['y']['Bits']/131072
                             z=act['Position']['z']['Bits']/131072
                             arot=get_rot(act)
                             for s,shape in enumerate(act['Shapes']):
-                                collname='NodeDataIndex_'+str(inst['nodeDataIndex'])+'_Actor_'+str(idx)+'_Shape_'+str(s)    
+                                collname='NodeDataIndex_'+str(inst['nodeDataIndex'])+'_Actor_'+str(idx)+'_Shape_'+str(s)
                                 if collname in sector_Collisions_coll.objects:
                                     print('found')
                                     crash= sector_Collisions_coll.objects[collname]
                                     if are_matrices_equal(crash.matrix_world,Matrix(crash['matrix'])):
                                         print('collision moved - cant process this yet')
                                 else:
-                                    if shape['ShapeType']=='Box' or shape['ShapeType']=='Capsule':     
+                                    if shape['ShapeType']=='Box' or shape['ShapeType']=='Capsule':
                                         if inst['nodeDataIndex'] in deletions['Collisions'][sectorName].keys():
                                             deletions['Collisions'][sectorName][inst['nodeDataIndex']].append(str(idx))
                                         else:
@@ -609,12 +624,12 @@ def exportSectors( filename):
 
 
         print(wIMNs)
-                                        
-    #       __   __          __      __  ___       ___  ___ 
-    #  /\  |  \ |  \ | |\ | / _`    /__`  |  |  | |__  |__  
-    # /~~\ |__/ |__/ | | \| \__>    .__/  |  \__/ |    |    
-    #                       
-        instances_to_copy=[]                                                               
+
+    #       __   __          __      __  ___       ___  ___
+    #  /\  |  \ |  \ | |\ | / _`    /__`  |  |  | |__  |__
+    # /~~\ |__/ |__/ | | \| \__>    .__/  |  \__/ |    |
+    #
+        instances_to_copy=[]
         destructibles_to_copy=[]
         ID=666
         for node in t:
@@ -634,7 +649,7 @@ def exportSectors( filename):
                             obj=col.objects[0]
                             createNodeData(t, col, new_ni, obj,ID)
                             ID+=1
-                                        
+
                         case 'worldInstancedMeshNode':
                             obj=col.objects[0]
                             nodeIndex=col['nodeIndex']
@@ -652,14 +667,14 @@ def exportSectors( filename):
                             set_rot(trans,obj)
                             set_scale(trans,obj)
                             print(trans)
-                            
+
                             if(meshname != 0):
                                 idx =start+num
                                 if 'Data' in base['worldTransformsBuffer']['sharedDataBuffer'].keys():
                                     #if the transforms are in the nodeData itself we can just add to the end of it - WRONG. it may be the shared one everything else is pointing to.
                                     base['worldTransformsBuffer']['sharedDataBuffer']['Data']['buffer']['Data']
                                     bufferID = nodeIndex
-                                            
+
                                 elif 'HandleRefId' in base['worldTransformsBuffer']['sharedDataBuffer'].keys():
                                     # transforms are in a shared buffer in another nodeData need to insert then update all the references to the shared buffer
                                     bufferID = int(base['worldTransformsBuffer']['sharedDataBuffer']['HandleRefId'])
@@ -695,35 +710,35 @@ def exportSectors( filename):
                             #Need to build the transform to go in the sharedDataBuffer
                             trans= {"$type": "Transform","orientation": {"$type": "Quaternion","i": 0.0, "j": 0.0,"k": 0.0, "r": 1.0 },
                             "position": {"$type": "Vector4","W": 0,  "X": 0.0,"Y": 0.0, "Z": 0.0 }}
-                            
-                            
+
+
                             instances = [x for x in t if x['NodeIndex'] == nodeIndex]
                             inst=instances[0]
-                            
+
                             inst_pos =Vector(get_pos(inst))
                             inst_rot =Quaternion(get_rot(inst))
                             inst_scale =Vector((1,1,1))
                             inst_m=Matrix.LocRotScale(inst_pos,inst_rot,inst_scale)
                             inst_m_inv=inst_m.inverted()
-                            inst_trans_m = inst_m_inv @ obj.matrix_local 
+                            inst_trans_m = inst_m_inv @ obj.matrix_local
                             pos=inst_trans_m.translation
-                            trans['position']['X']=pos[0] 
-                            trans['position']['Y']=pos[1] 
-                            trans['position']['Z']=pos[2] 
+                            trans['position']['X']=pos[0]
+                            trans['position']['Y']=pos[1]
+                            trans['position']['Z']=pos[2]
                             quat=inst_trans_m.to_quaternion()
                             trans['orientation']['r']=-quat[0]
                             trans['orientation']['i']=-quat[1]
                             trans['orientation']['j']=-quat[2]
                             trans['orientation']['k']=-quat[3]
                             print(trans)
-                            
+
                             if(meshname != 0):
                                 idx =start+num
                                 if 'Data' in base['cookedInstanceTransforms']['sharedDataBuffer'].keys():
                                     #if the transforms are in the nodeData itself we can just add to the end of it - WRONG
                                     wtbbuffer=base['cookedInstanceTransforms']['sharedDataBuffer']['Data']['buffer']['Data']
                                     bufferID = nodeIndex
-                                            
+
                                 elif 'HandleRefId' in base['cookedInstanceTransforms']['sharedDataBuffer'].keys():
                                     # transforms are in a shared buffer in another nodeData need to insert then update all the references to the shared buffer
                                     bufferID = int(base['cookedInstanceTransforms']['sharedDataBuffer']['HandleRefId'])
@@ -746,15 +761,15 @@ def exportSectors( filename):
                                             if citb['startIndex']>start:
                                                 citb['startIndex']=citb['startIndex']+1
 
-    #            
-    #     ___       __    ___ __  _                     ____                              __  __                 _____           __                 
+    #
+    #     ___       __    ___ __  _                     ____                              __  __                 _____           __
     #    /   | ____/ /___/ (_) /_(_)___  ____  _____   / __/________  ____ ___     ____  / /_/ /_  ___  _____   / ___/___  _____/ /_____  __________
     #   / /| |/ __  / __  / / __/ / __ \/ __ \/ ___/  / /_/ ___/ __ \/ __ `__ \   / __ \/ __/ __ \/ _ \/ ___/   \__ \/ _ \/ ___/ __/ __ \/ ___/ ___/
-    #  / ___ / /_/ / /_/ / / /_/ / /_/ / / / (__  )  / __/ /  / /_/ / / / / / /  / /_/ / /_/ / / /  __/ /      ___/ /  __/ /__/ /_/ /_/ / /  (__  ) 
-    # /_/  |_\__,_/\__,_/_/\__/_/\____/_/ /_/____/  /_/ /_/   \____/_/ /_/ /_/   \____/\__/_/ /_/\___/_/      /____/\___/\___/\__/\____/_/  /____/  
-    #                                                                                                                                              
-    #  Nodes from other sectors that have been imported           
-                            
+    #  / ___ / /_/ / /_/ / / /_/ / /_/ / / / (__  )  / __/ /  / /_/ / / / / / /  / /_/ / /_/ / / /  __/ /      ___/ /  __/ /__/ /_/ /_/ / /  (__  )
+    # /_/  |_\__,_/\__,_/_/\__/_/\____/_/ /_/____/  /_/ /_/   \____/_/ /_/ /_/   \____/\__/_/ /_/\___/_/      /____/\___/\___/\__/\____/_/  /____/
+    #
+    #  Nodes from other sectors that have been imported
+
                 elif 'nodeIndex' in col.keys() and col['sectorName'] in bpy.data.collections.keys() and len(col.objects)>0:
                     match col['nodeType']:
                         case 'worldStaticMeshNode' | 'worldBuildingProxyMeshNode' | 'worldGenericProxyMeshNode' | 'worldTerrainProxyMeshNode':
@@ -763,8 +778,8 @@ def exportSectors( filename):
                             source_sect_coll=bpy.data.collections.get(source_sector)
                             source_sect_json_path=source_sect_coll['filepath']
                             print(source_sect_json_path)
-                            with open(source_sect_json_path,'r') as f: 
-                                source_sect_json=json.load(f) 
+                            with open(source_sect_json_path,'r') as f:
+                                source_sect_json=json.load(f)
                             source_nodes = source_sect_json["Data"]["RootChunk"]["nodes"]
                             print(len(source_nodes),col['nodeIndex'])
                             print(source_nodes[col['nodeIndex']])
@@ -774,16 +789,16 @@ def exportSectors( filename):
                             obj=col.objects[0]
                             createNodeData(t, col, new_Index, obj,ID)
                             ID+=1
-                        
+
                         # make a list of all the instances, we'll copy the main node once and instance them
                         case 'worldInstancedMeshNode':
                             if [col['nodeIndex'],col['sectorName']] not in instances_to_copy:
                                 instances_to_copy.append([col['nodeIndex'],col['sectorName']])
-                        
+
                         case 'worldInstancedDestructibleMeshNode':
                             if [col['nodeIndex'],col['sectorName']] not in destructibles_to_copy:
                                 destructibles_to_copy.append([col['nodeIndex'],col['sectorName']])
-        
+
         print(instances_to_copy)
         print(destructibles_to_copy)
 
@@ -793,8 +808,8 @@ def exportSectors( filename):
             source_sect_coll=bpy.data.collections.get(source_sector)
             source_sect_json_path=source_sect_coll['filepath']
             print(source_sect_json_path)
-            with open(source_sect_json_path,'r') as f: 
-                source_sect_json=json.load(f) 
+            with open(source_sect_json_path,'r') as f:
+                source_sect_json=json.load(f)
             source_nodes = source_sect_json["Data"]["RootChunk"]["nodes"]
             nodes.append(copy.deepcopy(source_nodes[ni]))
             new_Index=len(nodes)-1
@@ -829,12 +844,12 @@ def exportSectors( filename):
             else:
                 # the sector has no other instanced meshes already in it, so no wtb to point to. Need to create one in the wtb data
                 # have absolutely no idea what the flags is here.
-                newbuf={ "BufferId": str(new_Index+1), "Flags": 4063232,"Type": "WolvenKit.RED4.Archive.Buffer.WorldTransformsBuffer, WolvenKit.RED4.Archive, Version=1.61.0.0, Culture=neutral, PublicKeyToken=null", "Data": { "Transforms": []} } 
+                newbuf={ "BufferId": str(new_Index+1), "Flags": 4063232,"Type": "WolvenKit.RED4.Archive.Buffer.WorldTransformsBuffer, WolvenKit.RED4.Archive, Version=1.61.0.0, Culture=neutral, PublicKeyToken=null", "Data": { "Transforms": []} }
                 new_node['Data']['worldTransformsBuffer']['sharedDataBuffer']['Data']={ "Data": {"$type": "worldSharedDataBuffer", "buffer": newbuf}}
 
                 bufferID = new_node['Data']['worldTransformsBuffer']['sharedDataBuffer']['Data']['Data']['BufferID']
                 Sector_additions_coll['Inst_bufferID']=bufferID
-            
+
             print('bufferID - ',bufferID)
             ref=new_nd_node
             for n in nodes:
@@ -842,7 +857,7 @@ def exportSectors( filename):
                     ref=n
             wtbbuffer=ref['Data']['worldTransformsBuffer']['sharedDataBuffer']['Data']['buffer']['Data']
             new_node['Data']['worldTransformsBuffer']['startIndex']=len(wtbbuffer['Transforms'])
-            
+
             new_node['HandleId']=str(int(nodes[new_Index-1]['HandleId'])+1)
             inst_col=[]
             for col in Sector_additions_coll.children:
@@ -863,15 +878,15 @@ def exportSectors( filename):
                 print('inserting at ',idx)
                 wtbbuffer['Transforms'].insert(idx,trans)
                 print('After = ',len(wtbbuffer['Transforms']))
-                
+
         for node in destructibles_to_copy:
             ni=node[0]
             source_sector=node[1]
             source_sect_coll=bpy.data.collections.get(source_sector)
             source_sect_json_path=source_sect_coll['filepath']
             print(source_sect_json_path)
-            with open(source_sect_json_path,'r') as f: 
-                source_sect_json=json.load(f) 
+            with open(source_sect_json_path,'r') as f:
+                source_sect_json=json.load(f)
             source_nodes = source_sect_json["Data"]["RootChunk"]["nodes"]
             nodes.append(copy.deepcopy(source_nodes[ni]))
             new_Index=len(nodes)-1
@@ -902,7 +917,7 @@ def exportSectors( filename):
             new_nd_node['Scale']['X']=1
             new_nd_node['Scale']['Y']=1
             new_nd_node['Scale']['Z']=1
-            
+
             maxHid=new_node['HandleId']
             print("New nodeData Node: ")
             print(new_nd_node)
@@ -911,7 +926,7 @@ def exportSectors( filename):
             # Hopefully we can add the instances to the end of the buffer we saved earlier.
             #print("Sector_additions_coll['Dest_bufferID'] = ",Sector_additions_coll['Dest_bufferID'])
             if 'Dest_bufferID' in Sector_additions_coll.keys() and int(Sector_additions_coll['Dest_bufferID'])>-1:
-                
+
                 print('  Found a shared buffer ',Sector_additions_coll['Dest_bufferID'])
                 new_node['Data']['cookedInstanceTransforms']['sharedDataBuffer']['HandleRefId']=str(Sector_additions_coll['Dest_bufferID'])
                 bufferID = Sector_additions_coll['Dest_bufferID']
@@ -923,7 +938,7 @@ def exportSectors( filename):
                 # the sector has no other instanced meshes already in it, so no wtb to point to. Need to create one in the wtb data
                 # have absolutely no idea what the flags is here.
                 print('No shared buffer found.')
-                newbuf={ "BufferId": str(new_Index+1), "Flags": 4063232,"Type": "WolvenKit.RED4.Archive.Buffer.WorldTransformsBuffer, WolvenKit.RED4.Archive, Version=1.61.0.0, Culture=neutral, PublicKeyToken=null", "Data": { "Transforms": []} } 
+                newbuf={ "BufferId": str(new_Index+1), "Flags": 4063232,"Type": "WolvenKit.RED4.Archive.Buffer.WorldTransformsBuffer, WolvenKit.RED4.Archive, Version=1.61.0.0, Culture=neutral, PublicKeyToken=null", "Data": { "Transforms": []} }
                 new_node['Data']['cookedInstanceTransforms']['sharedDataBuffer']['Data']= { "Data": {"$type": "worldSharedDataBuffer", "buffer": newbuf}}
                 print(new_node)
                 new_node['Data']['cookedInstanceTransforms']['sharedDataBuffer']['HandleId']=maxHid+1
@@ -932,7 +947,7 @@ def exportSectors( filename):
                 bufferID = new_node['Data']['cookedInstanceTransforms']['sharedDataBuffer']['HandleId']
                 print(new_node['Data']['cookedInstanceTransforms'])
                 Sector_additions_coll['Dest_bufferID']=bufferID
-            
+
             print('bufferID - ',bufferID)
             ref=new_node
             for n in nodes:
@@ -943,7 +958,7 @@ def exportSectors( filename):
             new_node['Data']['cookedInstanceTransforms']['startIndex']=len(wtbbuffer['Transforms'])
             if 'HandleId' in new_node['Data']['filterData'].keys():
                     new_node['Data']['filterData']['HandleId']=str(int(maxHid)+1)
-            
+
             inst_col=[]
             for col in Sector_additions_coll.children:
                 if col['nodeIndex']==ni and col['sectorName']==source_sector:
@@ -962,12 +977,12 @@ def exportSectors( filename):
                 print('Before = ',len(wtbbuffer['Transforms']))
                 print('inserting at ',idx)
                 wtbbuffer['Transforms'].insert(idx,trans)
-                print('After = ',len(wtbbuffer['Transforms']))            
-    
-   
+                print('After = ',len(wtbbuffer['Transforms']))
 
 
-                
+
+
+
     # Export the modified json
     sectpathout=os.path.join(projpath,os.path.splitext(os.path.basename(filename))[0]+'.streamingsector.json')
     with open(sectpathout, 'w') as outfile:
@@ -976,4 +991,4 @@ def exportSectors( filename):
     xlpathout=os.path.join(xloutpath,os.path.splitext(os.path.basename(filename))[0]+'.archive.xl')
     to_archive_xl(xlpathout, deletions, expectedNodes)
     print('Finished exporting sectors from ',os.path.splitext(os.path.basename(filename))[0])
-        
+

--- a/i_scene_cp77_gltf/importers/attribute_import.py
+++ b/i_scene_cp77_gltf/importers/attribute_import.py
@@ -4,37 +4,57 @@ from io_scene_gltf2.io.imp.gltf2_io_binary import BinaryData
 from io_scene_gltf2.blender.imp.gltf2_blender_mesh import points_edges_tris
 from io_scene_gltf2.blender.imp.gltf2_blender_mesh import squish
 
+def rename_color_attribute(mesh, name_before, name_after):
+    if mesh.color_attributes is None:
+        return
+    col_layer = mesh.color_attributes.get(name_before)
+    if col_layer is not None:
+        col_layer.name = name_after
+
 def manage_garment_support(existingMeshes, gltf_importer_data):
     gltf_importer = gltf_importer_data
     curMeshCount = 0
     for name in bpy.data.meshes.keys():
-        if name not in existingMeshes and "Icosphere" not in name:
-            mesh = bpy.data.meshes[name]
-            for prim in gltf_importer.data.meshes[curMeshCount].primitives:
-                if '_GARMENTSUPPORTWEIGHT' in prim.attributes:
-                    indices = get_indices(gltf_importer, prim)
-                    mesh.color_attributes.remove(mesh.color_attributes['_GARMENTSUPPORTWEIGHT'])
-                    add_vertex_color_attribute('_GARMENTSUPPORTWEIGHT', '_GARMENTSUPPORTWEIGHT', gltf_importer, mesh, prim, indices)
-                    mesh.color_attributes.remove(mesh.color_attributes['_GARMENTSUPPORTCAP'])                    
-                    add_vertex_color_attribute('_GARMENTSUPPORTCAP', '_GARMENTSUPPORTCAP', gltf_importer, mesh, prim, indices)
-                    
-                mesh.color_attributes.render_color_index = 0
-            curMeshCount = curMeshCount + 1
+        if name in existingMeshes or "Icosphere" in name:
+            continue
+        mesh = bpy.data.meshes[name]
+
+        # fix attributes. also fix exceptions.
+        for prim in gltf_importer.data.meshes[curMeshCount].primitives:
+            if not ('_GARMENTSUPPORTWEIGHT' in prim.attributes or '_GARMENTSUPPORTCAP' in prim.attributes):
+                continue
+            indices = get_indices(gltf_importer, prim)
+            if '_GARMENTSUPPORTWEIGHT' in prim.attributes:
+                mesh.color_attributes.remove(mesh.color_attributes['_GARMENTSUPPORTWEIGHT'])
+                add_vertex_color_attribute('_GARMENTSUPPORTWEIGHT', '_GARMENTSUPPORTWEIGHT', gltf_importer, mesh, prim, indices)
+            if '_GARMENTSUPPORTCAP' in prim.attributes:
+                mesh.color_attributes.remove(mesh.color_attributes['_GARMENTSUPPORTCAP'])
+                add_vertex_color_attribute('_GARMENTSUPPORTCAP', '_GARMENTSUPPORTCAP', gltf_importer, mesh, prim, indices)
+            mesh.color_attributes.render_color_index = 0
+
+        # rename attributes
+        # TODO (manavortex): Presto said that they needed an underscore to be exported. However, I used them without underscore,
+        # and they worked fine - I could see GarmentSupportCap becoming active in-game
+        rename_color_attribute(mesh, "_GARMENTSUPPORTCAP", "GarmentSupportCap")
+        rename_color_attribute(mesh, "_GARMENTSUPPORTWEIGHT", "GarmentSupportWeight")
+
+        curMeshCount = curMeshCount + 1
+
 
 def add_vertex_color_attribute(accessor_name, attribute_name, gltf_importer_data, mesh, prim, indices):
     gltf_importer = gltf_importer_data
-    if accessor_name in prim.attributes:
-        cols = BinaryData.decode_accessor(gltf_importer, prim.attributes[accessor_name], cache=True)
-        cols = cols[indices]
-        if cols.shape[1] == 3:
-            cols = colors_rgb_to_rgba(cols)
-        layer = mesh.vertex_colors.new(name=attribute_name)
+    if not accessor_name in prim.attributes:
+        return
+    cols = BinaryData.decode_accessor(gltf_importer, prim.attributes[accessor_name], cache=True)
+    cols = cols[indices]
+    if cols.shape[1] == 3:
+        cols = colors_rgb_to_rgba(cols)
+    layer = mesh.vertex_colors.new(name=attribute_name)
 
-        if layer is None:
-            print("WARNING: Vertex colors are ignored because the maximum number of vertex color layers has been "
-                "reached.")
-        else:
-            mesh.color_attributes[layer.name].data.foreach_set('color', squish(cols))
+    if layer is None:
+        print("WARNING: Vertex colors are ignored (maximum number of vertex color layers has been reached)")
+    else:
+        mesh.color_attributes[layer.name].data.foreach_set('color', squish(cols))
 
 def get_indices(gltf_importer_data, prim):
     gltf_importer = gltf_importer_data

--- a/i_scene_cp77_gltf/importers/attribute_import.py
+++ b/i_scene_cp77_gltf/importers/attribute_import.py
@@ -33,10 +33,8 @@ def manage_garment_support(existingMeshes, gltf_importer_data):
             mesh.color_attributes.render_color_index = 0
 
         # rename attributes
-        # TODO (manavortex): Presto said that they needed an underscore to be exported. However, I used them without underscore,
-        # and they worked fine - I could see GarmentSupportCap becoming active in-game
-        rename_color_attribute(mesh, "_GARMENTSUPPORTCAP", "GarmentSupportCap")
-        rename_color_attribute(mesh, "_GARMENTSUPPORTWEIGHT", "GarmentSupportWeight")
+        rename_color_attribute(mesh, "_GARMENTSUPPORTCAP", "_GarmentSupportCap")
+        rename_color_attribute(mesh, "_GARMENTSUPPORTWEIGHT", "_GarmentSupportWeight")
 
         curMeshCount = curMeshCount + 1
 

--- a/i_scene_cp77_gltf/importers/import_from_external.py
+++ b/i_scene_cp77_gltf/importers/import_from_external.py
@@ -1,0 +1,111 @@
+import bpy
+
+# Clean up external objects (e.g. from Sketchfab). This function will flatten the hierarchy and rename the objects
+# in a more Cyberpunk-specific way.
+
+valid_object_types = [
+    'MESH',
+    'ARMATURE'
+]
+
+def apply_object_transformations(ob):
+    try:
+        mb = ob.matrix_basis
+        if hasattr(ob.data, "transform"):
+            ob.data.transform(mb)
+        for c in ob.children:
+            c.matrix_local = mb @ c.matrix_local
+
+        ob.matrix_basis.identity()
+    except Exception as e:
+        print("Exception when trying to apply transformations: " + str(e))
+
+def cleanup_names_and_apply_transformations(old_object_names):
+    mesh_index = 0
+    new_object_names = []
+    for object_name in old_object_names:
+        object =  bpy.data.objects[object_name]
+        if object == None:
+            continue
+        apply_object_transformations(object)
+        if object.type == 'ARMATURE':
+            object.name = "Armature"
+        if object.type == 'MESH':
+            object.name = "submesh_{}_LOD_1".format(str(mesh_index).zfill(2))
+            mesh_index += 1
+
+        new_object_names.append(object.name)
+
+    return new_object_names
+
+# traverse the object's parent hierarchy all the way up, and collect all empties
+def get_parented_empties(current_obj):
+    empties = []
+    if current_obj == None:
+        return empties
+
+    if current_obj.type == 'EMPTY':
+        empties.append(current_obj)
+
+    if current_obj.parent == None:
+        return empties
+
+    empties.extend(get_parented_empties(current_obj.parent))
+    return empties
+
+# if the object is nested under something we'd like to keep (an armature or a mesh), we need to re-parent it
+# after removing all intermediate empties
+def get_closest_valid_parent(obj):
+    if obj == None or obj.parent == None:
+        return None
+    if obj.parent.type in valid_object_types:
+        return obj.parent
+    return get_closest_valid_parent(obj.parent)
+
+def CP77_cleanup_external_export(importedObjects):
+
+    empties=[]
+
+    # collect mesh names for iterating
+    validObjectNames = sorted([obj.name for obj in filter(lambda obj: obj.type in valid_object_types, importedObjects)])
+
+    # clear parents, keep transforms
+    for ob in importedObjects:
+        try:
+            empties.extend(get_parented_empties(ob))
+            bpy.ops.object.select_all(action="DESELECT")
+            new_parent = get_closest_valid_parent(ob)
+            if new_parent == ob.parent:
+                continue
+            ob.select_set(state=True)
+            bpy.ops.object.parent_clear(type='CLEAR_KEEP_TRANSFORM')
+            if (new_parent != None and new_parent != ob):
+                ob.parent = new_parent
+        except Exception as e:
+            print("Exception while cleaning up object: " + str(e))
+            continue
+
+    # delete empties
+    counter = 0
+    empty_names = [e.name for e in empties]
+    try:
+        while len(empty_names) and counter < 99:
+            counter += 1
+            for name in empty_names.copy():
+                e = bpy.data.objects.get(name)
+                if e == None:
+                    empty_names.remove(name)
+                    continue
+                if not e.children:
+                    bpy.data.objects.remove(e)
+                    empty_names.remove(name)
+
+    except Exception as e:
+        print("Exception when trying to delete empties: " + str(e))
+
+    new_object_names = cleanup_names_and_apply_transformations(validObjectNames)
+
+    for object_name in new_object_names:
+        bpy.data.objects[object_name].select_set(True)
+
+

--- a/i_scene_cp77_gltf/importers/import_with_materials.py
+++ b/i_scene_cp77_gltf/importers/import_with_materials.py
@@ -12,67 +12,56 @@ import traceback
 def objs_in_col(top_coll, objtype):
     return sum([len([o for o in col.objects if o.type==objtype]) for col in top_coll.children_recursive])+len([o for o in top_coll.objects if o.type==objtype])
 
+existingMaterials = None
+imported = None
+appearances = None
+collection = None
+
 def CP77GLBimport(self, exclude_unused_mats=True, image_format='png', with_materials=True, filepath='', hide_armatures=True,  import_garmentsupport=False, files=[], directory='', appearances=[], remap_depot=False):
-    
+
     context=bpy.context
     loadfiles=self.files
     appearances=self.appearances.split(",")
     for f in appearances:
         print(f)
-    
+
     # prevent crash if no directory supplied when using filepath
     if len(self.directory)>0:
         directory = self.directory
     else:
         directory = os.path.dirname(self.filepath)
-        
+
     #if no files were supplied and a filepath is populate the files from the filepath
     if len(loadfiles)==0 and len(self.filepath)>0:
         f={}
         f['name']=os.path.basename(self.filepath)
         loadfiles=(f,)
-        
-    
+
+
     for f in loadfiles:
         filepath = os.path.join(directory, f['name'])
-                    
+
         gltf_importer = glTFImporter(filepath, { "files": None, "loglevel": 0, "import_pack_images" :True, "merge_vertices" :False, "import_shading" : 'NORMALS', "bone_heuristic":'BLENDER', "guess_original_bind_pose" : False, "import_user_extensions": ""})
         gltf_importer.read()
         gltf_importer.checks()
-        
+
         #kwekmaster: modified to reflect user choice
-        
+
         if len(bpy.data.meshes) is not 0:
             print(filepath + " Loaded; With materials: "+str(with_materials))
         existingMeshes = bpy.data.meshes.keys()
 
-       
+
         existingMaterials = bpy.data.materials.keys()
         BlenderGlTF.create(gltf_importer)
-        imported= context.selected_objects #the new stuff should be selected 
+        imported= context.selected_objects #the new stuff should be selected
         if f['name'][:7]=='terrain':
             UV_by_bounds(imported)
         collection = bpy.data.collections.new(os.path.splitext(f['name'])[0])
         bpy.context.scene.collection.children.link(collection)
         for o in imported:
-            for parent in o.users_collection:
-                    parent.objects.unlink(o)
-            collection.objects.link(o)  
-            
-            # if animations exist, don't hide the armature and get the extras properties
-            # We should probably break the base import out into a separate function, have it check the gltf file and then send the info either to anim import or import with materials, but this works too
-            animations = gltf_importer.data.animations
-            meshes = gltf_importer.data.meshes
-            if animations:
-                get_anim_info(animations)
-                if meshes and "Icosphere" not in mesh.name:
-                    if 'Armature' in o.name:
-                        o.hide_set(hide_armatures)
-            else:
-            #print('o.name - ',o.name)
-                if 'Armature' in o.name:
-                    o.hide_set(hide_armatures)
-            
+            import_meshes_and_anims(collection, gltf_importer, hide_armatures, o)
+
         collection['orig_filepath']=filepath
         collection['numMeshChildren']=objs_in_col(collection, 'MESH')
         collection['numArmatureChildren']=objs_in_col(collection, 'ARMATURE')
@@ -80,128 +69,177 @@ def CP77GLBimport(self, exclude_unused_mats=True, image_format='png', with_mater
         for name in bpy.data.materials.keys():
             if name not in existingMaterials:
                 bpy.data.materials.remove(bpy.data.materials[name], do_unlink=True, do_id_user=True, do_ui_user=True)
-        
+
         if import_garmentsupport:
             manage_garment_support(existingMeshes, gltf_importer)
+
         BasePath = os.path.splitext(filepath)[0]
-        #Kwek: Gate this--do the block iff corresponding Material.json exist 
+
+        #Kwek: Gate this--do the block iff corresponding Material.json exist
         #Kwek: was tempted to do a try-catch, but that is just La-Z
         #Kwek: Added another gate for materials
-        if with_materials and os.path.exists(BasePath + ".Material.json"):
-                
-            file = open(BasePath + ".Material.json",mode='r')
-            obj = json.loads(file.read())
-            file.close()
-            valid_json=json_ver_validate(obj)
-            if not valid_json:
-                self.report({'ERROR'}, "Incompatible material.json file detected. Material depot needs to be cleared and mesh re exported with current Wolvenkit Version.")
-                show_message('Incompatible material.json file detected. Material depot needs to be cleared and mesh re exported with current Wolvenkit Version.')
-                break
-            DepotPath = str(obj["MaterialRepo"])  + "\\"
-            context=bpy.context
-            if remap_depot and os.path.exists(context.preferences.addons[__name__.split('.')[0]].preferences.depotfolder_path):
-                DepotPath = context.preferences.addons[__name__.split('.')[0]].preferences.depotfolder_path
-            DepotPath= DepotPath.replace('\\', os.sep)
-            json_apps=obj['Appearances']
-            # fix the app names as for some reason they have their index added on the end.
-            appkeys=[k for k in json_apps.keys()]
-            for i,k in enumerate(appkeys):
-                json_apps[k[:-1*len(str(i))]]=json_apps.pop(k)
-            validmats={}
-            #appearances = ({'name':'short_hair'},{'name':'02_ca_limestone'},{'name':'ml_plastic_doll'},{'name':'03_ca_senna'})
-            #if appearances defined populate valid mats with the mats for them, otherwise populate with everything used.
-            if len(appearances)>0 and 'ALL' not in appearances:
-                for key in json_apps.keys():
-                    if key in  appearances:
-                        for m in json_apps[key]:
-                            validmats[m]=True
-            # there isnt always a default, so if none were listed, or ALL was used, or an invalid one add everything. 
-            if len(validmats)==0:
-                for key in json_apps.keys():
+        if not (with_materials and os.path.exists(BasePath + ".Material.json")):
+            blender_4_scale_armature_bones()
+            return
+
+        file = open(BasePath + ".Material.json",mode='r')
+        obj = json.loads(file.read())
+        file.close()
+        valid_json=json_ver_validate(obj)
+        if not valid_json:
+            self.report({'ERROR'}, "Incompatible material.json file detected. Material depot needs to be cleared and mesh re exported with current Wolvenkit Version.")
+            show_message('Incompatible material.json file detected. Material depot needs to be cleared and mesh re exported with current Wolvenkit Version.')
+            break
+        DepotPath = str(obj["MaterialRepo"])  + "\\"
+        context=bpy.context
+        if remap_depot and os.path.exists(context.preferences.addons[__name__.split('.')[0]].preferences.depotfolder_path):
+            DepotPath = context.preferences.addons[__name__.split('.')[0]].preferences.depotfolder_path
+        DepotPath= DepotPath.replace('\\', os.sep)
+        json_apps=obj['Appearances']
+        # fix the app names as for some reason they have their index added on the end.
+        appkeys=[k for k in json_apps.keys()]
+        for i,k in enumerate(appkeys):
+            json_apps[k[:-1*len(str(i))]]=json_apps.pop(k)
+        validmats={}
+        #appearances = ({'name':'short_hair'},{'name':'02_ca_limestone'},{'name':'ml_plastic_doll'},{'name':'03_ca_senna'})
+        #if appearances defined populate valid mats with the mats for them, otherwise populate with everything used.
+        if len(appearances)>0 and 'ALL' not in appearances:
+            for key in json_apps.keys():
+                if key in  appearances:
                     for m in json_apps[key]:
                         validmats[m]=True
-            for mat in validmats.keys():
-                for m in obj['Materials']:
-                    if m['Name']==mat:
-                        if 'BaseMaterial' in m.keys():
-                             if 'GlobalNormal' in m['Data'].keys():
-                                 GlobalNormal=m['Data']['GlobalNormal']
-                             else:
-                                 GlobalNormal='None'
-                             if 'MultilayerMask' in m['Data'].keys():
-                                 MultilayerMask=m['Data']['MultilayerMask']
-                             else:
-                                 MultilayerMask='None'
-                             if 'DiffuseMap' in m['Data'].keys():
-                                 DiffuseMap=m['Data']['DiffuseMap']
-                             else:
-                                 DiffuseMap='None'
+        # there isnt always a default, so if none were listed, or ALL was used, or an invalid one add everything.
+        if len(validmats)==0:
+            for key in json_apps.keys():
+                for m in json_apps[key]:
+                    validmats[m]=True
 
-                             validmats[mat]={'Name':m['Name'], 'BaseMaterial': m['BaseMaterial'],'GlobalNormal':GlobalNormal, 'MultilayerMask':MultilayerMask,'DiffuseMap':DiffuseMap}
-                        else:
-                            print(m.keys())
-            MatImportList=[k for k in validmats.keys()]
-            
-            Builder = MaterialBuilder(obj,DepotPath,str(image_format),BasePath)
-            
-            counter = 0
-            bpy_mats=bpy.data.materials
-            for name in bpy.data.meshes.keys():
-                if name not in existingMeshes and "Icosphere" not in name:
-                    bpy.data.meshes[name].materials.clear()
-                    if gltf_importer.data.meshes[counter].extras is not None: #Kwek: I also found that other material hiccups will cause the Collection to fail
-                        for matname in gltf_importer.data.meshes[counter].extras["materialNames"]:
-                            if matname in validmats.keys():
-                                #print('matname: ',matname, validmats[matname])
-                                m=validmats[matname]
-                                # Should create a list of mis that dont play nice with this and just check if the mat is using one.
+        import_mats(BasePath, DepotPath, exclude_unused_mats, existingMeshes, gltf_importer, image_format, obj,
+                    validmats)
 
-                                if matname in bpy_mats.keys() and 'glass' not in matname and 'MaterialTemplate' not in matname and 'Window' not in matname and matname[:5]!='Atlas' and 'BaseMaterial' in bpy_mats[matname].keys() and bpy_mats[matname]['BaseMaterial']==m['BaseMaterial'] and bpy_mats[matname]['GlobalNormal']==m['GlobalNormal'] and bpy_mats[matname]['MultilayerMask']==m['MultilayerMask'] :
 
-                                    bpy.data.meshes[name].materials.append(bpy_mats[matname])
-                                elif matname in bpy_mats.keys() and matname[:5]=='Atlas' and bpy_mats[matname]['BaseMaterial']==m['BaseMaterial'] and bpy_mats[matname]['DiffuseMap']==m['DiffuseMap'] :
-                                    bpy.data.meshes[name].materials.append(bpy_mats[matname])
-                                else:
-                                    if matname in validmats.keys():
-                                        index = 0
-                                        for rawmat in obj["Materials"]:
-                                            if rawmat["Name"] == matname :
-                                                try:
-                                                    bpymat = Builder.create(index)
-                                                    if bpymat:
-                                                        bpymat['BaseMaterial']=validmats[matname]['BaseMaterial']
-                                                        bpymat['GlobalNormal']=validmats[matname]['GlobalNormal']
-                                                        bpymat['MultilayerMask']=validmats[matname]['MultilayerMask']
-                                                        bpymat['DiffuseMap']=validmats[matname]['DiffuseMap']
-                                                        bpy.data.meshes[name].materials.append(bpymat)
-                                                        if 'no_shadows' in bpymat.keys() and bpymat['no_shadows']:
-                                                            bpy.data.objects[name].visible_shadow=False
-                                                except: 
-                                                    #Kwek -- finally, even if the Builder couldn't find the materials, keep calm and carry on
-                                                    print(traceback.print_exc())                                                    
-                                                    pass                                            
-                                            index = index + 1
-                            else:
-                                #print(matname, validmats.keys())
-                                pass
-                        
-                    counter = counter + 1
-            if not exclude_unused_mats:
-                index = 0
-                for rawmat in obj["Materials"]:
-                    if rawmat["Name"] not in  bpy.data.materials.keys() and ((rawmat["Name"] in MatImportList) or len(MatImportList)<1):
-                        Builder.create(index)
-                    index = index + 1
-                    
-    vers=bpy.app.version
+def import_mats(BasePath, DepotPath, exclude_unused_mats, existingMeshes, gltf_importer, image_format, obj, validmats):
+    for mat in validmats.keys():
+        for m in obj['Materials']:
+            if m['Name'] != mat:
+                continue
+            if 'BaseMaterial' in m.keys():
+                if 'GlobalNormal' in m['Data'].keys():
+                    GlobalNormal = m['Data']['GlobalNormal']
+                else:
+                    GlobalNormal = 'None'
+                if 'MultilayerMask' in m['Data'].keys():
+                    MultilayerMask = m['Data']['MultilayerMask']
+                else:
+                    MultilayerMask = 'None'
+                if 'DiffuseMap' in m['Data'].keys():
+                    DiffuseMap = m['Data']['DiffuseMap']
+                else:
+                    DiffuseMap = 'None'
+
+                validmats[mat] = {'Name': m['Name'], 'BaseMaterial': m['BaseMaterial'],
+                                  'GlobalNormal': GlobalNormal, 'MultilayerMask': MultilayerMask,
+                                  'DiffuseMap': DiffuseMap}
+            else:
+                print(m.keys())
+
+    MatImportList = [k for k in validmats.keys()]
+    Builder = MaterialBuilder(obj, DepotPath, str(image_format), BasePath)
+    counter = 0
+    bpy_mats = bpy.data.materials
+    for name in bpy.data.meshes.keys():
+        if name in existingMeshes or "Icosphere" in name:
+            continue
+        bpy.data.meshes[name].materials.clear()
+        extras = gltf_importer.data.meshes[counter].extras
+        if extras is None or "materialNames" not in extras.keys() or extras["materialNames"] is None:
+            counter = counter + 1
+            continue
+        # Kwek: I also found that other material hiccups will cause the Collection to fail
+        for matname in extras["materialNames"]:
+
+            if matname not in validmats.keys():
+                # print("Pass")
+                # print(matname, validmats.keys())
+                pass
+            else:
+                # print('matname: ',matname, validmats[matname])
+                m = validmats[matname]
+                # Should create a list of mis that dont play nice with this and just check if the mat is using one.
+
+                if matname in bpy_mats.keys() and 'glass' not in matname and 'MaterialTemplate' not in matname and 'Window' not in matname and matname[
+                                                                                                                                                :5] != 'Atlas' and 'BaseMaterial' in \
+                        bpy_mats[matname].keys() and bpy_mats[matname]['BaseMaterial'] == m['BaseMaterial'] and \
+                        bpy_mats[matname]['GlobalNormal'] == m['GlobalNormal'] and bpy_mats[matname][
+                    'MultilayerMask'] == m['MultilayerMask']:
+
+                    bpy.data.meshes[name].materials.append(bpy_mats[matname])
+                elif matname in bpy_mats.keys() and matname[:5] == 'Atlas' and bpy_mats[matname][
+                    'BaseMaterial'] == m['BaseMaterial'] and bpy_mats[matname]['DiffuseMap'] == m['DiffuseMap']:
+                    bpy.data.meshes[name].materials.append(bpy_mats[matname])
+                else:
+                    if matname in validmats.keys():
+                        index = 0
+                        for rawmat in obj["Materials"]:
+                            if rawmat["Name"] == matname:
+                                try:
+                                    bpymat = Builder.create(index)
+                                    if bpymat:
+                                        bpymat['BaseMaterial'] = validmats[matname]['BaseMaterial']
+                                        bpymat['GlobalNormal'] = validmats[matname]['GlobalNormal']
+                                        bpymat['MultilayerMask'] = validmats[matname]['MultilayerMask']
+                                        bpymat['DiffuseMap'] = validmats[matname]['DiffuseMap']
+                                        bpy.data.meshes[name].materials.append(bpymat)
+                                        if 'no_shadows' in bpymat.keys() and bpymat['no_shadows']:
+                                            bpy.data.objects[name].visible_shadow = False
+                                except:
+                                    # Kwek -- finally, even if the Builder couldn't find the materials, keep calm and carry on
+                                    print(traceback.print_exc())
+                                    pass
+                            index = index + 1
+
+        counter = counter + 1
+
+    if exclude_unused_mats:
+        return
+
+    index = 0
+    for rawmat in obj["Materials"]:
+        if rawmat["Name"] not in bpy.data.materials.keys() and (
+                (rawmat["Name"] in MatImportList) or len(MatImportList) < 1):
+            Builder.create(index)
+        index = index + 1
+
+
+def blender_4_scale_armature_bones():
+    vers = bpy.app.version
     if vers[0] >= 4:
-        arms = [obj for obj in bpy.data.objects if obj.type== 'ARMATURE']
+        arms = [obj for obj in bpy.data.objects if obj.type == 'ARMATURE']
         for arm in arms:
             for pb in arm.pose.bones:
                 pb.custom_shape_scale_xyz[0] = .0175
                 pb.custom_shape_scale_xyz[1] = .0175
                 pb.custom_shape_scale_xyz[2] = .0175
                 pb.use_custom_shape_bone_size = True
+
+
+def import_meshes_and_anims(collection, gltf_importer, hide_armatures, o):
+    for parent in o.users_collection:
+        parent.objects.unlink(o)
+    collection.objects.link(o)
+    # if animations exist, don't hide the armature and get the extras properties
+    # We should probably break the base import out into a separate function, have it check the gltf file and then send the info either to anim import or import with materials, but this works too
+    animations = gltf_importer.data.animations
+    meshes = gltf_importer.data.meshes
+    if animations:
+        get_anim_info(animations)
+        if meshes and "Icosphere" not in mesh.name:
+            if 'Armature' in o.name:
+                o.hide_set(hide_armatures)
+    else:
+        # print('o.name - ',o.name)
+        if 'Armature' in o.name:
+            o.hide_set(hide_armatures)
 
 
 

--- a/i_scene_cp77_gltf/importers/import_with_materials.py
+++ b/i_scene_cp77_gltf/importers/import_with_materials.py
@@ -94,9 +94,11 @@ def CP77GLBimport(self, exclude_unused_mats=True, image_format='png', with_mater
         collection['numMeshChildren']=objs_in_col(collection, 'MESH')
         collection['numArmatureChildren']=objs_in_col(collection, 'ARMATURE')
 
-        for name in bpy.data.materials.keys():
-            if name not in existingMaterials:
-                bpy.data.materials.remove(bpy.data.materials[name], do_unlink=True, do_id_user=True, do_ui_user=True)
+        #for sketchfab exports, we want to keep our materials
+        if not isExternalImport:
+            for name in bpy.data.materials.keys():
+                if name not in existingMaterials:
+                    bpy.data.materials.remove(bpy.data.materials[name], do_unlink=True, do_id_user=True, do_ui_user=True)
 
         if import_garmentsupport:
             manage_garment_support(existingMeshes, gltf_importer)


### PR DESCRIPTION
- Fixed several import errors I ran into when working on my socks mesh
- Added a checkbox on export to add a red _GarmentSupportCap layer (I needed this on export because I processed 40+ meshes, I **really** didn't want the three extra clicks for the mesh tools. That being said, it should probably go there as well)
- Fixed import for multiple meshes aborting prematurely if one of the meshes had no armature (return => continue)

- Added support for external imports (e.g. sketchfab). Dumped them into their own file, but they will flatten the hierarchy and turn it into something Cyberpunk-friendly

![image](https://github.com/WolvenKit/Cyberpunk-Blender-add-on/assets/965785/08278650-ee68-4e4f-85a0-47f9a265a356)
