### PR TITLE
multilayered: fix mask path handling on non-windows OSes

### DIFF
--- a/i_scene_cp77_gltf/material_types/multilayered.py
+++ b/i_scene_cp77_gltf/material_types/multilayered.py
@@ -192,10 +192,12 @@ class Multilayered:
         NG = _getOrCreateLayerBlend()
         for x in range(LayerCount-1):
             MaskTexture=None
-            if os.path.exists((os.path.splitext(self.ProjPath + mlmaskpath)[0]+'_layers\\'+mlmaskpath.split('\\')[-1:][0][:-7]+"_"+str(x+1)+".png").replace('\\',os.sep)):
-                MaskTexture = imageFromPath(os.path.splitext(self.ProjPath+ mlmaskpath)[0]+'_layers\\'+mlmaskpath.split('\\')[-1:][0][:-7]+"_"+str(x+1)+".png",self.image_format,isNormal = True)
-            elif os.path.exists((os.path.splitext(self.BasePath + mlmaskpath)[0]+'_layers\\'+mlmaskpath.split('\\')[-1:][0][:-7]+"_"+str(x+1)+".png").replace('\\',os.sep)):
-                MaskTexture = imageFromPath((os.path.splitext(self.BasePath + mlmaskpath)[0]+'_layers\\'+mlmaskpath.split('\\')[-1:][0][:-7]+"_"+str(x+1)+".png").replace('\\',os.sep),self.image_format,isNormal = True)
+            projpath = os.path.join(os.path.splitext(os.path.join(self.ProjPath, mlmaskpath))[0] + '_layers', os.path.split(mlmaskpath)[-1:][0][:-7] + "_" + str(x + 1) + ".png")
+            basepath = os.path.join(os.path.splitext(os.path.join(self.BasePath, mlmaskpath))[0] + '_layers', os.path.split(mlmaskpath)[-1:][0][:-7] + "_" + str(x + 1) + ".png")
+            if os.path.exists(projpath):
+                MaskTexture = imageFromPath(projpath, self.image_format, isNormal = True)
+            elif os.path.exists(basepath):
+                MaskTexture = imageFromPath(basepath, self.image_format, isNormal = True)
             else:
                 print('Mask image not found for layer ',x+1)
 


### PR DESCRIPTION
The current logic for importing layers on non-windows OSes assumes that the various path components being used to construct the final layer path are using Windows separators, but they are actually already using native separators.

This causes the splitting logic to fail, leading to an invalid path, and failure to load all layers after the base one, which is always assumed to be a fully open layer (is this is really true for all mask sets?)

So, let's simplify the logic by using `os.path.join` and `os.path.split` to properly recombine the path elements in an OS-neutral way.