### PR TITLE
Autofitter fixes

### DIFF
--- a/i_scene_cp77_gltf/meshtools/meshtools.py
+++ b/i_scene_cp77_gltf/meshtools/meshtools.py
@@ -208,10 +208,8 @@ def CP77RefitChecker(self, context):
         if obj.type =='LATTICE':
             if "refitter_type" in obj:
                 refitter.append(obj)
-                print('refitters found in scene:', refitter)
             if "refitter_addon" in obj:
                 addon.append(obj)
-                print('refitter addons found in scene:', addon)
     print(f'refitter result: {refitter} refitter addon: {addon}')
     return refitter, addon
 


### PR DESCRIPTION
Made following changes to autofitter:
- Removed requirement for active object (unnecessary)
- Removed duplicate logic for refitting when a refitter already exists in scene (fixes #279)
- Cleaned up some parts of the code

It's not perfect, but I do believe it works better now. Please do double-check my changes though ![:cat_pray:](https://cdn.discordapp.com/emojis/1229687576454107208.webp?size=24)