### PR TITLE
Fix: anim export (missing arg default for export_tracks)

### DIFF
--- a/i_scene_cp77_gltf/exporters/glb_export.py
+++ b/i_scene_cp77_gltf/exporters/glb_export.py
@@ -171,7 +171,7 @@ def export_cyberpunk_glb(context, filepath, export_poses=False, export_visible=F
         restore_user_settings(user_settings)
         return {'FINISHED'}
 
-def export_anims(context, filepath, options, armatures, export_tracks = True):
+def export_anims(context, filepath, options, armatures, export_tracks = False):
     cp77_addon_prefs = bpy.context.preferences.addons['i_scene_cp77_gltf'].preferences
     for action in bpy.data.actions:
         # schema & base defaults
@@ -361,6 +361,7 @@ def ExportAll(self, context):
         for obj in to_exp:
             filepath = obj.get('projPath', '')  # Use 'projPath' property or empty string if it doesn't exist
             export_cyberpunk_glb(filepath=filepath, export_poses=False)
+
 
 
 


### PR DESCRIPTION
FIX: missing default arg for enabling track export.  (set to false as default, to avoid lengthening sector import)