### PR TITLE
Add "apply transform" to export options

### DIFF
--- a/i_scene_cp77_gltf/__init__.py
+++ b/i_scene_cp77_gltf/__init__.py
@@ -15,7 +15,7 @@ from . scriptman import *
 
 bl_info = {
     "name": "Cyberpunk 2077 IO Suite",
-    "author": "HitmanHimself, Turk, Jato, dragonzkiller, kwekmaster, glitchered, Simarilius, Doctor Presto, shotlastc, Rudolph2109, Holopointz",
+    "author": "HitmanHimself, Turk, Jato, dragonzkiller, kwekmaster, glitchered, Simarilius, Doctor Presto, shotlastc, Rudolph2109, Holopointz, Peatral",
     "version": (1, 5, 5, 3),
     "blender": (4, 0, 0),
     "location": "File > Import-Export",

--- a/i_scene_cp77_gltf/exporters/__init__.py
+++ b/i_scene_cp77_gltf/exporters/__init__.py
@@ -31,16 +31,16 @@ class CP77StreamingSectorExport(Operator,ExportHelper):
 
 
 class CP77GLBExport(Operator,ExportHelper):
-  ### cleaned this up and moved most code to exporters.py
+    ### cleaned this up and moved most code to exporters.py
     bl_idname = "export_scene.cp77_glb"
     bl_label = "Export for Cyberpunk"
     bl_options = {'REGISTER','UNDO'}
     bl_description = "Export to GLB with optimized settings for use with Wolvenkit for Cyberpunk 2077" 
     filename_ext = ".glb"
-   ### adds a checkbox for anim export settings
+    ### adds a checkbox for anim export settings
     
     filter_glob: StringProperty(default="*.glb", options={'HIDDEN'})
-   
+
     filepath: StringProperty(subtype="FILE_PATH")
 
     limit_selected: BoolProperty(
@@ -67,6 +67,12 @@ class CP77GLBExport(Operator,ExportHelper):
         description="Use this option to export all visible objects. Only use this if you know why you're using this"
     )
 
+    apply_transform: BoolProperty(
+        name="Apply Transform",
+        default=True,
+        description="Applies the transform of the objects. Disable this if you don't care about the location/rotation/scale of the objects"
+    )
+
     def draw(self, context):
         layout = self.layout
         row = layout.row(align=True) 
@@ -80,9 +86,11 @@ class CP77GLBExport(Operator,ExportHelper):
             else: 
                 row = layout.row(align=True)
                 row.prop(self, "static_prop")
-        
+            row = layout.row(align=True)
+            row.prop(self, "apply_transform")
+    
     def execute(self, context):
-        export_cyberpunk_glb(context, self.filepath, self.export_poses, self.export_visible, self.limit_selected, self.static_prop)
+        export_cyberpunk_glb(context=context, filepath=self.filepath, export_poses=self.export_poses, export_visible=self.export_visible, limit_selected=self.limit_selected, static_prop=self.static_prop, apply_transform=self.apply_transform)
         return {'FINISHED'}
 
 

--- a/i_scene_cp77_gltf/exporters/__init__.py
+++ b/i_scene_cp77_gltf/exporters/__init__.py
@@ -106,11 +106,14 @@ class CP77GLBExport(Operator,ExportHelper):
                 row.prop(self, "static_prop")
             (panel_header, panel_body) = layout.panel("apply_transform", default_closed=True)
             panel_header.prop(self, "apply_transform")
-            panel_body.use_property_decorate = False
-            panel_body.enabled = self.apply_transform
-            panel_body.prop(self, "apply_transform_location")
-            panel_body.prop(self, "apply_transform_rotation")
-            panel_body.prop(self, "apply_transform_scale")
+
+            if panel_body is not None:
+                panel_body.use_property_split = True
+                panel_body.use_property_decorate = False
+                panel_body.enabled = self.apply_transform
+                panel_body.prop(self, "apply_transform_location")
+                panel_body.prop(self, "apply_transform_rotation")
+                panel_body.prop(self, "apply_transform_scale")
     
     def execute(self, context):
         export_cyberpunk_glb(

--- a/i_scene_cp77_gltf/exporters/__init__.py
+++ b/i_scene_cp77_gltf/exporters/__init__.py
@@ -73,6 +73,24 @@ class CP77GLBExport(Operator,ExportHelper):
         description="Applies the transform of the objects. Disable this if you don't care about the location/rotation/scale of the objects"
     )
 
+    apply_transform_location: BoolProperty(
+        name="Apply Location",
+        default=True,
+        description="Applies the location of the objects."
+    )
+
+    apply_transform_rotation: BoolProperty(
+        name="Apply Rotation",
+        default=True,
+        description="Applies the rotation of the objects."
+    )
+
+    apply_transform_scale: BoolProperty(
+        name="Apply Scale",
+        default=True,
+        description="Applies the scale of the objects."
+    )
+
     def draw(self, context):
         layout = self.layout
         row = layout.row(align=True) 
@@ -86,11 +104,27 @@ class CP77GLBExport(Operator,ExportHelper):
             else: 
                 row = layout.row(align=True)
                 row.prop(self, "static_prop")
-            row = layout.row(align=True)
-            row.prop(self, "apply_transform")
+            (panel_header, panel_body) = layout.panel("apply_transform", default_closed=True)
+            panel_header.prop(self, "apply_transform")
+            panel_body.use_property_decorate = False
+            panel_body.enabled = self.apply_transform
+            panel_body.prop(self, "apply_transform_location")
+            panel_body.prop(self, "apply_transform_rotation")
+            panel_body.prop(self, "apply_transform_scale")
     
     def execute(self, context):
-        export_cyberpunk_glb(context=context, filepath=self.filepath, export_poses=self.export_poses, export_visible=self.export_visible, limit_selected=self.limit_selected, static_prop=self.static_prop, apply_transform=self.apply_transform)
+        export_cyberpunk_glb(
+            context=context, 
+            filepath=self.filepath, 
+            export_poses=self.export_poses, 
+            export_visible=self.export_visible, 
+            limit_selected=self.limit_selected, 
+            static_prop=self.static_prop, 
+            apply_transform=self.apply_transform,
+            apply_location=self.apply_transform_location,
+            apply_rotation=self.apply_transform_rotation,
+            apply_scale=self.apply_transform_scale,
+        )
         return {'FINISHED'}
 
 

--- a/i_scene_cp77_gltf/exporters/__init__.py
+++ b/i_scene_cp77_gltf/exporters/__init__.py
@@ -73,24 +73,6 @@ class CP77GLBExport(Operator,ExportHelper):
         description="Applies the transform of the objects. Disable this if you don't care about the location/rotation/scale of the objects"
     )
 
