### PR TITLE
add support for decal_gradientmap_recolor_emissive

### DIFF
--- a/i_scene_cp77_gltf/main/material_registry.py
+++ b/i_scene_cp77_gltf/main/material_registry.py
@@ -21,6 +21,7 @@ from ..material_types.parallaxscreentransparent import ParallaxScreenTransparent
 from ..material_types.speedtree import SpeedTree
 from ..material_types.decal import Decal
 from ..material_types.decal_gradientmap_recolor import DecalGradientmapRecolor
+from ..material_types.decal_gradientmap_recolor_emissive import DecalGradientmapRecolorEmissive
 from ..material_types.televisionad import TelevisionAd
 from ..material_types.window_parallax_interior_proxy import windowParallaxIntProx
 from ..material_types.hologram import Hologram
@@ -234,5 +235,9 @@ DECAL_REGISTRY.register([
 DECAL_REGISTRY.register([
     "base\\materials\\decal_gradientmap_recolor.mt",
 ], MaterialRule(factory=_factory_bip(DecalGradientmapRecolor)))
+
+DECAL_REGISTRY.register([
+    "base\\materials\\decal_gradientmap_recolor_emissive.mt",
+], MaterialRule(factory=_factory_bip(DecalGradientmapRecolorEmissive)))
 
 

--- a/i_scene_cp77_gltf/material_types/decal_gradientmap_recolor_emissive.py
+++ b/i_scene_cp77_gltf/material_types/decal_gradientmap_recolor_emissive.py
@@ -1,0 +1,134 @@
+import bpy
+import os
+
+if __name__ != "__main__":
+    from ..main.common import *
+
+
+class DecalGradientmapRecolorEmissive:
+    def __init__(self, BasePath, image_format, ProjPath):
+        self.BasePath = BasePath
+        self.ProjPath = ProjPath
+        self.image_format = image_format
+
+    def found(self, tex):
+        result = os.path.exists(
+            os.path.join(self.BasePath, tex)[:-3] + self.image_format
+        )
+        if not result:
+            result = os.path.exists(
+                os.path.join(self.ProjPath, tex)[:-3] + self.image_format
+            )
+            if not result:
+                print(f"Texture not found: {tex}")
+        return result
+
+    def create(self, Data, Mat):
+        masktex = ""
+        difftex = ""
+        gradmap = ""
+        emissive_gradmap = ""
+        emissiveEV = 0
+        diffAsMask = 1
+        if "enableMask" in Data.keys():
+            if Data["enableMask"] == True:
+                diffAsMask = 0
+        for i in range(len(Data["values"])):
+            for value in Data["values"][i]:
+                if value == "DiffuseTexture":
+                    difftex = Data["values"][i]["DiffuseTexture"]["DepotPath"]["$value"]
+                if value == "GradientMap":
+                    gradmap = Data["values"][i]["GradientMap"]["DepotPath"]["$value"]
+                if value == "EmissiveGradientMap":
+                    emissive_gradmap = Data["values"][i]["EmissiveGradientMap"][
+                        "DepotPath"
+                    ]["$value"]
+                if value == "MaskTexture":
+                    masktex = Data["values"][i]["MaskTexture"]["DepotPath"]["$value"]
+                if value == "EmissiveEV":
+                    emissiveEV = Data["values"][i]["EmissiveEV"]
+        CurMat = Mat.node_tree
+        pBSDF = CurMat.nodes[loc("Principled BSDF")]
+        sockets = bsdf_socket_names()
+
+        if self.found(difftex) and self.found(gradmap):
+            diffImg = imageFromRelPath(
+                difftex,
+                self.image_format,
+                DepotPath=self.BasePath,
+                ProjPath=self.ProjPath,
+                isNormal=True,
+            )
+            diff_image_node = create_node(
+                CurMat.nodes,
+                "ShaderNodeTexImage",
+                (-800, -300),
+                label="DiffuseTexture",
+                image=diffImg,
+            )
+
+            gradImg = imageFromRelPath(
+                gradmap,
+                self.image_format,
+                DepotPath=self.BasePath,
+                ProjPath=self.ProjPath,
+            )
+            grad_image_node = create_node(
+                CurMat.nodes,
+                "ShaderNodeTexImage",
+                (-500, -200),
+                label="GradientMap",
+                image=gradImg,
+            )
+            CurMat.links.new(diff_image_node.outputs[0], grad_image_node.inputs[0])
+            CurMat.links.new(grad_image_node.outputs[0], pBSDF.inputs["Base Color"])
+            CurMat.links.new(grad_image_node.outputs[0], pBSDF.inputs[sockets["Emission"]])
+
+            if emissive_gradmap and self.found(emissive_gradmap):
+                emissiveGradImg = imageFromRelPath(
+                    emissive_gradmap,
+                    self.image_format,
+                    DepotPath=self.BasePath,
+                    ProjPath=self.ProjPath,
+                    isNormal=True,
+                )
+                emissive_grad_node = create_node(
+                    CurMat.nodes,
+                    "ShaderNodeTexImage",
+                    (-500, -500),
+                    label="EmissiveGradientMap",
+                    image=emissiveGradImg,
+                )
+                CurMat.links.new(diff_image_node.outputs[0], emissive_grad_node.inputs[0])
+                emissive_mult = create_node(
+                    CurMat.nodes, "ShaderNodeMath", (-300, -500), operation="MULTIPLY"
+                )
+                emissive_mult.inputs[1].default_value = emissiveEV
+                CurMat.links.new(emissive_grad_node.outputs[0], emissive_mult.inputs[0])
+                CurMat.links.new(emissive_mult.outputs[0], pBSDF.inputs["Emission Strength"])
+
+            if masktex and self.found(masktex):
+                maskImg = imageFromRelPath(
+                    masktex,
+                    self.image_format,
+                    DepotPath=self.BasePath,
+                    ProjPath=self.ProjPath,
+                    isNormal=True,
+                )
+                mask_image_node = create_node(
+                    CurMat.nodes,
+                    "ShaderNodeTexImage",
+                    (-800, -600),
+                    label="MaskTexture",
+                    image=maskImg,
+                )
+                alpha_mult = create_node(
+                    CurMat.nodes, "ShaderNodeMath", (-300, -350), operation="MULTIPLY"
+                )
+                CurMat.links.new(grad_image_node.outputs[1], alpha_mult.inputs[0])
+                CurMat.links.new(mask_image_node.outputs[0], alpha_mult.inputs[1])
+                CurMat.links.new(alpha_mult.outputs[0], pBSDF.inputs["Alpha"])
+            else:
+                CurMat.links.new(grad_image_node.outputs[1], pBSDF.inputs["Alpha"])
+        else:
+            pBSDF.inputs["Alpha"].default_value = 0


### PR DESCRIPTION
Adds support for the emissive variant of the gradient map recolor decal shader (`base\materials\decal_gradientmap_recolor_emissive.mt`) used for graffiti (eg `base\surfaces\textures\decals\graffiti\maelstrom\maelstrom_skull_17_emissive.mi` )

Two more parameters compared to decal_gradientmap_recolor.mt:
+ EmissiveGradientMap: grayscale gradient for emission intensity
+ EmissiveEV: Multiplier for emissive strength

<img width="2285" height="709" alt="image" src="https://github.com/user-attachments/assets/a151db92-faf3-4142-9e13-45e4c858a07c" />

Comparison
<img width="1818" height="789" alt="Group 4 (14)" src="https://github.com/user-attachments/assets/5eb0f4f3-c38b-4bbe-9eba-22cef0840ffc" />

maybe not quite there yet but open to suggestions, was just a quick thing while i was trying to make an emissive graffiti to make atleast something appear in blender


example blend also attached here
[decal_gradientmap_recolor_emissive.zip](https://github.com/user-attachments/files/24772375/decal_gradientmap_recolor_emissive.zip)
