### PR TITLE
importers: fix inconsistent casing of .Material.json filename

### DIFF
--- a/i_scene_cp77_gltf/importers/__init__.py
+++ b/i_scene_cp77_gltf/importers/__init__.py
@@ -446,7 +446,7 @@ def get_gltf_appearance_items(self, context):
     names = []
 
     base = os.path.splitext(self.filepath)[0]
-    material_json = base + ".material.json"
+    material_json = base + ".Material.json"
 
     if os.path.isfile(material_json):
         try:


### PR DESCRIPTION
This matters on case-sensitive filesystems like Linux. Without it, the import dialog will never recognise that there is a material file next to the mesh the user is trying to import.