-    apply_transform_location: BoolProperty(
-        name="Apply Location",
-        default=True,
-        description="Applies the location of the objects."
-    )
-
-    apply_transform_rotation: BoolProperty(
-        name="Apply Rotation",
-        default=True,
-        description="Applies the rotation of the objects."
-    )
-
-    apply_transform_scale: BoolProperty(
-        name="Apply Scale",
-        default=True,
-        description="Applies the scale of the objects."
-    )
-
     def draw(self, context):
         layout = self.layout
         row = layout.row(align=True) 
@@ -104,16 +86,8 @@ class CP77GLBExport(Operator,ExportHelper):
             else: 
                 row = layout.row(align=True)
                 row.prop(self, "static_prop")
-            (panel_header, panel_body) = layout.panel("apply_transform", default_closed=True)
-            panel_header.prop(self, "apply_transform")
-
-            if panel_body is not None:
-                panel_body.use_property_split = True
-                panel_body.use_property_decorate = False
-                panel_body.enabled = self.apply_transform
-                panel_body.prop(self, "apply_transform_location")
-                panel_body.prop(self, "apply_transform_rotation")
-                panel_body.prop(self, "apply_transform_scale")
+            row = layout.row(align=True)
+            row.prop(self, "apply_transform")
     
     def execute(self, context):
         export_cyberpunk_glb(
@@ -124,9 +98,6 @@ class CP77GLBExport(Operator,ExportHelper):
             limit_selected=self.limit_selected, 
             static_prop=self.static_prop, 
             apply_transform=self.apply_transform,
-            apply_location=self.apply_transform_location,
-            apply_rotation=self.apply_transform_rotation,
-            apply_scale=self.apply_transform_scale,
         )
         return {'FINISHED'}
 

--- a/i_scene_cp77_gltf/exporters/glb_export.py
+++ b/i_scene_cp77_gltf/exporters/glb_export.py
@@ -96,7 +96,7 @@ def add_garment_cap(mesh):
 
 # setup the actual exporter - rewrote almost all of this, much quicker now
 # mana: by assigning default attributes, we make this update-safe (some older scripts broke). Just don't re-name them!
-def export_cyberpunk_glb(context, filepath, export_poses=False, export_visible=False, limit_selected=True, static_prop=False, red_garment_col=False, apply_transform=True):
+def export_cyberpunk_glb(context, filepath, export_poses=False, export_visible=False, limit_selected=True, static_prop=False, red_garment_col=False, apply_transform=True, apply_location=True, apply_rotation=True, apply_scale=True):
 
     groupless_bones = set()
     bone_names = []
