### PR TITLE
materialBuilder: normalise paths to work correctly on non-Windows hosts

### DIFF
--- a/i_scene_cp77_gltf/main/setup.py
+++ b/i_scene_cp77_gltf/main/setup.py
@@ -53,7 +53,8 @@ class MaterialBuilder:
             bpyMat['MaterialTemplate'] = rawMat["MaterialTemplate"]
             bpyMat.use_nodes = True
             no_shadows=False
-            match rawMat["MaterialTemplate"]:
+            material_template = rawMat["MaterialTemplate"].replace('/','\\')
+            match material_template:
                 case "engine\\materials\\multilayered.mt" | "base\\materials\\vehicle_destr_blendshape.mt" | "base\\materials\\multilayered_clear_coat.mt" |  "base\\materials\\multilayered_terrain.mt":
                     multilayered = Multilayered(self.BasePath,self.image_format,self.ProjPath)
                     multilayered.create(rawMat["Data"],bpyMat)


### PR DESCRIPTION
The code that identifies material templates assumes the use of windows paths, and so will fail to match the paths constructed when reading a Material.json, which are normalised to the host path format.

Ideally, we'd make the material template matching code use the host format, but it's easier to just re-normalise the paths back to windows.