### PR TITLE
refac: Add material registry and refactor material handling in setup.py

### DIFF
--- a/i_scene_cp77_gltf/importers/import_with_materials.py
+++ b/i_scene_cp77_gltf/importers/import_with_materials.py
@@ -23,7 +23,7 @@ def get_anim_info(animations, oldanims, import_tracks):
 	Keeps original logic/printing; only adds track import + alignment.
 	"""
 	cp77_addon_prefs = bpy.context.preferences.addons['i_scene_cp77_gltf'].preferences
-	
+
 	if bpy.app.version >= (4, 4, 0):
 		old_names = {getattr(x, 'name', x) for x in (oldanims or [])}
 		# Only actions created during this import
@@ -453,9 +453,7 @@ def import_mats(BasePath, DepotPath, exclude_unused_mats, existingMeshes, gltf_i
             if matname in bpy_mats.keys() and 'glass' not in matname and 'MaterialTemplate' not in matname and 'Window' not in matname \
                  and matname[:5] != 'Atlas' and 'decal_diffuse' not in matname and \
                 'BaseMaterial' in bpy_mats[matname].keys() and bpy_mats[matname]['BaseMaterial'] == m['BaseMaterial'] and \
-                    bpy_mats[matname]['GlobalNormal'] == m['GlobalNormal'] and bpy_mats[matname][
-                'MultilayerMask'] == m['MultilayerMask']:
-
+                    bpy_mats[matname]['GlobalNormal'] == m['GlobalNormal'] and bpy_mats[matname]['MultilayerMask'] == m['MultilayerMask']:
                 bpy.data.meshes[name].materials.append(bpy_mats[matname])
             elif matname in bpy_mats.keys() and matname[:5] == 'Atlas' and bpy_mats[matname][
                 'BaseMaterial'] == m['BaseMaterial'] and bpy_mats[matname]['DiffuseMap'] == m['DiffuseMap']:

--- a/i_scene_cp77_gltf/main/material_registry.py
+++ b/i_scene_cp77_gltf/main/material_registry.py
@@ -1,0 +1,242 @@
+import os
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable
+
+# Handlers
+from ..material_types.multilayered import Multilayered
+from ..material_types.multilayeredclearcoat import MultilayeredClearCoat
+from ..material_types.vehicledestrblendshape import VehicleDestrBlendshape
+from ..material_types.skin import Skin
+from ..material_types.meshdecal import MeshDecal
+from ..material_types.meshdecaldoublediffuse import MeshDecalDoubleDiffuse
+from ..material_types.vehiclemeshdecal import VehicleMeshDecal
+from ..material_types.vehiclelights import VehicleLights
+from ..material_types.metalbase import MetalBase
+from ..material_types.metalbasedet import MetalBaseDet
+from ..material_types.hair import Hair
+from ..material_types.meshdecalgradientmaprecolor import MeshDecalGradientMapReColor
+from ..material_types.eye import Eye
+from ..material_types.eyegradient import EyeGradient
+from ..material_types.eyeshadow import EyeShadow
+from ..material_types.meshdecalemissive import MeshDecalEmissive
+from ..material_types.glass import Glass
+from ..material_types.glassdeferred import GlassDeferred
+from ..material_types.signages import Signages
+from ..material_types.meshdecalparallax import MeshDecalParallax
+from ..material_types.parallaxscreen import ParallaxScreen
+from ..material_types.parallaxscreentransparent import ParallaxScreenTransparent
+from ..material_types.speedtree import SpeedTree
+from ..material_types.decal import Decal
+from ..material_types.decal_gradientmap_recolor import DecalGradientmapRecolor
+from ..material_types.televisionad import TelevisionAd
+from ..material_types.window_parallax_interior_proxy import windowParallaxIntProx
+from ..material_types.hologram import Hologram
+from ..material_types.pbr_layer import pbr_layer
+
+
+def _norm(path: str) -> str:
+    return path.replace('/', '\\') if path else path
+
+
+@dataclass(frozen=True)
+class MaterialRule:
+    factory: Callable[[object, dict], object]
+    no_shadows: bool = False
+
+
+class MaterialRegistry:
+    def __init__(self) -> None:
+        self.by_template: Dict[str, MaterialRule] = {}
+
+    def register(self, templates: Iterable[str], rule: MaterialRule) -> None:
+        for t in templates:
+            self.by_template[_norm(t)] = rule
+
+    def resolve(self, template: str) -> MaterialRule | None:
+        return self.by_template.get(_norm(template))
+
+
+REGISTRY = MaterialRegistry()
+
+def _factory_bip(cls):
+    return lambda b, raw: cls(b.BasePath, b.image_format, b.ProjPath)
+
+def _factory_bi(cls):
+    return lambda b, raw: cls(b.BasePath, b.image_format)
+
+def _factory_bip_enablemask(cls):
+    return lambda b, raw: cls(b.BasePath, b.image_format, b.ProjPath, raw.get('EnableMask', False))
+
+
+# Multilayered group
+REGISTRY.register([
+    "engine\\materials\\multilayered.mt",
+    "base\\materials\\silverhand_overlay_blendable.mt",
+    "base\\materials\\silverhand_overlay.mt",
+    "base\\materials\\vehicle_destr_blendshape.mt",
+    "base\\materials\\multilayered_clear_coat.mt",
+    "base\\materials\\multilayered_terrain.mt",
+], MaterialRule(factory=_factory_bip(Multilayered)))
+
+# Mesh decals
+REGISTRY.register([
+    "base\\materials\\mesh_decal.mt",
+    "base\\materials\\mesh_decal_blendable.mt",
+    "base\\materials\\mesh_decal_wet_character.mt",
+], MaterialRule(factory=_factory_bip_enablemask(MeshDecal), no_shadows=True))
+
+REGISTRY.register([
+    "base\\materials\\mesh_decal_double_diffuse.mt",
+], MaterialRule(factory=_factory_bi(MeshDecalDoubleDiffuse), no_shadows=True))
+
+REGISTRY.register([
+    "base\\materials\\vehicle_mesh_decal.mt",
+], MaterialRule(factory=_factory_bip_enablemask(VehicleMeshDecal), no_shadows=True))
+
+# Vehicle lights
+REGISTRY.register([
+    "base\\materials\\vehicle_lights.mt",
+], MaterialRule(factory=_factory_bip(VehicleLights)))
+
+# Skin
+REGISTRY.register([
+    "base\\materials\\skin.mt",
+    "base\\materials\\skin_blendable.mt",
+], MaterialRule(factory=_factory_bip(Skin)))
+
+# Metal base
+REGISTRY.register([
+    "engine\\materials\\metal_base.remt",
+    "engine\\materials\\metal_base_blendable.mt",
+    "engine\\materials\\metal_base_proxy.mt",
+    "base\\materials\\metal_base_parallax.mt",
+    "base\\materials\\metal_base_gradientmap_recolor.mt",
+], MaterialRule(factory=_factory_bip_enablemask(MetalBase)))
+
+REGISTRY.register([
+    "base\\materials\\metal_base_det.mt",
+    "base\\materials\\lights_interactive.mt",
+], MaterialRule(factory=_factory_bip(MetalBaseDet)))
+
+# PBR layer
+REGISTRY.register([
+    "base\\materials\\pbr_layer.remt",
+], MaterialRule(factory=_factory_bip(pbr_layer)))
+
+# Hair
+REGISTRY.register([
+    "base\\materials\\hair.mt",
+    "base\\materials\\hair_blendable.mt",
+], MaterialRule(factory=_factory_bip(Hair)))
+
+# Mesh decal gradient map recolor
+REGISTRY.register([
+    "base\\materials\\mesh_decal_gradientmap_recolor.mt",
+    "base\\materials\\mesh_decal_gradientmap_recolor_blendable.mt",
+], MaterialRule(factory=_factory_bip(MeshDecalGradientMapReColor), no_shadows=True))
+
+# Eye
+REGISTRY.register([
+    "base\\materials\\eye.mt",
+    "base\\materials\\eye_blendable.mt",
+], MaterialRule(factory=_factory_bip(Eye)))
+
+# Eye gradient
+REGISTRY.register([
+    "base\\materials\\eye_gradient.mt",
+    "base\\materials\\eye_gradient_blendable.mt",
+], MaterialRule(factory=_factory_bip(EyeGradient)))
+
+# Eye shadow
+REGISTRY.register([
+    "base\\materials\\eye_shadow.mt",
+    "base\\materials\\eye_shadow_blendable.mt",
+], MaterialRule(factory=_factory_bip(EyeShadow)))
+
+# Mesh decal emissive
+REGISTRY.register([
+    "base\\materials\\mesh_decal_emissive.mt",
+], MaterialRule(factory=_factory_bip(MeshDecalEmissive), no_shadows=True))
+
+# Glass
+REGISTRY.register([
+    "base\\materials\\glass.mt",
+    "base\\materials\\vehicle_glass.mt",
+    "base\\materials\\glass_blendable.mt",
+    "base\\materials\\vehicle_glass_blendable.mt",
+], MaterialRule(factory=_factory_bip(Glass)))
+
+REGISTRY.register([
+    "base\\materials\\glass_deferred.mt",
+], MaterialRule(factory=_factory_bip(GlassDeferred)))
+
+REGISTRY.register([
+    "base\\materials\\glass_onesided.mt",
+    "base\\materials\\vehicle_glass_onesided.mt",
+], MaterialRule(factory=_factory_bip(Glass)))
+
+# Signages
+REGISTRY.register([
+    "base\\fx\\shaders\\signages.mt",
+], MaterialRule(factory=_factory_bip(Signages)))
+
+# Mesh decal parallax
+REGISTRY.register([
+    "base\\materials\\mesh_decal_parallax.mt",
+    "base\\materials\\vehicle_mesh_decal_parallax.mt",
+], MaterialRule(factory=_factory_bip(MeshDecalParallax), no_shadows=True))
+
+# Parallax screen
+REGISTRY.register([
+    "base\\fx\\shaders\\parallaxscreen.mt",
+], MaterialRule(factory=_factory_bip(ParallaxScreen)))
+
+REGISTRY.register([
+    "base\\fx\\shaders\\parallaxscreen_transparent.mt",
+], MaterialRule(factory=_factory_bip(ParallaxScreenTransparent)))
+
+# Speedtree
+REGISTRY.register([
+    "base\\materials\\speedtree_3d_v8_twosided.mt",
+    "base\\materials\\speedtree_3d_v8_onesided.mt",
+    "base\\materials\\speedtree_3d_v8_seams.mt",
+], MaterialRule(factory=_factory_bip(SpeedTree)))
+
+# Television Ad
+REGISTRY.register([
+    "base\\fx\\shaders\\television_ad.mt",
+], MaterialRule(factory=_factory_bip(TelevisionAd)))
+
+# Window parallax interior
+REGISTRY.register([
+    "base\\materials\\window_parallax_interior_proxy.mt",
+    "base\\materials\\window_parallax_interior.mt",
+], MaterialRule(factory=_factory_bip(windowParallaxIntProx)))
+
+# Hologram
+REGISTRY.register([
+    "base\\fx\\shaders\\hologram.mt",
+], MaterialRule(factory=_factory_bip(Hologram)))
+
+
+# Decal registry (baseMaterial path flow)
+DECAL_REGISTRY = MaterialRegistry()
+
+DECAL_REGISTRY.register([
+    "base\\materials\\decal.remt",
+    "base\\materials\\decal_roughness.mt",
+    "base\\materials\\decal_puddle.mt",
+    "base\\materials\\decal_normal_roughness_metalness.mt",
+    "base\\materials\\decal_normal_roughness.mt",
+    "base\\surfaces\\textures\\decals\\road_markings\\materials\\road_markings_white.mi",
+    "base\\materials\\decal_parallax.mt",
+    "base\\materials\\decal_normal.remt",
+    "base\\materials\\decal_normal_roughness_metalness_2.mt",
+    "base\\materials\\decal_terrain_projected.mt",
+], MaterialRule(factory=_factory_bi(Decal)))
+
+DECAL_REGISTRY.register([
+    "base\\materials\\decal_gradientmap_recolor.mt",
+], MaterialRule(factory=_factory_bip(DecalGradientmapRecolor)))
+
+

--- a/i_scene_cp77_gltf/main/material_registry.py
+++ b/i_scene_cp77_gltf/main/material_registry.py
@@ -76,6 +76,7 @@ REGISTRY.register([
     "base\\materials\\vehicle_destr_blendshape.mt",
     "base\\materials\\multilayered_clear_coat.mt",
     "base\\materials\\multilayered_terrain.mt",
+    "base\\materials\\cloth_tarps.mt"
 ], MaterialRule(factory=_factory_bip(Multilayered)))
 
 # Mesh decals

--- a/i_scene_cp77_gltf/main/setup.py
+++ b/i_scene_cp77_gltf/main/setup.py
@@ -32,6 +32,7 @@ from ..material_types.window_parallax_interior_proxy import windowParallaxIntPro
 from ..material_types.hologram import Hologram
 from ..material_types.unknown import unknownMaterial
 from ..material_types.pbr_layer import pbr_layer
+from .material_registry import REGISTRY, DECAL_REGISTRY
 
 class bcolors:
     HEADER = '\033[95m'
@@ -69,151 +70,19 @@ class MaterialBuilder:
             bpyMat.use_nodes = True
             no_shadows=False
             material_template = rawMat["MaterialTemplate"].replace('/','\\')
-            match material_template:
-                case "engine\\materials\\multilayered.mt" | "base\\materials\\vehicle_destr_blendshape.mt" | "base\\materials\\multilayered_clear_coat.mt" |  "base\\materials\\multilayered_terrain.mt":
-                    multilayered = Multilayered(self.BasePath,self.image_format,self.ProjPath)
-                    multilayered.create(rawMat["Data"],bpyMat)
-
-
-                #case  "base\\materials\\multilayered_terrain.mt":
-                 #   multilayeredTerrain = Multilayered(self.BasePath,self.image_format, self.ProjPath)
-                  #  multilayeredTerrain.create(rawMat["Data"],bpyMat)
-
-                # This material should be handled within the main multilayered.py file. Commenting this out for now in case I broke something - jato
-                #case "base\\materials\\multilayered_clear_coat.mt":
-                    #multilayered = MultilayeredClearCoat(self.BasePath,self.image_format)
-                    #multilayered.create(rawMat["Data"],bpyMat)
-
-                # This material should be handled within the main multilayered.py file. Commenting this out for now in case I broke something - jato
-                #case "base\\materials\\vehicle_destr_blendshape.mt":
-                    #vehicleDestrBlendshape = VehicleDestrBlendshape(self.BasePath, self.image_format)
-                    #vehicleDestrBlendshape.create(rawMat["Data"],bpyMat)
-
-                case "base\\materials\\mesh_decal.mt" | "base\\materials\\mesh_decal_wet_character.mt":
-                    if 'EnableMask' in rawMat.keys():
-                        enableMask=rawMat['EnableMask']
-                    else:
-                        enableMask=False
-                    no_shadows=True
-                    meshDecal = MeshDecal(self.BasePath, self.image_format, self.ProjPath,enableMask)
-                    meshDecal.create(rawMat["Data"],bpyMat)
-
-                case "base\\materials\\mesh_decal_double_diffuse.mt":
-                    no_shadows=True
-                    meshDecalDoubleDiffuse = MeshDecalDoubleDiffuse(self.BasePath, self.image_format)
-                    meshDecalDoubleDiffuse.create(rawMat["Data"],bpyMat)
-
-                case "base\\materials\\vehicle_mesh_decal.mt" :
-                    no_shadows=True
-                    if 'EnableMask' in rawMat.keys():
-                        enableMask=rawMat['EnableMask']
-                    else:
-                        enableMask=False
-                    vehicleMeshDecal = VehicleMeshDecal(self.BasePath, self.image_format, self.ProjPath, enableMask)
-                    vehicleMeshDecal.create(rawMat["Data"],bpyMat)
-
-                case "base\\materials\\vehicle_lights.mt":
-                    vehicleLights = VehicleLights(self.BasePath, self.image_format, self.ProjPath)
-                    vehicleLights.create(rawMat["Data"],bpyMat)
-
-                case "base\\materials\\skin.mt":
-                    skin = Skin(self.BasePath, self.image_format, self.ProjPath)
-                    skin.create(rawMat["Data"],bpyMat)
-
-                case "engine\\materials\\metal_base.remt" | "engine\\materials\\metal_base_proxy.mt" |\
-                    'base\\materials\\metal_base_parallax.mt' | 'base\materials\metal_base_gradientmap_recolor.mt':
-                    if 'EnableMask' in rawMat.keys():
-                        enableMask=rawMat['EnableMask']
-                    else:
-                        enableMask=False
-                    metalBase = MetalBase(self.BasePath,self.image_format, self.ProjPath, enableMask)
-                    metalBase.create(rawMat["Data"],bpyMat)
-
-                case "base\\materials\\metal_base_det.mt" | "base\materials\lights_interactive.mt":
-                    metalBaseDet = MetalBaseDet(self.BasePath,self.image_format, self.ProjPath)
-                    metalBaseDet.create(rawMat["Data"],bpyMat)
-
-                case "base\\materials\\pbr_layer.remt":
-                    pbrLayer = pbr_layer(self.BasePath,self.image_format, self.ProjPath)
-                    pbrLayer.create(rawMat["Data"],bpyMat)
-
-                case "base\\materials\\hair.mt":
-                    hair = Hair(self.BasePath,self.image_format, self.ProjPath)
-                    hair.create(rawMat["Data"],bpyMat)
-
-                case "base\\materials\\mesh_decal_gradientmap_recolor.mt":
-                    no_shadows=True
-                    meshDecalGradientMapReColor = MeshDecalGradientMapReColor(self.BasePath,self.image_format, self.ProjPath)
-                    meshDecalGradientMapReColor.create(rawMat["Data"],bpyMat)
-
-                case "base\\materials\\eye.mt":
-                    eye = Eye(self.BasePath,self.image_format, self.ProjPath)
-                    eye.create(rawMat["Data"],bpyMat)
-
-                case "base\\materials\\eye_gradient.mt":
-                    eyeGradient = EyeGradient(self.BasePath,self.image_format, self.ProjPath)
-                    eyeGradient.create(rawMat["Data"],bpyMat)
-
-                case "base\\materials\\eye_shadow.mt":
-                    eyeShadow = EyeShadow(self.BasePath,self.image_format, self.ProjPath)
-                    eyeShadow.create(rawMat["Data"],bpyMat)
-
-                case "base\\materials\\mesh_decal_emissive.mt" :
-                    no_shadows=True
-                    meshDecalEmissive = MeshDecalEmissive(self.BasePath,self.image_format, self.ProjPath)
-                    meshDecalEmissive.create(rawMat["Data"],bpyMat)
-
-                case "base\\materials\\glass.mt" | "base\\materials\\vehicle_glass.mt":
-                    glass = Glass(self.BasePath,self.image_format, self.ProjPath)
-                    glass.create(rawMat["Data"],bpyMat)
-
-                case "base\\materials\\glass_deferred.mt":
-                    glassdef = GlassDeferred(self.BasePath,self.image_format, self.ProjPath)
-                    glassdef.create(rawMat["Data"],bpyMat)
-
-                case "base\\fx\\shaders\\signages.mt" :
-                    signages= Signages(self.BasePath,self.image_format, self.ProjPath)
-                    signages.create(rawMat["Data"],bpyMat)
-
-                case "base\\materials\\glass_onesided.mt" | "base\\materials\\vehicle_glass_onesided.mt":
-                    glass = Glass(self.BasePath,self.image_format, self.ProjPath)
-                    glass.create(rawMat["Data"],bpyMat)
-
-                case "base\\materials\\mesh_decal_parallax.mt" | "base\\materials\\vehicle_mesh_decal_parallax.mt":
-                    no_shadows=True
-                    meshDecalParallax = MeshDecalParallax(self.BasePath,self.image_format, self.ProjPath)
-                    meshDecalParallax.create(rawMat["Data"],bpyMat)
-
-                case  "base\\fx\\shaders\\parallaxscreen.mt" :
-                    parallaxScreen = ParallaxScreen(self.BasePath,self.image_format,self.ProjPath)
-                    parallaxScreen.create(rawMat["Data"],bpyMat)
-
-                case  "base\\fx\\shaders\\parallaxscreen_transparent.mt" :
-                    parallaxScreenTransparent = ParallaxScreenTransparent(self.BasePath,self.image_format,self.ProjPath)
-                    parallaxScreenTransparent.create(rawMat["Data"],bpyMat)
-
-                case "base\\materials\\speedtree_3d_v8_twosided.mt" |  "base\\materials\\speedtree_3d_v8_onesided.mt" |  "base\\materials\\speedtree_3d_v8_seams.mt":
-                    speedtree = SpeedTree(self.BasePath,self.image_format, self.ProjPath)
-                    speedtree.create(rawMat["Data"],bpyMat)
-
-                case  "base\\fx\\shaders\\television_ad.mt" :
-                    televisionAd = TelevisionAd(self.BasePath,self.image_format,self.ProjPath)
-                    televisionAd.create(rawMat["Data"],bpyMat)
-
-                case "base\\materials\\window_parallax_interior_proxy.mt" | "base\\materials\\window_parallax_interior.mt":
-                    window = windowParallaxIntProx(self.BasePath,self.image_format,self.ProjPath)
-                    window.create(rawMat["Data"],bpyMat)
-
-                case  "base\\fx\\shaders\\hologram.mt" :
-                    hologram = Hologram(self.BasePath,self.image_format,self.ProjPath)
-                    hologram.create(rawMat["Data"],bpyMat)
-
-                case _:
-                    print(f'{bcolors.WARNING}Unhandled mt - ', rawMat["MaterialTemplate"])
-                    context=bpy.context
-                    if context.preferences.addons[__name__.split('.')[0]].preferences.experimental_features:
-                        unkown = unknownMaterial(self.BasePath,self.image_format,self.ProjPath)
-                        unkown.create(rawMat["Data"],bpyMat)
+            rule = REGISTRY.resolve(material_template)
+            if rule:
+                instance = rule.factory(self, rawMat)
+                instance.create(rawMat["Data"], bpyMat)
+                no_shadows = rule.no_shadows
+                bpyMat.blend_method='HASHED'
+                bpyMat['no_shadows']=no_shadows
+                return bpyMat
+            print(f'{bcolors.WARNING}Unhandled mt - ', rawMat["MaterialTemplate"])
+            context=bpy.context
+            if context.preferences.addons[__name__.split('.')[0]].preferences.experimental_features:
+                unkown = unknownMaterial(self.BasePath,self.image_format,self.ProjPath)
+                unkown.create(rawMat["Data"],bpyMat)
 
             #set the viewport blend mode to hashed - no more black tattoos and cybergear
             bpyMat.blend_method='HASHED'
@@ -231,20 +100,15 @@ class MaterialBuilder:
             bpyMat = bpy.data.materials.new(name)
             bpyMat.use_nodes = True
 
-            match self.obj["Data"]["RootChunk"]["baseMaterial"]["DepotPath"]['$value']:
-                case "base\\materials\\decal.remt" | "base\\materials\\decal_roughness.mt" | "base\\materials\\decal_puddle.mt" | "base\materials\decal_normal_roughness_metalness.mt":
-                    print('decal.remt')
-                    decal = Decal(self.BasePath,self.image_format)
-                    decal.create(self.obj["Data"]["RootChunk"],bpyMat)
+            base_path = self.obj["Data"]["RootChunk"]["baseMaterial"]["DepotPath"]['$value']
+            drule = DECAL_REGISTRY.resolve(base_path)
+            if drule:
+                instance = drule.factory(self, self.obj["Data"]["RootChunk"]) 
+                instance.create(self.obj["Data"]["RootChunk"], bpyMat)
+                bpyMat.blend_method='HASHED'
+                return bpyMat
 
-                case "base\\materials\\decal_gradientmap_recolor.mt":
-                    print('decal_gradientmap_recolor.mt')
-                    decalGradientMapRecolor = DecalGradientmapRecolor(self.BasePath,self.image_format, self.ProjPath)
-                    decalGradientMapRecolor.create(self.obj["Data"]["RootChunk"],bpyMat)
-
-
-                case _:
-                    print(self.obj["Data"]["RootChunk"]["baseMaterial"]["DepotPath"]['$value']," | unimplemented yet")
+            print(base_path, " | unimplemented yet")
 
             bpyMat.blend_method='HASHED'
             return bpyMat
@@ -260,22 +124,15 @@ class MaterialBuilder:
             bpyMat = bpy.data.materials.new(name)
             bpyMat.use_nodes = True
 
-            match self.obj["Data"]["RootChunk"]["baseMaterial"]["DepotPath"]['$value']:
-                case "base\\materials\\decal.remt" | "base\\materials\\decal_roughness.mt" | "base\\materials\\decal_puddle.mt" | "base\\materials\\decal_normal_roughness_metalness.mt"|  \
-                    'base\\materials\\decal_normal_roughness.mt' | 'base\\surfaces\\textures\\decals\\road_markings\\materials\\road_markings_white.mi' | 'base\\materials\\decal_parallax.mt' |  \
-                    'base\\materials\\decal_normal_roughness_metalness.mt' | 'base\\materials\\decal_normal_roughness_metalness_2.mt' | 'base\\materials\\decal_terrain_projected.mt' | 'base\\materials\\decal_normal.remt' :
-                    print('decal.remt')
-                    decal = Decal(self.BasePath,self.image_format)
-                    decal.create(self.obj["Data"]["RootChunk"],bpyMat)
+            base_path = self.obj["Data"]["RootChunk"]["baseMaterial"]["DepotPath"]['$value']
+            drule = DECAL_REGISTRY.resolve(base_path)
+            if drule:
+                instance = drule.factory(self, self.obj["Data"]["RootChunk"]) 
+                instance.create(self.obj["Data"]["RootChunk"], bpyMat)
+                bpyMat.blend_method='HASHED'
+                return bpyMat
 
-                case "base\\materials\\decal_gradientmap_recolor.mt":
-                    print('decal_gradientmap_recolor.mt')
-                    decalGradientMapRecolor = DecalGradientmapRecolor(self.BasePath,self.image_format, self.ProjPath)
-                    decalGradientMapRecolor.create(self.obj["Data"]["RootChunk"],bpyMat)
-
-
-                case _:
-                    print(self.obj["Data"]["RootChunk"]["baseMaterial"]["DepotPath"]['$value']," | unimplemented yet")
+            print(base_path, " | unimplemented yet")
 
             bpyMat.blend_method='HASHED'
             return bpyMat


### PR DESCRIPTION
Refactored the huge amount of case matching into a Material Registry.

this should imo make it easier to extend while also having some speed benefits.

(also contains some blendable materials previously not handled when importing silverhand)