@@ -169,7 +169,7 @@ def export_cyberpunk_glb(context, filepath, export_poses=False, export_visible=F
 
         # apply transforms
         if apply_transform:
-            bpy.ops.object.transform_apply(location=True, rotation=True, scale=True)
+            bpy.ops.object.transform_apply(location=apply_location, rotation=apply_rotation, scale=apply_scale)
         if not mesh.data.uv_layers:
             bpy.ops.cp77.message_box('INVOKE_DEFAULT', message="Meshes must have UV layers in order to import in Wolvenkit. See https://tinyurl.com/uv-layers")
             return {'CANCELLED'}

--- a/i_scene_cp77_gltf/exporters/glb_export.py
+++ b/i_scene_cp77_gltf/exporters/glb_export.py
@@ -96,7 +96,7 @@ def add_garment_cap(mesh):
 
 # setup the actual exporter - rewrote almost all of this, much quicker now
 # mana: by assigning default attributes, we make this update-safe (some older scripts broke). Just don't re-name them!
-def export_cyberpunk_glb(context, filepath, export_poses=False, export_visible=False, limit_selected=True, static_prop=False, red_garment_col=False, apply_transform=True, apply_location=True, apply_rotation=True, apply_scale=True):
+def export_cyberpunk_glb(context, filepath, export_poses=False, export_visible=False, limit_selected=True, static_prop=False, red_garment_col=False, apply_transform=True):
 
     groupless_bones = set()
     bone_names = []
@@ -169,7 +169,7 @@ def export_cyberpunk_glb(context, filepath, export_poses=False, export_visible=F
 
         # apply transforms
         if apply_transform:
-            bpy.ops.object.transform_apply(location=apply_location, rotation=apply_rotation, scale=apply_scale)
+            bpy.ops.object.transform_apply(location=True, rotation=True, scale=True)
         if not mesh.data.uv_layers:
             bpy.ops.cp77.message_box('INVOKE_DEFAULT', message="Meshes must have UV layers in order to import in Wolvenkit. See https://tinyurl.com/uv-layers")
             return {'CANCELLED'}

--- a/i_scene_cp77_gltf/exporters/glb_export.py
+++ b/i_scene_cp77_gltf/exporters/glb_export.py
@@ -96,7 +96,7 @@ def add_garment_cap(mesh):
 
 # setup the actual exporter - rewrote almost all of this, much quicker now
 # mana: by assigning default attributes, we make this update-safe (some older scripts broke). Just don't re-name them!
-def export_cyberpunk_glb(context, filepath, export_poses=False, export_visible=False, limit_selected=True, static_prop=False, red_garment_col=False):
+def export_cyberpunk_glb(context, filepath, export_poses=False, export_visible=False, limit_selected=True, static_prop=False, red_garment_col=False, apply_transform=True):
 
     groupless_bones = set()
     bone_names = []
@@ -168,7 +168,8 @@ def export_cyberpunk_glb(context, filepath, export_poses=False, export_visible=F
     for mesh in meshes:
 
         # apply transforms
-        bpy.ops.object.transform_apply(location=True, rotation=True, scale=True)
+        if apply_transform:
+            bpy.ops.object.transform_apply(location=True, rotation=True, scale=True)
         if not mesh.data.uv_layers:
             bpy.ops.cp77.message_box('INVOKE_DEFAULT', message="Meshes must have UV layers in order to import in Wolvenkit. See https://tinyurl.com/uv-layers")
             return {'CANCELLED'}
@@ -248,7 +249,7 @@ def export_cyberpunk_glb(context, filepath, export_poses=False, export_visible=F
                     for group in obj.vertex_groups:
                         if group.name in bone_names:
                             group_has_bone[group.index] = True
-                             # print(vertex_group.name)
+                            # print(vertex_group.name)
 
                         # Add groups with no weights to the set
                     for group_index, has_bone in group_has_bone.items():


### PR DESCRIPTION
Added an option to the export options. When disabled (enabled by default) the transform does not get applied during export.

I found myself in a situation where this is quite helpful. When creating vehicles you often have to align positions with bones from the rig. Before exporting I always had to clear the location and reset it after, this solves this. (I have the complete model and moving its way easier to just keep the parts where they belong and don't apply the transform during export)

As it is enabled by default the current behaviour should not change as long as you don't touch the option.

I am open to modify this that you can toggle location, rotation and scale individually for those who need it.