### PR TITLE
Ent import corrections and optimizations

### DIFF
--- a/i_scene_cp77_gltf/__init__.py
+++ b/i_scene_cp77_gltf/__init__.py
@@ -18,7 +18,7 @@ from .main.common import exclusion_cache
 bl_info = {
     "name": "Cyberpunk 2077 IO Suite",
     "author": "HitmanHimself, Turk, Jato, dragonzkiller, kwekmaster, glitchered, Simarilius, Doctor Presto, shotlastc, Rudolph2109, Holopointz, Peatral, John CO., Chase_81, akikoe,  sprt_, Jazza, 86maylin",
-    "version": (2, 0, 0),
+    "version": (2, 1, 0),
     "blender": (5, 0, 0),
     "location": "File > Import-Export",
     "description": "Import and Export WolvenKit Cyberpunk2077 gLTF models with materials, Import .streamingsector and .ent from .json",

--- a/i_scene_cp77_gltf/datakrash.py
+++ b/i_scene_cp77_gltf/datakrash.py
@@ -1,0 +1,184 @@
+"""Fast cached file indexing and exact depot asset resolution."""
+
+import logging
+import os
+from typing import Dict, Iterable, List, Set
+
+_file_index_cache: Dict[str, Set[str]] = {}
+_cache_root = None
+_cache_extensions: Set[str] = set()
+_SKIP_DIRS = frozenset({'__pycache__', '.git', '.svn', 'node_modules', '.vscode', '.idea', 'archive', 'backup'})
+DEFAULT_ASSET_EXTENSIONS = (
+    '.app.json',
+    '.glb',
+    '.mesh.json',
+    '.anims.glb',
+    '.anims.json',
+    '.rig.json',
+    '.phys.json',
+)
+
+
+def _normalize_path(path: str) -> str:
+    return os.path.abspath(os.path.normpath(path)) if path else ''
+
+
+def _path_key(path: str) -> str:
+    return os.path.normcase(os.path.normpath(path)).replace('\\', '/') if path else ''
+
+
+def _local_ref(reference: str) -> str:
+    return reference.replace('\\', os.sep).replace('/', os.sep) if reference else ''
+
+
+def _extension_key(extension: str) -> str:
+    if not extension:
+        return ''
+    extension = extension.lower()
+    return extension if extension.startswith('.') else f'.{extension}'
+
+
+def _normalize_extensions(extensions: Iterable[str]) -> Set[str]:
+    return {_extension_key(ext) for ext in extensions if ext}
+
+
+def dataKrash_fast(root: str, extensions: List[str]) -> Dict[str, Set[str]]:
+    """Recursively index files by longest exact extension suffix using os.scandir."""
+    root = _normalize_path(root)
+    requested = _normalize_extensions(extensions)
+    ext_map = {ext: set() for ext in requested}
+    if not os.path.isdir(root):
+        logging.error("Root directory not found: %s", root)
+        return ext_map
+
+    norm_exts = tuple(sorted(requested, key=len, reverse=True))
+    stack = [root]
+
+    while stack:
+        folder = stack.pop()
+        try:
+            with os.scandir(folder) as entries:
+                for entry in entries:
+                    try:
+                        if entry.is_dir(follow_symlinks=False):
+                            if entry.name.lower() not in _SKIP_DIRS:
+                                stack.append(entry.path)
+                            continue
+                        if not entry.is_file(follow_symlinks=False):
+                            continue
+                        name_lower = entry.name.lower()
+                        for ext in norm_exts:
+                            if name_lower.endswith(ext):
+                                ext_map[ext].add(_normalize_path(entry.path))
+                                break
+                    except (PermissionError, OSError) as exc:
+                        logging.debug("Could not access %s: %s", entry.path, exc)
+        except (PermissionError, OSError) as exc:
+            logging.warning("Could not scan directory %s: %s", folder, exc)
+
+    return ext_map
+
+
+def dataKrash_cached(root: str, extensions: List[str], force_refresh: bool = False) -> Dict[str, Set[str]]:
+    """Return a cached recursive index for root, expanding when new suffixes are requested."""
+    global _file_index_cache, _cache_root, _cache_extensions
+
+    root = _normalize_path(root)
+    requested = _normalize_extensions(extensions)
+
+    if not force_refresh and _cache_root == root and _file_index_cache and requested.issubset(_cache_extensions):
+        return {ext: set(_file_index_cache.get(ext, set())) for ext in requested}
+
+    same_root = _cache_root == root
+    _cache_root = root
+    _cache_extensions = requested if force_refresh or not same_root else _cache_extensions.union(requested)
+    _file_index_cache = dataKrash_fast(root, sorted(_cache_extensions, key=len, reverse=True))
+    for ext in _cache_extensions:
+        _file_index_cache.setdefault(ext, set())
+    return {ext: set(_file_index_cache.get(ext, set())) for ext in requested}
+
+
+def clear_dataKrash_cache():
+    """Clear the global file index cache."""
+    global _file_index_cache, _cache_root, _cache_extensions
+    _file_index_cache = {}
+    _cache_root = None
+    _cache_extensions = set()
+
+
+def dataKrash(root: str, extensions: List[str]) -> Dict[str, Set[str]]:
+    """Uncached compatibility entrypoint for direct file indexing."""
+    return dataKrash_fast(root, extensions)
+
+
+class DepotAssetIndex:
+    """Indexed source/raw asset resolver with exact extension-bucket membership checks."""
+
+    def __init__(self, root: str, extensions: Iterable[str] = DEFAULT_ASSET_EXTENSIONS, force_refresh: bool = False, warn_missing: bool = True):
+        self.root = _normalize_path(root)
+        self.extensions = tuple(sorted(_normalize_extensions(extensions), key=len, reverse=True))
+        self.warn_missing = warn_missing
+        self.files_by_ext = dataKrash_cached(self.root, list(self.extensions), force_refresh=force_refresh)
+        for ext in self.extensions:
+            self.files_by_ext.setdefault(ext, set())
+        self._keys_by_ext = {
+            ext: {_path_key(path): path for path in paths}
+            for ext, paths in self.files_by_ext.items()
+        }
+
+    @classmethod
+    def cached(cls, root: str, extensions: Iterable[str] = DEFAULT_ASSET_EXTENSIONS, force_refresh: bool = False, warn_missing: bool = True):
+        return cls(root, extensions, force_refresh=force_refresh, warn_missing=warn_missing)
+
+    def get_files_by_extension(self, extension: str):
+        return sorted(self.files_by_ext.get(_extension_key(extension), set()))
+
+    def files(self, extension: str):
+        return self.get_files_by_extension(extension)
+
+    def contains(self, path: str, extension: str) -> bool:
+        ext = _extension_key(extension)
+        return _path_key(path) in self._keys_by_ext.get(ext, {})
+
+    def _candidate(self, reference: str) -> str:
+        local = _local_ref(reference)
+        if not local:
+            return ''
+        return _normalize_path(local if os.path.isabs(local) else os.path.join(self.root, local))
+
+    def resolve_expected(self, reference: str, expected_extension: str, warn=None):
+        ext = _extension_key(expected_extension)
+        candidate = self._candidate(reference)
+        if not candidate:
+            return None
+        resolved = self._keys_by_ext.get(ext, {}).get(_path_key(candidate))
+        if resolved:
+            return resolved
+        if self.warn_missing if warn is None else warn:
+            logging.warning("Expected %s path is not indexed and will be skipped: %s", ext, candidate)
+        return None
+
+    def resolve_app_json(self, depot_path: str):
+        return self.resolve_expected(f'{depot_path}.json', '.app.json')
+
+    def resolve_mesh_glb(self, depot_path: str):
+        if not depot_path:
+            return None
+        return self.resolve_expected(os.path.splitext(depot_path)[0] + '.glb', '.glb')
+
+    def resolve_mesh_json(self, depot_path: str):
+        return self.resolve_expected(f'{depot_path}.json', '.mesh.json')
+
+    def resolve_rig_json(self, depot_path: str):
+        return self.resolve_expected(f'{depot_path}.json', '.rig.json')
+
+    def resolve_anim_glb(self, depot_path: str):
+        return self.resolve_expected(f'{depot_path}.glb', '.anims.glb')
+
+    def resolve_anim_json(self, depot_path: str):
+        return self.resolve_expected(f'{depot_path}.json', '.anims.json')
+
+    def resolve_anim_json_from_glb(self, anim_glb_path: str):
+        if not anim_glb_path:
+            return None
+        return self.resolve_expected(os.path.splitext(anim_glb_path)[0] + '.json', '.anims.json')

--- a/i_scene_cp77_gltf/importers/entity_import.py
+++ b/i_scene_cp77_gltf/importers/entity_import.py
@@ -7,6 +7,7 @@ import bpy
 import time
 import math
 import traceback
+from functools import lru_cache
 from mathutils import Vector, Matrix , Quaternion
 from ..main.common import *
 from ..jsontool import JSONTool
@@ -22,6 +23,7 @@ _SUBMESH_INDEX_CACHE = {}
 ARMATURE_TYPE = 'ARMATURE'
 _RIG_ARMATURE_OBJECT_CACHE = {}
 _ARMATURE_BONE_SET_CACHE = {}
+_INVERSE_MATRIX_CACHE = {}
 FIXED_POINT_DIVISOR = 131072
 
 
@@ -39,19 +41,65 @@ def create_axes(ent_coll,name):
     return o
 
 
+def set_rotation_axis_cycles(obj, axis_no, delta_radians, end_frame):
+    start_value = obj.rotation_euler[axis_no]
+    end_value = start_value + delta_radians
+    anim_data = obj.animation_data_create()
+    action = bpy.data.actions.new(f'{obj.name}_rotation')
+    anim_data.action = action
+    fcurve = None
+    try:
+        fcurve = action.fcurves.new(data_path='rotation_euler', index=axis_no)
+        fcurve.keyframe_points.add(1)
+        keyframes = fcurve.keyframe_points
+        keyframes[0].co = (1, start_value)
+        keyframes[1].co = (end_frame, end_value)
+        for point in keyframes:
+            point.interpolation = 'LINEAR'
+        fcurve.update()
+    except Exception:
+        obj.keyframe_insert('rotation_euler', index=axis_no, frame=1)
+        obj.rotation_euler[axis_no] = end_value
+        obj.keyframe_insert('rotation_euler', index=axis_no, frame=end_frame)
+        if obj.animation_data and obj.animation_data.action:
+            obj_action = bpy.data.actions.get(obj.animation_data.action.name)
+            obj_slot = obj.animation_data.action_slot
+            channelbag = anim_utils.action_get_channelbag_for_slot(obj_action, obj_slot)
+            if channelbag and channelbag.fcurves:
+                fcurve = channelbag.fcurves[0]
+    if fcurve is not None:
+        modifier = fcurve.modifiers.new(type='CYCLES')
+        modifier.mode_before = 'REPEAT'
+        modifier.mode_after = 'REPEAT'
+        for point in fcurve.keyframe_points:
+            point.interpolation = 'LINEAR'
+    obj.rotation_euler[axis_no] = start_value
+
+
 def cname_value(value, default=''):
-    if isinstance(value, dict):
+    if type(value) is dict:
         return value.get('$value', default)
     return value if value is not None else default
 
 
+def get_dict_cname(component, key, default=''):
+    if type(component) is not dict:
+        return default
+    target = component.get(key)
+    if type(target) is dict:
+        return target.get('$value', default)
+    return target if target is not None else default
+
+
 def component_name(component, default=''):
-    return cname_value(component.get('name'), default) if isinstance(component, dict) else default
+    return get_dict_cname(component, 'name', default)
 
 
 def depot_path_value(component, key):
-    resource = component.get(key) if isinstance(component, dict) else None
-    if not isinstance(resource, dict):
+    if type(component) is not dict:
+        return ''
+    resource = component.get(key)
+    if type(resource) is not dict:
         return ''
     depot_path = resource.get('DepotPath')
     return cname_value(depot_path)
@@ -62,12 +110,11 @@ def mesh_component_depot(component):
 
 
 def mesh_appearance_value(component):
-    value = component.get('meshAppearance') if isinstance(component, dict) else None
-    return cname_value(value, 'default')
+    return get_dict_cname(component, 'meshAppearance', 'default')
 
 
 def red_quaternion(value):
-    if not isinstance(value, dict):
+    if type(value) is not dict:
         return Quaternion((1, 0, 0, 0))
     return Quaternion((
         value.get('r', 1),
@@ -77,33 +124,17 @@ def red_quaternion(value):
     ))
 
 
-def position_axis_value(data, fixed_key, float_key):
-    value = data.get(fixed_key) if isinstance(data, dict) else None
-    if isinstance(value, dict):
-        return value.get('Bits', 0) / FIXED_POINT_DIVISOR
-    return data.get(float_key, 0) if isinstance(data, dict) else 0
-
-
-def position_vector(data):
-    return Vector((
-        position_axis_value(data, 'x', 'X'),
-        position_axis_value(data, 'y', 'Y'),
-        position_axis_value(data, 'z', 'Z'),
-    ))
-
-
 def fixed_point_position(transform):
-    position = transform.get('Position', {}) if isinstance(transform, dict) else {}
-    return position_vector(position)
+    return vector_from_transform_position(transform, ('Position',))
 
 
 def component_local_transform(component):
-    transform = component.get('localTransform', {}) if isinstance(component, dict) else {}
+    transform = component.get('localTransform', {}) if type(component) is dict else {}
     return fixed_point_position(transform), red_quaternion(transform.get('Orientation'))
 
 
 def is_component_enabled(component):
-    return component.get('isEnabled', 1) != 0 if isinstance(component, dict) else True
+    return component.get('isEnabled', 1) != 0 if type(component) is dict else True
 
 
 def depot_to_local_path(root, depot_path):
@@ -117,6 +148,7 @@ def depot_to_glb_path(root, depot_path):
     return os.path.splitext(local_path)[0] + '.glb'
 
 
+@lru_cache(maxsize=65536)
 def norm_path_key(value):
     return os.path.normcase(os.path.normpath(value)) if value else ''
 
@@ -267,24 +299,28 @@ def resolve_requested_appearance_name(app_name, ent_default, ent_apps, by_appear
 
 
 def resolve_ent_app(app_name, ent_apps, by_appearance, by_name, ent_default=None):
-    ent_app_idx = by_appearance.get(app_name, -1)
-    if ent_app_idx >= 0:
-        print('appearance matched, id = ', ent_app_idx)
-        return ent_app_idx, app_name
-    ent_app_idx = by_name.get(app_name, -1)
-    if ent_app_idx >= 0:
-        print('appearance matched, id = ', ent_app_idx)
-        return ent_app_idx, cname_value(ent_apps[ent_app_idx].get('appearanceName'), app_name)
-    if app_name != 'default':
-        return 0, cname_value(ent_apps[0].get('appearanceName'), app_name) if ent_apps else app_name
-    ent_app_idx = by_name.get(ent_default, -1)
-    if ent_app_idx >= 0:
-        print('appearance matched, id = ', ent_app_idx)
-        return ent_app_idx, cname_value(ent_apps[ent_app_idx].get('appearanceName'), app_name)
-    ent_app_idx = by_appearance.get(ent_default, -1)
-    if ent_app_idx >= 0:
-        print('appearance matched, id = ', ent_app_idx)
-        return ent_app_idx, cname_value(ent_apps[ent_app_idx].get('appearanceName'), app_name)
+    candidates = []
+    if app_name and app_name != 'default':
+        candidates.append((app_name, app_name))
+    if ent_default and ent_default != 'default' and ent_default != 'None':
+        candidates.append((ent_default, app_name))
+
+    seen = set()
+    for search_term, fallback_name in candidates:
+        if search_term in seen:
+            continue
+        seen.add(search_term)
+
+        ent_app_idx = by_appearance.get(search_term, -1)
+        if ent_app_idx >= 0:
+            print('appearance matched, id = ', ent_app_idx)
+            return ent_app_idx, cname_value(ent_apps[ent_app_idx].get('appearanceName'), fallback_name)
+
+        ent_app_idx = by_name.get(search_term, -1)
+        if ent_app_idx >= 0:
+            print('appearance matched, id = ', ent_app_idx)
+            return ent_app_idx, cname_value(ent_apps[ent_app_idx].get('appearanceName'), fallback_name)
+
     return 0, cname_value(ent_apps[0].get('appearanceName'), app_name) if ent_apps else app_name
 
 
@@ -307,13 +343,94 @@ def build_skinning_lookup(chunks):
     return build_chunk_lookup(chunks, 'skinning')
 
 
+def build_shape_lookup(chunks):
+    return build_chunk_lookup(chunks, 'shape')
+
+
+def light_channel_shape_data(component, shape_lookup):
+    resolved = resolve_handle_data(component, shape_lookup, 'shape')
+    if isinstance(resolved, dict):
+        return resolved
+    shape = component.get('shape') if type(component) is dict else None
+    if not isinstance(shape, dict):
+        return None
+    inline = shape.get('Data')
+    if isinstance(inline, dict):
+        return inline
+    if 'vertices' in shape or 'indices' in shape or 'faces' in shape:
+        return shape
+    return None
+
+
+def light_channel_geometry(component, shape_lookup):
+    shape = light_channel_shape_data(component, shape_lookup)
+    if not isinstance(shape, dict):
+        return None, None
+    vertices = shape.get('vertices')
+    indices = shape.get('indices') or shape.get('faces')
+    if not vertices or not indices:
+        return None, None
+    return vertices, indices
+
+
+def light_channel_has_inline_geometry(component):
+    shape = component.get('shape') if type(component) is dict else None
+    if not isinstance(shape, dict):
+        return False
+    inline = shape.get('Data') if isinstance(shape.get('Data'), dict) else shape
+    return bool(isinstance(inline, dict) and inline.get('vertices') and (inline.get('indices') or inline.get('faces')))
+
+
+def collect_light_channel_components(*component_groups):
+    collected = {}
+    order = []
+    for components in component_groups:
+        for source in components or ():
+            if not isinstance(source, dict) or source.get('$type') != 'entLightChannelComponent':
+                continue
+            key = component_name(source) or str(id(source))
+            if key not in collected:
+                collected[key] = source
+                order.append(key)
+            elif not light_channel_has_inline_geometry(collected[key]) and light_channel_has_inline_geometry(source):
+                collected[key] = source
+    return [collected[key] for key in order]
+
+
+def create_light_channel_mesh(component, shape_lookup, filepath):
+    vertices, indices = light_channel_geometry(component, shape_lookup)
+    if not vertices or not indices:
+        return None
+    name = component_name(component) or 'LightChannel'
+    mesh_data = bpy.data.meshes.new(name)
+    verts = [(v.get('X', 0), v.get('Y', 0), v.get('Z', 0)) for v in vertices]
+    if indices and isinstance(indices[0], (list, tuple)):
+        faces = [list(face[:3]) for face in indices if len(face) >= 3]
+    else:
+        faces = [indices[i:i + 3] for i in range(0, len(indices), 3) if len(indices[i:i + 3]) == 3]
+    mesh_data.from_pydata(verts, [], faces)
+    mesh_data.update()
+
+    obj = bpy.data.objects.new(name, mesh_data)
+    obj.display_type = 'WIRE'
+    obj.color = (0.005, 0.79105, 1, 1)
+    obj.show_wire = True
+    obj.show_in_front = True
+    obj.display.show_shadows = False
+    obj.rotation_mode = 'QUATERNION'
+    obj['ntype'] = 'entLightChannelComponent'
+    obj['name'] = name
+    obj['entJSON'] = filepath
+    return obj
+
+
 class ComponentHandleLookup:
     def __init__(self, default_lookup=None):
         self.default_lookup = default_lookup or {}
         self.by_component_id = {}
 
     def set_component_lookup(self, component, lookup):
-        if isinstance(component, dict):
+        if type(component) is dict:
             self.by_component_id[id(component)] = lookup or {}
 
     def get_for_component(self, component, handle_id):
@@ -370,7 +487,7 @@ def build_rig_bone_index(rig_j):
 
 
 def rig_bone_index_for(rig_j):
-    if not isinstance(rig_j, dict):
+    if not type(rig_j) is dict:
         return {}
     cache_key = id(rig_j)
     index = _RIG_BONE_INDEX_CACHE.get(cache_key)
@@ -381,7 +498,7 @@ def rig_bone_index_for(rig_j):
 
 
 def rig_json_bone_matrix(rig_j, bone_name, rig_bone_index=None):
-    if not isinstance(rig_j, dict) or not bone_name:
+    if not type(rig_j) is dict or not bone_name:
         return Matrix.Identity(4)
     rig_id = id(rig_j)
     matrices = _RIG_BONE_MATRIX_CACHE.get(rig_id)
@@ -398,7 +515,7 @@ def rig_json_bone_matrix(rig_j, bone_name, rig_bone_index=None):
     for key in ('aPoseMS', 'boneTransforms', 'aPoseLS'):
         transforms = rig_j.get(key)
         if isinstance(transforms, list) and index < len(transforms):
-            matrices[bone_name] = qs_transform_matrix(transforms[index])
+            matrices[bone_name] = transform_dict_matrix(transforms[index])
             return matrices[bone_name]
     matrices[bone_name] = Matrix.Identity(4)
     return matrices[bone_name]
@@ -409,13 +526,13 @@ def build_slot_owner_rig_jsons(components, parent_transform_lookup, rig_json_by_
     if not components or not rig_json_by_component_name:
         return slot_owner_rig_jsons
     for component in components:
-        if not isinstance(component, dict) or component.get('$type') != 'entSlotComponent':
+        if not type(component) is dict or component.get('$type') != 'entSlotComponent':
             continue
         owner_name = component_name(component)
         if not owner_name:
             continue
         binding = parent_transform_data(component, parent_transform_lookup)
-        bind_name = cname_value(binding.get('bindName')) if isinstance(binding, dict) else ''
+        bind_name = cname_value(binding.get('bindName')) if type(binding) is dict else ''
         rig_json = rig_json_by_component_name.get(bind_name)
         if rig_json is not None:
             slot_owner_rig_jsons[owner_name] = rig_json
@@ -427,13 +544,13 @@ def build_slot_owner_rig_owner_names(components, parent_transform_lookup, rig_co
     if not components or not rig_component_names:
         return slot_owner_rig_owner_names
     for component in components:
-        if not isinstance(component, dict) or component.get('$type') != 'entSlotComponent':
+        if not type(component) is dict or component.get('$type') != 'entSlotComponent':
             continue
         owner_name = component_name(component)
         if not owner_name:
             continue
         binding = parent_transform_data(component, parent_transform_lookup)
-        bind_name = cname_value(binding.get('bindName')) if isinstance(binding, dict) else ''
+        bind_name = cname_value(binding.get('bindName')) if type(binding) is dict else ''
         if bind_name in rig_component_names:
             slot_owner_rig_owner_names[owner_name] = bind_name
     return slot_owner_rig_owner_names
@@ -457,10 +574,10 @@ def is_excluded_mesh(depot_path, meshpath, meshname, excluded_meshes):
 
 
 def red_scale(transform, visual_scale=None):
-    scale = transform.get('Scale') or transform.get('scale') if isinstance(transform, dict) else None
-    if not isinstance(scale, dict) and isinstance(visual_scale, dict):
+    scale = transform.get('Scale') or transform.get('scale') if type(transform) is dict else None
+    if type(scale) is not dict and type(visual_scale) is dict:
         scale = visual_scale
-    if not isinstance(scale, dict):
+    if type(scale) is not dict:
         return Vector((1, 1, 1))
     return Vector((
         scale.get('X', 1),
@@ -470,88 +587,65 @@ def red_scale(transform, visual_scale=None):
 
 
 def vector_from_transform_position(transform, keys):
-    if not isinstance(transform, dict):
+    if type(transform) is not dict:
         return Vector((0, 0, 0))
     for key in keys:
         data = transform.get(key)
-        if isinstance(data, dict):
-            return position_vector(data)
+        if type(data) is not dict:
+            continue
+        x = data.get('x')
+        y = data.get('y')
+        z = data.get('z')
+        return Vector((
+            x.get('Bits', 0) / FIXED_POINT_DIVISOR if type(x) is dict else data.get('X', 0),
+            y.get('Bits', 0) / FIXED_POINT_DIVISOR if type(y) is dict else data.get('Y', 0),
+            z.get('Bits', 0) / FIXED_POINT_DIVISOR if type(z) is dict else data.get('Z', 0),
+        ))
     return Vector((0, 0, 0))
 
 
 def first_transform_value(transform, keys):
-    if not isinstance(transform, dict):
+    if type(transform) is not dict:
         return {}
     for key in keys:
         value = transform.get(key)
-        if isinstance(value, dict):
+        if type(value) is dict:
             return value
     return {}
 
 
-def transform_dict_matrix(transform, pos_keys=('Position', 'Translation', 'relativePosition'), rot_keys=('Orientation', 'Rotation', 'relativeRotation'), scale=None):
-    if not isinstance(transform, dict):
+def transform_dict_matrix(transform, pos_keys=('Position', 'Translation', 'relativePosition'), rot_keys=('Orientation', 'Rotation', 'relativeRotation'), scale=None, visual_scale=None):
+    if type(transform) is not dict:
         return Matrix.Identity(4)
     return Matrix.LocRotScale(
         vector_from_transform_position(transform, pos_keys),
         red_quaternion(first_transform_value(transform, rot_keys)),
-        scale if scale is not None else red_scale(transform),
-    )
-
-
-def red_transform_matrix(transform, visual_scale=None):
-    if not isinstance(transform, dict):
-        return Matrix.Identity(4)
-    return transform_dict_matrix(
-        transform,
-        ('Position',),
-        ('Orientation',),
-        red_scale(transform, visual_scale),
-    )
-
-
-def slot_transform_matrix(slot):
-    return transform_dict_matrix(
-        slot,
-        ('relativePosition',),
-        ('relativeRotation',),
-        Vector((1, 1, 1)),
+        scale if scale is not None else red_scale(transform, visual_scale),
     )
 
 
 def slot_translation_matrix(slot):
-    if not isinstance(slot, dict):
+    if type(slot) is not dict:
         return Matrix.Identity(4)
     return Matrix.Translation(vector_from_transform_position(slot, ('relativePosition',)))
 
 
-def qs_transform_matrix(transform):
-    return transform_dict_matrix(
-        transform,
-        ('Translation', 'Position'),
-        ('Rotation', 'Orientation'),
-        red_scale(transform),
-    )
-
-
-def resolve_handle_data(component, lookup, key, fallback_to_inline=False):
-    data = component.get(key) if isinstance(component, dict) else None
-    if not isinstance(data, dict):
+def resolve_handle_data(component, lookup, key):
+    data = component.get(key) if type(component) is dict else None
+    if type(data) is not dict:
         return None
-    if isinstance(data.get('Data'), dict):
+    if type(data.get('Data')) is dict:
         return data.get('Data')
 
     handle_id = data.get('HandleRefId')
     if handle_id is None:
-        return data if fallback_to_inline else None
+        return None
 
     if hasattr(lookup, 'get_for_component'):
         referenced = lookup.get_for_component(component, handle_id)
     else:
         referenced = lookup.get(handle_id) if lookup else None
-    if isinstance(referenced, dict):
-        return referenced.get('Data')
-    return data if fallback_to_inline else None
+    return referenced.get('Data') if type(referenced) is dict else None
 
 
 def parent_transform_data(component, parent_transform_lookup):
@@ -559,7 +653,11 @@ def parent_transform_data(component, parent_transform_lookup):
 
 
 def skinning_binding_data(component, skinning_lookup=None):
-    return resolve_handle_data(component, skinning_lookup, 'skinning', fallback_to_inline=True)
+    resolved = resolve_handle_data(component, skinning_lookup, 'skinning')
+    if resolved is not None:
+        return resolved
+    skinning = component.get('skinning') if type(component) is dict else None
+    return skinning if isinstance(skinning, dict) and 'Data' not in skinning else None
 
 
 def skinning_bind_name(component, skinning_lookup=None):
@@ -608,13 +706,20 @@ def imported_armatures_from_selection():
 
 
 def child_of_inverse_matrix(target, subtarget_name=''):
+    cache_key = (id(target), subtarget_name or '')
+    cached = _INVERSE_MATRIX_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
     target_matrix = target.matrix_world.copy()
-    if subtarget_name and getattr(target, 'pose', None) and subtarget_name in target.pose.bones:
+    if armature_has_bone(target, subtarget_name):
         target_matrix = target.matrix_world @ target.pose.bones[subtarget_name].matrix
     try:
-        return target_matrix.inverted()
+        inverse = target_matrix.inverted()
     except Exception:
-        return Matrix.Identity(4)
+        inverse = Matrix.Identity(4)
+    _INVERSE_MATRIX_CACHE[cache_key] = inverse
+    return inverse
 
 
 def set_child_of_inverse(constraint, target, subtarget_name=''):
@@ -743,7 +848,7 @@ def bind_skinned_objects_to_rig(objects, rig):
 def build_slot_component_lookups(components):
     lookups = {}
     for component in components or []:
-        slots = component.get('slots') if isinstance(component, dict) else None
+        slots = component.get('slots') if type(component) is dict else None
         name = component_name(component)
         if name and isinstance(slots, list):
             lookups[name] = build_slot_lookup(slots)
@@ -751,12 +856,12 @@ def build_slot_component_lookups(components):
 
 
 class EntityTransformResolver:
-    def __init__(self, components, parent_transform_lookup, skinning_lookup=None, rig=None, rig_j=None, rig_bone_index=None, default_slot_lookup=None, slot_owner_rig_jsons=None, rig_json_by_component_name=None, armature_by_component_name=None, slot_owner_rig_owner_names=None):
+    def __init__(self, components, parent_transform_lookup, skinning_lookup=None, rig=None, rig_j=None, rig_bone_index=None, default_slot_lookup=None, slot_owner_rig_jsons=None, rig_json_by_component_name=None, armature_by_component_name=None, slot_owner_rig_owner_names=None, components_by_name=None, slot_component_lookups=None):
         self.components = components or []
-        self.components_by_name = build_component_lookup(self.components)
+        self.components_by_name = components_by_name if components_by_name is not None else build_component_lookup(self.components)
         self.parent_transform_lookup = parent_transform_lookup or {}
         self.skinning_lookup = skinning_lookup or {}
-        self.slot_component_lookups = build_slot_component_lookups(self.components)
+        self.slot_component_lookups = slot_component_lookups if slot_component_lookups is not None else build_slot_component_lookups(self.components)
         self.rig = rig
         self.rig_j = rig_j
         self.rig_bone_index = rig_bone_index or build_rig_bone_index(rig_j)
@@ -765,7 +870,7 @@ class EntityTransformResolver:
         self.armature_by_component_name = armature_by_component_name or {}
         self.slot_owner_rig_owner_names = slot_owner_rig_owner_names or {}
         self.rig_json_bone_indices = {id(rig_json): build_rig_bone_index(rig_json) for rig_json in self.rig_json_by_component_name.values() if isinstance(rig_json, dict)}
-        if isinstance(self.rig_j, dict):
+        if type(self.rig_j) is dict:
             self.rig_json_bone_indices[id(self.rig_j)] = self.rig_bone_index
         self.default_slot_lookup = default_slot_lookup or {}
         self.cache = {}
@@ -776,8 +881,16 @@ class EntityTransformResolver:
         self.bone_matrix_cache = {}
         self.bone_rotation_cache = {}
         self.bone_head_cache = {}
+        self.bone_transform_data_cache = {}
         self.rig_space_bone_matrix_cache = {}
         self.rig_json_for_bone_cache = {}
+        self.slot_cache = {}
+        self.binding_target_cache = {}
+        self.slot_component_is_animated_child_cache = {}
+        self.animated_base_slot_cache = {}
+        self.slot_primary_bone_cache = {}
+        self.rig_bone_translation_matrix_cache = {}
+        self.rig_bone_yaw_matrix_cache = {}
         self.resolving = set()
 
     def _slot_owner_rig_json(self, slot_owner=None):
@@ -798,15 +911,15 @@ class EntityTransformResolver:
         matrix = self.local_matrix_cache.get(key)
         if matrix is None:
             if transform is None:
-                transform = component.get('localTransform', {}) if isinstance(component, dict) else {}
-            if visual_scale is None and isinstance(component, dict):
+                transform = component.get('localTransform', {}) if type(component) is dict else {}
+            if visual_scale is None and type(component) is dict:
                 visual_scale = component.get('visualScale')
-            matrix = red_transform_matrix(transform, visual_scale)
+            matrix = transform_dict_matrix(transform, visual_scale=visual_scale)
             self.local_matrix_cache[key] = matrix
         return matrix
 
     def _rig_json_index(self, rig_j):
-        if not isinstance(rig_j, dict):
+        if not type(rig_j) is dict:
             return {}
         index = self.rig_json_bone_indices.get(id(rig_j))
         if index is None:
@@ -865,22 +978,37 @@ class EntityTransformResolver:
             return armature, armature.pose.bones[bone_name]
         return None, None
 
-    def bone_matrix(self, bone_name, slot_owner=None):
+    def _bone_transform_data(self, bone_name, slot_owner=None):
         cache_key = (bone_name, slot_owner)
-        cached = self.bone_matrix_cache.get(cache_key)
+        cached = self.bone_transform_data_cache.get(cache_key)
         if cached is not None:
             return cached
+
         armature, pose_bone = self._pose_bone(bone_name, slot_owner)
         if pose_bone is not None:
             matrix = armature.matrix_world @ pose_bone.matrix
+            rotation = pose_bone.rotation_quaternion.copy()
+            head = pose_bone.head.copy()
         else:
             rig_j = self._rig_json_for_bone(bone_name, slot_owner)
             if self._rig_json_has_bone(bone_name, rig_j):
                 matrix = rig_json_bone_matrix(rig_j, bone_name, self._rig_json_index(rig_j))
+                rotation = matrix.to_quaternion()
+                head = matrix.to_translation()
             else:
                 matrix = Matrix.Identity(4)
+                rotation = Quaternion((1, 0, 0, 0))
+                head = Vector((0, 0, 0))
+
+        result = (matrix, rotation, head)
+        self.bone_transform_data_cache[cache_key] = result
         self.bone_matrix_cache[cache_key] = matrix
-        return matrix
+        self.bone_rotation_cache[cache_key] = rotation
+        self.bone_head_cache[cache_key] = head
+        return result
+
+    def bone_matrix(self, bone_name, slot_owner=None):
+        return self._bone_transform_data(bone_name, slot_owner)[0]
 
     def resolve_slot_matrix(self, slot_owner, slot_name):
         cache_key = (slot_owner, slot_name)
@@ -892,44 +1020,107 @@ class EntityTransformResolver:
             result = (Matrix.Identity(4), slot_owner, slot_name)
         else:
             bone_name = cname_value(slot.get('boneName'), slot_name)
-            result = (self.bone_matrix(bone_name, slot_owner) @ slot_transform_matrix(slot), bone_name, slot_name)
+            result = (self.bone_matrix(bone_name, slot_owner) @ transform_dict_matrix(slot), bone_name, slot_name)
         self.slot_matrix_cache[cache_key] = result
         return result
 
-    def resolve_binding(self, component):
-        binding = self._binding_data(component)
-        if not isinstance(binding, dict):
-            return Matrix.Identity(4), '', '', 'none'
-
-        bind_name = cname_value(binding.get('bindName'))
-        slot_name = cname_value(binding.get('slotName'))
+    def _get_binding_target(self, bind_name):
+        cached = self.binding_target_cache.get(bind_name)
+        if cached is not None:
+            return cached
         if not bind_name or bind_name == 'None':
+            target = 'none'
+        elif bind_name in ('vehicle_slots', 'slots'):
+            target = 'slot'
+        elif bind_name == 'deformation_rig':
+            target = 'deformation_rig'
+        elif bind_name in self.components_by_name:
+            target = 'component'
+        elif armature_has_bone(self.rig, bind_name):
+            target = 'bone'
+        else:
+            target = 'unresolved'
+        self.binding_target_cache[bind_name] = target
+        return target
+
+    def _resolve_parent_target(self, bind_name, slot_name, is_hard=False, component=None):
+        target_type = self._get_binding_target(bind_name)
+        if target_type == 'none':
             return Matrix.Identity(4), bind_name, slot_name, 'none'
 
-        if bind_name in ('vehicle_slots', 'slots'):
-            matrix, bone_name, slot_name = self.resolve_slot_matrix(bind_name, slot_name)
-            return matrix, bone_name, slot_name, 'slot'
-
-        if bind_name == 'deformation_rig':
+        if target_type == 'deformation_rig':
             base = self.rig.matrix_world.copy() if self.rig else Matrix.Identity(4)
             return base, bind_name, slot_name, 'deformation_rig'
 
-        if bind_name in self.components_by_name:
-            bound_component = self.components_by_name[bind_name]
-            if component_uses_skinning(component, self.skinning_lookup) and self._component_is_rig_owner(bound_component):
-                base = self.rig.matrix_world.copy() if self.rig else Matrix.Identity(4)
-                return base, bind_name, slot_name, 'skinning_root'
-            parent_matrix, _, _, _ = self.resolve_component_matrix(bound_component)
-            if slot_name and slot_name != 'None':
-                slot_lookup = self.slot_component_lookups.get(bind_name)
-                if slot_lookup and slot_name in slot_lookup:
-                    return parent_matrix @ slot_transform_matrix(slot_lookup[slot_name]), bind_name, slot_name, 'component_slot'
-            return parent_matrix, bind_name, slot_name, 'component'
+        if target_type == 'bone':
+            if is_hard and component is not None:
+                local_transform = component.get('localTransform', {}) if type(component) is dict else {}
+                visual_scale = component.get('visualScale') if type(component) is dict else None
+                matrix = self._hard_bone_slot_matrix(bind_name, bind_name, slot_name, local_transform, visual_scale)
+            else:
+                matrix = self.bone_matrix(bind_name)
+            return matrix, bind_name, slot_name, 'bone'
 
-        if self.rig and getattr(self.rig, 'pose', None) and bind_name in self.rig.pose.bones:
-            return self.bone_matrix(bind_name), bind_name, slot_name, 'bone'
+        if target_type == 'slot':
+            if is_hard and component is not None:
+                bone_name = self._slot_bone_name(bind_name, slot_name)
+                local_transform = component.get('localTransform', {}) if type(component) is dict else {}
+                visual_scale = component.get('visualScale') if type(component) is dict else None
+                matrix = self._hard_bone_slot_matrix(bone_name, bind_name, slot_name, local_transform, visual_scale)
+                return matrix, bone_name, slot_name, 'slot'
+            matrix, bone_name, resolved_slot = self.resolve_slot_matrix(bind_name, slot_name)
+            return matrix, bone_name, resolved_slot, 'slot'
+
+        if target_type == 'component':
+            bound_component = self.components_by_name[bind_name]
+            if not is_hard:
+                if component_uses_skinning(component, self.skinning_lookup) and self._component_is_rig_owner(bound_component):
+                    base = self.rig.matrix_world.copy() if self.rig else Matrix.Identity(4)
+                    return base, bind_name, slot_name, 'skinning_root'
+                parent_matrix, _, _, _ = self.resolve_component_matrix(bound_component)
+                if slot_name and slot_name != 'None':
+                    slot_lookup = self.slot_component_lookups.get(bind_name)
+                    if slot_lookup and slot_name in slot_lookup:
+                        return parent_matrix @ transform_dict_matrix(slot_lookup[slot_name]), bind_name, slot_name, 'component_slot'
+                return parent_matrix, bind_name, slot_name, 'component'
+
+            parent_matrix, parent_bind, parent_slot, parent_type = self.resolve_hard_component_matrix(bound_component)
+            if slot_name and slot_name != 'None':
+                slot = self._slot(bind_name, slot_name)
+                if slot:
+                    bound_is_animated_child = self._slot_component_is_animated_child(bound_component)
+                    skip_animated_base_slot = bind_name == 'base' and slot_name == 'base' and bound_is_animated_child
+                    animated_parent_name = self._binding_name(bound_component) if bound_is_animated_child else ''
+                    animated_base_slot = self._animated_base_slot(animated_parent_name) if animated_parent_name else None
+                    bone_name = cname_value(slot.get('boneName'), slot_name)
+                    if animated_parent_name and type(animated_base_slot) is not dict:
+                        animated_parent = self.components_by_name.get(animated_parent_name)
+                        animated_parent_matrix = Matrix.Identity(4)
+                        if animated_parent is not None:
+                            animated_parent_matrix, _, _, _ = self.resolve_hard_component_matrix(animated_parent)
+                        parent_matrix = (
+                            animated_parent_matrix
+                            @ self._rig_bone_translation_matrix(bone_name)
+                            @ self._rig_bone_yaw_matrix(bone_name)
+                            @ slot_translation_matrix(slot)
+                        )
+                        parent_bind = bone_name or parent_bind or bind_name
+                        parent_slot = slot_name
+                        parent_type = 'slot'
+                    elif not skip_animated_base_slot:
+                        parent_matrix = parent_matrix @ transform_dict_matrix(slot)
+                        parent_type = 'component_slot'
+            return parent_matrix, parent_bind or bind_name, parent_slot or slot_name, parent_type if parent_type != 'none' else 'component'
 
         return Matrix.Identity(4), bind_name, slot_name, 'unresolved'
+
+    def resolve_binding(self, component):
+        binding = self._binding_data(component)
+        if type(binding) is not dict:
+            return Matrix.Identity(4), '', '', 'none'
+        bind_name = cname_value(binding.get('bindName'))
+        slot_name = cname_value(binding.get('slotName'))
+        return self._resolve_parent_target(bind_name, slot_name, is_hard=False, component=component)
 
     def resolve_component_matrix(self, component):
         key = ('component', id(component))
@@ -947,38 +1138,10 @@ class EntityTransformResolver:
         return result
 
     def _bone_rotation(self, bone_name, slot_owner=None):
-        cache_key = (bone_name, slot_owner)
-        cached = self.bone_rotation_cache.get(cache_key)
-        if cached is not None:
-            return cached
-        _, pose_bone = self._pose_bone(bone_name, slot_owner)
-        if pose_bone is not None:
-            rotation = pose_bone.rotation_quaternion.copy()
-        else:
-            rig_j = self._rig_json_for_bone(bone_name, slot_owner)
-            if self._rig_json_has_bone(bone_name, rig_j):
-                rotation = rig_json_bone_matrix(rig_j, bone_name, self._rig_json_index(rig_j)).to_quaternion()
-            else:
-                rotation = Quaternion((1, 0, 0, 0))
-        self.bone_rotation_cache[cache_key] = rotation
-        return rotation
+        return self._bone_transform_data(bone_name, slot_owner)[1]
 
     def _bone_head(self, bone_name, slot_owner=None):
-        cache_key = (bone_name, slot_owner)
-        cached = self.bone_head_cache.get(cache_key)
-        if cached is not None:
-            return cached
-        _, pose_bone = self._pose_bone(bone_name, slot_owner)
-        if pose_bone is not None:
-            head = pose_bone.head.copy()
-        else:
-            rig_j = self._rig_json_for_bone(bone_name, slot_owner)
-            if self._rig_json_has_bone(bone_name, rig_j):
-                head = rig_json_bone_matrix(rig_j, bone_name, self._rig_json_index(rig_j)).to_translation()
-            else:
-                head = Vector((0, 0, 0))
-        self.bone_head_cache[cache_key] = head
-        return head
+        return self._bone_transform_data(bone_name, slot_owner)[2]
 
     def _rig_bone_index(self, bone_name):
         if not bone_name:
@@ -991,19 +1154,19 @@ class EntityTransformResolver:
             return cached
         index = self._rig_bone_index(bone_name)
         if index is None:
-            if self.rig and getattr(self.rig, 'pose', None) and bone_name in self.rig.pose.bones:
+            if armature_has_bone(self.rig, bone_name):
                 matrix = self.rig.pose.bones[bone_name].matrix.copy()
             else:
                 matrix = Matrix.Identity(4)
             self.rig_space_bone_matrix_cache[bone_name] = matrix
             return matrix
         for key in ('aPoseMS', 'boneTransforms', 'aPoseLS'):
-            transforms = self.rig_j.get(key) if isinstance(self.rig_j, dict) else None
+            transforms = self.rig_j.get(key) if type(self.rig_j) is dict else None
             if isinstance(transforms, list) and index < len(transforms):
-                matrix = qs_transform_matrix(transforms[index])
+                matrix = transform_dict_matrix(transforms[index])
                 self.rig_space_bone_matrix_cache[bone_name] = matrix
                 return matrix
-        if self.rig and getattr(self.rig, 'pose', None) and bone_name in self.rig.pose.bones:
+        if armature_has_bone(self.rig, bone_name):
             matrix = self.rig.pose.bones[bone_name].matrix.copy()
         else:
             matrix = Matrix.Identity(4)
@@ -1031,22 +1194,37 @@ class EntityTransformResolver:
     def _rig_bone_translation_matrix(self, bone_name):
         if not bone_name or bone_name == 'None':
             return Matrix.Identity(4)
-        return Matrix.Translation(self._rig_space_bone_matrix(bone_name).to_translation())
+        cached = self.rig_bone_translation_matrix_cache.get(bone_name)
+        if cached is not None:
+            return cached
+        matrix = Matrix.Translation(self._rig_space_bone_matrix(bone_name).to_translation())
+        self.rig_bone_translation_matrix_cache[bone_name] = matrix
+        return matrix
 
     def _rig_bone_yaw_matrix(self, bone_name):
         if not bone_name or bone_name == 'None':
             return Matrix.Identity(4)
+        cached = self.rig_bone_yaw_matrix_cache.get(bone_name)
+        if cached is not None:
+            return cached
         try:
             yaw = self._rig_space_bone_matrix(bone_name).to_euler().z
         except Exception:
             yaw = 0
-        return Matrix.Rotation(yaw, 4, 'Z')
+        matrix = Matrix.Rotation(yaw, 4, 'Z')
+        self.rig_bone_yaw_matrix_cache[bone_name] = matrix
+        return matrix
 
     def _slot(self, owner, slot_name):
+        cache_key = (owner, slot_name)
+        if cache_key in self.slot_cache:
+            return self.slot_cache[cache_key]
         slot_lookup = self.slot_component_lookups.get(owner)
         if not slot_lookup and owner in ('vehicle_slots', 'slots'):
             slot_lookup = self.default_slot_lookup
-        return slot_lookup.get(slot_name) if slot_lookup else None
+        slot = slot_lookup.get(slot_name) if slot_lookup else None
+        self.slot_cache[cache_key] = slot
+        return slot
 
     def _slot_bone_name(self, owner, slot_name):
         slot = self._slot(owner, slot_name)
@@ -1056,43 +1234,59 @@ class EntityTransformResolver:
 
     def _binding_name(self, component):
         binding = self._binding_data(component)
-        return cname_value(binding.get('bindName')) if isinstance(binding, dict) else ''
+        return cname_value(binding.get('bindName')) if type(binding) is dict else ''
 
     def _component_is_rig_owner(self, component):
-        return isinstance(component, dict) and bool(depot_path_value(component, 'rig'))
+        return type(component) is dict and bool(depot_path_value(component, 'rig'))
 
     def _slot_component_is_animated_child(self, component):
+        cache_key = id(component)
+        cached = self.slot_component_is_animated_child_cache.get(cache_key)
+        if cached is not None:
+            return cached
         parent_name = self._binding_name(component)
         parent = self.components_by_name.get(parent_name)
-        return bool(parent_name and self._component_is_rig_owner(parent))
+        result = bool(parent_name and self._component_is_rig_owner(parent))
+        self.slot_component_is_animated_child_cache[cache_key] = result
+        return result
 
     def _animated_base_slot(self, animated_component_name):
+        if animated_component_name in self.animated_base_slot_cache:
+            return self.animated_base_slot_cache[animated_component_name]
         for slot_owner in self.components:
-            if not isinstance(slot_owner, dict) or slot_owner.get('$type') != 'entSlotComponent':
+            if type(slot_owner) is not dict or slot_owner.get('$type') != 'entSlotComponent':
                 continue
             if self._binding_name(slot_owner) != animated_component_name:
                 continue
             slots = slot_owner.get('slots')
-            if not isinstance(slots, list):
+            if type(slots) is not list:
                 continue
             for slot in slots:
                 slot_name = cname_value(slot.get('slotName'))
                 bone_name = cname_value(slot.get('boneName'))
                 if slot_name == 'base' or bone_name == 'base':
+                    self.animated_base_slot_cache[animated_component_name] = slot
                     return slot
+        self.animated_base_slot_cache[animated_component_name] = None
         return None
 
     def _animated_base_slot_matrix(self, animated_component_name):
-        return slot_transform_matrix(self._animated_base_slot(animated_component_name))
+        return transform_dict_matrix(self._animated_base_slot(animated_component_name))
 
     def _slot_component_primary_bone(self, component):
-        slots = component.get('slots') if isinstance(component, dict) else None
-        if not isinstance(slots, list):
+        cache_key = id(component)
+        if cache_key in self.slot_primary_bone_cache:
+            return self.slot_primary_bone_cache[cache_key]
+        slots = component.get('slots') if type(component) is dict else None
+        if type(slots) is not list:
+            self.slot_primary_bone_cache[cache_key] = None
             return None
         for slot in slots:
             bone_name = cname_value(slot.get('boneName'))
             if bone_name and bone_name != 'None':
+                self.slot_primary_bone_cache[cache_key] = bone_name
                 return bone_name
+        self.slot_primary_bone_cache[cache_key] = None
         return None
 
     def _animated_slot_component_basis(self, component):
@@ -1116,23 +1310,18 @@ class EntityTransformResolver:
         slot = self._slot(slot_owner, slot_name)
         slot_pos = Vector((0, 0, 0))
         slot_rot = Quaternion((1, 0, 0, 0))
-        if slot:
-            slot_pos_data = slot.get('relativePosition') if isinstance(slot.get('relativePosition'), dict) else {}
-            slot_pos = Vector((
-                slot_pos_data.get('X', 0),
-                slot_pos_data.get('Y', 0),
-                slot_pos_data.get('Z', 0),
-            ))
+        if type(slot) is dict:
+            slot_pos = vector_from_transform_position(slot, ('relativePosition',))
             slot_rot = red_quaternion(slot.get('relativeRotation'))
 
+        bone_matrix, bone_rotation, bone_head = self._bone_transform_data(bone_name, slot_owner)
         local_pos = fixed_point_position(local_transform)
         if bone_name and bone_name != 'Base':
-            z_ang = self.bone_matrix(bone_name, slot_owner).to_euler().z
-            local_pos = Matrix.Rotation(z_ang, 4, 'Z') @ local_pos
+            local_pos = Matrix.Rotation(bone_matrix.to_euler().z, 4, 'Z') @ local_pos
 
-        rotation = self._bone_rotation(bone_name, slot_owner) @ slot_rot @ red_quaternion(local_transform.get('Orientation'))
+        rotation = bone_rotation @ slot_rot @ red_quaternion(local_transform.get('Orientation'))
         scale = red_scale(local_transform, visual_scale)
-        return Matrix.LocRotScale(self._bone_head(bone_name, slot_owner) + slot_pos + local_pos, rotation, scale)
+        return Matrix.LocRotScale(bone_head + slot_pos + local_pos, rotation, scale)
 
     def resolve_hard_component_matrix(self, component):
         key = ('hard', id(component))
@@ -1142,16 +1331,17 @@ class EntityTransformResolver:
             return Matrix.Identity(4), '', '', 'cycle'
         self.resolving.add(key)
 
-        local_transform = component.get('localTransform', {}) if isinstance(component, dict) else {}
-        visual_scale = component.get('visualScale') if isinstance(component, dict) else None
+        local_transform = component.get('localTransform', {}) if type(component) is dict else {}
+        visual_scale = component.get('visualScale') if type(component) is dict else None
         animated_slot_basis = self._animated_slot_component_basis(component)
         if animated_slot_basis is not None:
             result = (animated_slot_basis @ self._local_matrix(component, local_transform, visual_scale), self._binding_name(component), '', 'animated_slot_component')
             self.cache[key] = result
             self.resolving.remove(key)
             return result
+
         binding = self._binding_data(component)
-        if not isinstance(binding, dict):
+        if type(binding) is not dict:
             result = (self._local_matrix(component, local_transform, visual_scale), '', '', 'none')
             self.cache[key] = result
             self.resolving.remove(key)
@@ -1159,69 +1349,14 @@ class EntityTransformResolver:
 
         bind_name = cname_value(binding.get('bindName'))
         slot_name = cname_value(binding.get('slotName'))
-        if not bind_name or bind_name == 'None':
-            result = (self._local_matrix(component, local_transform, visual_scale), bind_name, slot_name, 'none')
-            self.cache[key] = result
-            self.resolving.remove(key)
-            return result
+        target_type = self._get_binding_target(bind_name)
+        parent_matrix, res_bind, res_slot, res_type = self._resolve_parent_target(bind_name, slot_name, is_hard=True, component=component)
 
-        if bind_name in ('vehicle_slots', 'slots'):
-            bone_name = self._slot_bone_name(bind_name, slot_name)
-            result = (self._hard_bone_slot_matrix(bone_name, bind_name, slot_name, local_transform, visual_scale), bone_name, slot_name, 'slot')
-            self.cache[key] = result
-            self.resolving.remove(key)
-            return result
+        if target_type in {'bone', 'slot'}:
+            result = (parent_matrix, res_bind, res_slot, res_type)
+        else:
+            result = (parent_matrix @ self._local_matrix(component, local_transform, visual_scale), res_bind, res_slot, res_type)
 
-        if bind_name == 'deformation_rig':
-            base = self.rig.matrix_world.copy() if self.rig else Matrix.Identity(4)
-            result = (base @ self._local_matrix(component, local_transform, visual_scale), bind_name, slot_name, 'deformation_rig')
-            self.cache[key] = result
-            self.resolving.remove(key)
-            return result
-
-        if bind_name in self.components_by_name:
-            bound_component = self.components_by_name[bind_name]
-            parent_matrix, parent_bind, parent_slot, parent_type = self.resolve_hard_component_matrix(bound_component)
-            if slot_name and slot_name != 'None':
-                slot = self._slot(bind_name, slot_name)
-                if slot:
-                    skip_animated_base_slot = (
-                        bind_name == 'base'
-                        and slot_name == 'base'
-                        and self._slot_component_is_animated_child(bound_component)
-                    )
-                    animated_parent_name = self._binding_name(bound_component) if self._slot_component_is_animated_child(bound_component) else ''
-                    animated_base_slot = self._animated_base_slot(animated_parent_name) if animated_parent_name else None
-                    bone_name = cname_value(slot.get('boneName'), slot_name)
-                    if animated_parent_name and not isinstance(animated_base_slot, dict):
-                        animated_parent = self.components_by_name.get(animated_parent_name)
-                        animated_parent_matrix = Matrix.Identity(4)
-                        if animated_parent is not None:
-                            animated_parent_matrix, _, _, _ = self.resolve_hard_component_matrix(animated_parent)
-                        parent_matrix = (
-                            animated_parent_matrix
-                            @ self._rig_bone_translation_matrix(bone_name)
-                            @ self._rig_bone_yaw_matrix(bone_name)
-                            @ slot_translation_matrix(slot)
-                        )
-                        parent_bind = bone_name or parent_bind or bind_name
-                        parent_slot = slot_name
-                        parent_type = 'slot'
-                    elif not skip_animated_base_slot:
-                        parent_matrix = parent_matrix @ slot_transform_matrix(slot)
-                        parent_type = 'component_slot'
-            result = (parent_matrix @ self._local_matrix(component, local_transform, visual_scale), parent_bind or bind_name, parent_slot or slot_name, parent_type if parent_type != 'none' else 'component')
-            self.cache[key] = result
-            self.resolving.remove(key)
-            return result
-
-        if self.rig and getattr(self.rig, 'pose', None) and bind_name in self.rig.pose.bones:
-            result = (self._hard_bone_slot_matrix(bind_name, bind_name, slot_name, local_transform, visual_scale), bind_name, slot_name, 'bone')
-            self.cache[key] = result
-            self.resolving.remove(key)
-            return result
-
-        result = (self._local_matrix(component, local_transform, visual_scale), bind_name, slot_name, 'unresolved')
         self.cache[key] = result
         self.resolving.remove(key)
         return result
@@ -1247,6 +1382,7 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
     C = bpy.context
     coll_scene = C.scene.collection
     start_time = time.time()
+    _INVERSE_MATRIX_CACHE.clear()
 
     path, after = split_source_raw_root(filepath)
     asset_index = build_asset_index(path)
@@ -1263,13 +1399,19 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
             print(f"Importing appearance: {', '.join(appearances)} from entity: {ent_name}")
         else:
             print(f"Importing appearance: {appearances} from entity: {ent_name}")
-    if filepath is not None:
-        ent_apps, ent_components, ent_component_data, res, ent_default = JSONTool.jsonload(filepath, error_messages)
+    parsed_ent = JSONTool.load_entity(filepath, error_messages) if filepath is not None else None
+    if parsed_ent is None:
+        return {'CANCELLED'}
 
-    ent_applist=[cname_value(app.get('appearanceName')) for app in ent_apps]
-    ent_app_index_by_name = {name: index for index, name in enumerate(ent_applist) if name}
-    ent_app_by_appearance, ent_app_by_name = build_ent_app_lookup(ent_apps)
-    ent_default = normalize_default_appearance(ent_default, ent_apps, ent_app_by_appearance, ent_app_by_name, filepath)
+    ent_apps = parsed_ent.appearances
+    ent_components = parsed_ent.component_dicts
+    ent_component_data = parsed_ent.component_data
+    res = parsed_ent.resolved_dependencies
+    ent_default = parsed_ent.default_appearance
+    ent_applist = parsed_ent.appearance_names
+    ent_app_index_by_name = parsed_ent.appearance_index_by_name
+    ent_app_by_appearance = parsed_ent.appearances_by_appearance
+    ent_app_by_name = parsed_ent.appearances_by_name
 
     if len(ent_applist) == 0:
         print(f"No appearances found in entity file {ent_name}. Imported objects may be incomplete or missing.")
@@ -1304,27 +1446,15 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
 
 
     #presto_stash.append(ent_components)
-    ent_complist=[]
-    ent_rigs=[]
-    ent_colliderComps=[]
-    ent_simpleCollComps=[]
-    chassis_info=[]
-    for comp in ent_components:
-        comp_name = component_name(comp)
-        if comp_name:
-            ent_complist.append(comp['name'])
-        rig_depot = depot_path_value(comp, 'rig')
-        if rig_depot:
-            print(f"Rig found in entity: {rig_depot}")
-            ent_rigs.append(depot_to_local_path(path, rig_depot))
-        if comp_name == 'Chassis':
-            chassis_info = comp
-    for comp in ent_component_data:
-        comp_type = comp.get('$type')
-        if comp_type == 'entColliderComponent':
-            ent_colliderComps.append(comp)
-        if comp_type == 'entSimpleColliderComponent':
-            ent_simpleCollComps.append(comp)
+    ent_complist = [component.name for component in parsed_ent.parsed_components if component.name]
+    ent_rigs = []
+    for component in parsed_ent.parsed_components:
+        if component.rig_depot:
+            print(f"Rig found in entity: {component.rig_depot}")
+            ent_rigs.append(depot_to_local_path(path, component.rig_depot))
+    ent_colliderComps = parsed_ent.collider_components
+    ent_simpleCollComps = parsed_ent.simple_collider_components
+    chassis_info = parsed_ent.components_by_name.get('Chassis', [])
     #print('collider components:', ent_colliderComps)
     #print('simple collider components:', ent_simpleCollComps)
     #    presto_stash.append(ent_rigs)
@@ -1337,6 +1467,8 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
         if depot_value:
             resolved.append(depot_to_local_path(path, depot_value))
 
+    ent_rig_keys = {norm_path_key(rig_path) for rig_path in ent_rigs}
+
     # if no apps requested populate the list with all available.
 
     if len(appearances[0])==0 or appearances[0].upper()=='ALL':
@@ -1346,13 +1478,9 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
     if len(appearances)==0:
         appearances.append('BASE_COMPONENTS_ONLY')
 
-    VS=[]
-    vehicle_slots=None
-    for x in ent_components:
-        if component_name(x) in ('vehicle_slots', 'slots'):
-            VS.append(x)
-    if len(VS)>0:
-        vehicle_slots= VS[0]['slots']
+    initial_vehicle_slot_component = parsed_ent.vehicle_slot_component
+    vehicle_slot_component_ids = {id(initial_vehicle_slot_component)} if initial_vehicle_slot_component else set()
+    vehicle_slots = initial_vehicle_slot_component.get('slots') if initial_vehicle_slot_component else None
     vehicle_slot_lookup = build_slot_lookup(vehicle_slots)
 
     # Discover exported resources from the indexed source/raw tree.
@@ -1379,7 +1507,6 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
         print('no anim rig found')
     else:
         resolved_keys = {norm_path_key(resolved_path) for resolved_path in resolved}
-        ent_rig_keys = {norm_path_key(rig_path) for rig_path in ent_rigs}
         animsinres=[x for x in anim_files if norm_path_key(os.path.splitext(x)[0]) in resolved_keys]
         if len(animsinres)==0:
             for anim in anim_files:
@@ -1417,7 +1544,6 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
     if len(rigjsons)==0 or len(ent_rigs)==0:
         print('no rig json loaded')
     else:
-        ent_rig_keys = {norm_path_key(rig_path) for rig_path in ent_rigs}
         entrigjsons=[x for x in rigjsons if norm_path_key(x[:-5]) in ent_rig_keys]
         if len(entrigjsons)>0:
             for entrig in entrigjsons:
@@ -1484,8 +1610,18 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
         app_comps={}
         ent_chunks={}
         app_json_cache={}
+        parsed_app_cache={}
         app_lookup={}
+        app_bundle_lookup={}
         component_mesh_info_cache = {}
+        ent_component_ids = parsed_ent.component_ids
+        ent_component_data_ids = parsed_ent.component_data_ids
+        ent_parent_transform_lookup = parsed_ent.parent_transform_lookup
+        ent_skinning_lookup = parsed_ent.skinning_lookup
+        ent_shape_lookup = parsed_ent.shape_lookup
+        base_components_by_id = parsed_ent.components_by_id
+        base_components_by_name = parsed_ent.components_by_name
+        base_slot_component_lookups = parsed_ent.slot_component_lookups
 
         def component_mesh_info(component):
             cache_key = id(component)
@@ -1504,6 +1640,17 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
             component_mesh_info_cache[cache_key] = cached
             return cached
 
+        master_group_objects_cache = {}
+
+        def master_group_objects(group):
+            cache_key = id(group)
+            cached = master_group_objects_cache.get(cache_key)
+            if cached is None:
+                cached = tuple(group.all_objects)
+                master_group_objects_cache[cache_key] = cached
+            return cached
+
+
         for x,requested_app_name in enumerate(appearances):
             app_name = resolve_requested_appearance_name(requested_app_name, ent_default, ent_apps, ent_app_by_appearance, ent_app_by_name)
             app_comps[requested_app_name]=[]
@@ -1516,36 +1663,35 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
 
                 app_file = ent_apps[ent_app_idx]['appearanceResource']['DepotPath']['$value']
                 appfilepath=resolve_app_json_path(asset_index, app_file)
-                a_j=None
+                parsed_app = None
                 if not appfilepath:
                     print('app file not found -', depot_to_local_path(path, app_file) + '.json')
                 else:
-                    if appfilepath not in app_json_cache:
-                        app_json_cache[appfilepath]=JSONTool.jsonload(appfilepath, error_messages)
-                    a_j=app_json_cache.get(appfilepath)
-                    if a_j is not None:
-                        apps=a_j['Data']['RootChunk']['appearances']
-
-                        app_idx=0
-                        app_definition_by_name = {cname_value(a.get('Data', {}).get('name')): i for i, a in enumerate(apps) if isinstance(a, dict)}
-                        matched_app_idx = app_definition_by_name.get(app_name)
-                        if matched_app_idx is not None:
-                            app_idx=matched_app_idx
-                            print('appearance matched, id = ',app_idx)
-                        chunks=None
-                        app_data = a_j['Data']['RootChunk']['appearances'][app_idx].get('Data')
-                        if app_data:
-                            if app_data.get('components'):
-                                app_comps[requested_app_name]= ent_components+app_data['components']
-                                if app_name != requested_app_name:
-                                    app_comps[app_name]=app_comps[requested_app_name]
-                            compiled_data = app_data.get('compiledData')
-                            if compiled_data and compiled_data.get('Data', {}).get('Chunks'):
-                                chunks= compiled_data['Data']['Chunks']
-                                ent_chunks[requested_app_name]=chunks
-                                if app_name != requested_app_name:
-                                    ent_chunks[app_name]=chunks
-                                print('Chunks found')
+                    parsed_app = parsed_app_cache.get(appfilepath)
+                    if parsed_app is None:
+                        parsed_app = JSONTool.load_app(appfilepath, error_messages)
+                        parsed_app_cache[appfilepath] = parsed_app
+                    if parsed_app is not None:
+                        app_idx = parsed_app.appearances_by_name.get(app_name, 0)
+                        parsed_app_name = app_name
+                        if app_name in parsed_app.appearances_by_name:
+                            print('appearance matched, id = ', app_idx)
+                        elif parsed_app.appearance_names:
+                            parsed_app_name = parsed_app.appearance_names[app_idx]
+                        app_components = parsed_app.components_by_appearance_name.get(parsed_app_name, [])
+                        if app_components:
+                            app_comps[requested_app_name] = ent_components + app_components
+                            if app_name != requested_app_name:
+                                app_comps[app_name] = app_comps[requested_app_name]
+                        chunks = parsed_app.chunks_by_appearance_name.get(parsed_app_name)
+                        app_bundle_lookup[requested_app_name] = (parsed_app, parsed_app_name)
+                        if app_name != requested_app_name:
+                            app_bundle_lookup[app_name] = (parsed_app, parsed_app_name)
+                        if chunks:
+                            ent_chunks[requested_app_name] = chunks
+                            if app_name != requested_app_name:
+                                ent_chunks[app_name] = chunks
+                            print('Chunks found')
 
 
             if len(app_comps[requested_app_name])==0:
@@ -1591,10 +1737,12 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
                 coll_scene.children.link(ent_coll)
             # tag it with some custom properties.
             ent_coll['depotPath']=after
+            app_bundle = app_bundle_lookup.get(requested_app_name) or app_bundle_lookup.get(app_name)
             if len(ent_apps)==0 and ent_component_data:
                 chunks= ent_component_data
             elif len(ent_apps)>0:
                 ent_app_idx, app_name = resolve_ent_app(app_name, ent_apps, ent_app_by_appearance, ent_app_by_name, ent_default)
+                app_bundle = app_bundle_lookup.get(requested_app_name) or app_bundle_lookup.get(app_name) or app_bundle
             if not chunks:
                 chunks=ent_chunks.get(requested_app_name) or ent_chunks.get(app_name) or ent_component_data
 
@@ -1602,21 +1750,32 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
             ent_coll['appearanceIndex'] = ent_app_index_by_name.get(app_name, 0)
 
             comps=app_comps.get(requested_app_name) or app_comps.get(app_name) or ent_components
-            transform_components = list({id(comp): comp for comp in list(ent_components) + list(comps)}.values())
-            ent_component_ids = {id(comp) for comp in ent_components}
-            ent_parent_transform_lookup = build_parent_transform_lookup(ent_component_data)
-            app_parent_transform_lookup = build_parent_transform_lookup(chunks)
+            transform_components_by_id = dict(base_components_by_id)
+            for comp in comps:
+                transform_components_by_id[id(comp)] = comp
+            transform_components = list(transform_components_by_id.values())
+            if app_bundle:
+                parsed_app, parsed_app_name = app_bundle
+                app_parent_transform_lookup = parsed_app.parent_transform_lookup_by_appearance_name.get(parsed_app_name, {})
+                app_skinning_lookup = parsed_app.skinning_lookup_by_appearance_name.get(parsed_app_name, {})
+                app_shape_lookup = parsed_app.shape_lookup_by_appearance_name.get(parsed_app_name, {})
+                app_light_channels = parsed_app.light_channels_by_appearance_name.get(parsed_app_name, [])
+            else:
+                app_parent_transform_lookup = build_parent_transform_lookup(chunks)
+                app_skinning_lookup = build_skinning_lookup(chunks)
+                app_shape_lookup = build_shape_lookup(chunks)
+                app_light_channels = []
             parent_transform_lookup = ComponentHandleLookup(app_parent_transform_lookup)
-            ent_skinning_lookup = build_skinning_lookup(ent_component_data)
-            app_skinning_lookup = build_skinning_lookup(chunks)
             skinning_lookup = ComponentHandleLookup(app_skinning_lookup)
+            shape_lookup = ComponentHandleLookup(app_shape_lookup)
+            set_parent_lookup = parent_transform_lookup.set_component_lookup
+            set_skinning_lookup = skinning_lookup.set_component_lookup
+            set_shape_lookup = shape_lookup.set_component_lookup
             for comp in transform_components:
                 if id(comp) in ent_component_ids:
-                    parent_transform_lookup.set_component_lookup(comp, ent_parent_transform_lookup)
-                    skinning_lookup.set_component_lookup(comp, ent_skinning_lookup)
-                else:
-                    parent_transform_lookup.set_component_lookup(comp, app_parent_transform_lookup)
-                    skinning_lookup.set_component_lookup(comp, app_skinning_lookup)
+                    set_parent_lookup(comp, ent_parent_transform_lookup)
+                    set_skinning_lookup(comp, ent_skinning_lookup)
+                    set_shape_lookup(comp, ent_shape_lookup)
                 rig_depot = depot_path_value(comp, 'rig')
                 rig_name = component_name(comp)
                 if rig_depot and rig_name:
@@ -1628,10 +1787,15 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
             slot_owner_rig_owner_names = build_slot_owner_rig_owner_names(transform_components, parent_transform_lookup, rig_component_names)
             anim_impl_lookup = build_anim_impl_lookup(chunks)
 
+            if not vehicle_slots:
+                slot_component = next((c for c in comps if component_name(c) in ('vehicle_slots', 'slot', 'slots') and id(c) not in vehicle_slot_component_ids), None)
+                if slot_component is not None:
+                    vehicle_slot_component_ids.add(id(slot_component))
+                    vehicle_slots = slot_component.get('slots')
+                    vehicle_slot_lookup = build_slot_lookup(vehicle_slots)
+
             if not rig:
                 for c in comps:
-                    if component_name(c) in ('vehicle_slots', 'slot', 'slots'):
-                        VS.append(c)
                     rig_depot = depot_path_value(c, 'rig')
                     if rig_depot:
                         rig_path = depot_to_local_path(path, rig_depot)
@@ -1701,14 +1865,30 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
                     cache_armature_bones(rig)
                     armature_by_component_name[component_name_value] = rig
 
-            if not vehicle_slots:
-                if len(VS)>0:
-                    vehicle_slots= VS[0]['slots']
-                    vehicle_slot_lookup = build_slot_lookup(vehicle_slots)
-
+            light_channel_components = collect_light_channel_components(app_light_channels, chunks, comps, parsed_ent.light_channel_components, ent_components)
+            for comp in light_channel_components:
+                if id(comp) in ent_component_ids or id(comp) in ent_component_data_ids:
+                    set_parent_lookup(comp, ent_parent_transform_lookup)
+                    set_skinning_lookup(comp, ent_skinning_lookup)
+                    set_shape_lookup(comp, ent_shape_lookup)
+            resolver_components_by_id = dict(transform_components_by_id)
+            for comp in light_channel_components:
+                resolver_components_by_id[id(comp)] = comp
+            resolver_components = list(resolver_components_by_id.values())
+            resolver_components_by_name = dict(base_components_by_name)
+            for comp in resolver_components:
+                name = component_name(comp)
+                if name:
+                    resolver_components_by_name[name] = comp
+            resolver_slot_component_lookups = dict(base_slot_component_lookups)
+            for comp in resolver_components:
+                name = component_name(comp)
+                slots = comp.get('slots') if type(comp) is dict else None
+                if name and type(slots) is list:
+                    resolver_slot_component_lookups[name] = build_slot_lookup(slots)
 
             transform_resolver = EntityTransformResolver(
-                transform_components,
+                resolver_components,
                 parent_transform_lookup,
                 skinning_lookup=skinning_lookup,
                 rig=rig,
@@ -1719,6 +1899,8 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
                 rig_json_by_component_name=rig_json_by_component_name,
                 armature_by_component_name=armature_by_component_name,
                 slot_owner_rig_owner_names=slot_owner_rig_owner_names,
+                components_by_name=resolver_components_by_name,
+                slot_component_lookups=resolver_slot_component_lookups,
             )
 
             for c in comps:
@@ -1742,19 +1924,7 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
                         reverse=chunk_anim['reverseDirection']
                         no_rot=chunk_anim['numberOfFullRotations']
                         o = create_axes(ent_coll=ent_coll,name=comp_name)
-                        o.keyframe_insert('rotation_euler', index=axis_no ,frame=1)
-                        o.rotation_euler[axis_no] = o.rotation_euler[axis_no] +math.radians(no_rot*(-1*reverse)*360)
-                        o.keyframe_insert('rotation_euler', index=axis_no ,frame=duration*24)
-                        if o.animation_data.action:
-                            obj_action = bpy.data.actions.get(o.animation_data.action.name)
-                            obj_slot = o.animation_data.action_slot
-                            channelbag = anim_utils.action_get_channelbag_for_slot(obj_action, obj_slot)
-                            obj_fcu = channelbag.fcurves[0]
-                            modifier = obj_fcu.modifiers.new(type='CYCLES')
-                            modifier.mode_before = 'REPEAT'
-                            modifier.mode_after = 'REPEAT'
-                            for pt in obj_fcu.keyframe_points:
-                                pt.interpolation = 'LINEAR'
+                        set_rotation_axis_cycles(o, axis_no, math.radians(no_rot * (-1 * reverse) * 360), duration * 24)
                 elif 'mesh' in c or 'graphicsMesh' in c:
                     depot_path, meshname, meshpath, meshApp, component_enabled = component_mesh_info(c)
                     if meshname and meshpath and not is_excluded_mesh(depot_path, meshpath, meshname, excluded_meshes):
@@ -1765,18 +1935,16 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
                             #bpy.ops.io_scene_gltf.cp77(with_materials, filepath=meshpath, appearances=meshApp,scripting=True,generate_overrides=generate_overrides)
                             group, groupname = get_group(meshpath,meshApp,Masters)
                             if (group):
-                                new=bpy.data.collections.new(groupname)                                       
-                                ent_coll.children.link(new)
+                                new=bpy.data.collections.new(groupname)
                                 copied_objects = []
                                 object_copy_map = {}
                                 link_object = new.objects.link
-                                for old_obj in tuple(group.all_objects):
-                                    obj=old_obj.copy()
+                                hide_disabled = not component_enabled
+                                for old_obj in master_group_objects(group):
+                                    obj = old_obj.copy()
                                     object_copy_map[old_obj] = obj
                                     copied_objects.append(obj)
                                     link_object(obj)
-                                remap_copied_object_references(copied_objects, object_copy_map)
-                                for obj in copied_objects:
                                     obj['componentName'] = comp_name
                                     obj['sourcePath'] = meshpath
                                     obj['meshAppearance'] = meshApp
@@ -1784,11 +1952,12 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
                                     if app_resource:
                                         obj['appResource'] = app_resource
                                     obj['entAppearance'] = app_name
-                                    if not component_enabled:
-                                        obj.hide_set(True)
+                                    if hide_disabled:
+                                        obj.hide_viewport = True
                                         obj.hide_render = True
                                     if 'Armature' in obj.name:
-                                        obj.hide_set(True)
+                                        obj.hide_viewport = True
+                                remap_copied_object_references(copied_objects, object_copy_map)
                             else:
                                 print('BREAK collection not found after import - ', meshname)
                             print('checking for collection - ', meshname)
@@ -1812,40 +1981,42 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
                             child_inverse = child_of_inverse_matrix(rig, bindname) if can_bind_bone else None
                             copy_wheel_rotation = can_bind_bone and 'wheel' in bindname
                             set_steering_subtarget = copy_wheel_rotation and 'steering' not in bindname
+                            has_bindname = bool(bindname)
+                            has_slotname = bool(slotname)
+                            hide_disabled = not component_enabled
                             for obj in objs:
                                 obj['bindingType'] = binding_type
-                                if bindname:
+                                if has_bindname:
                                     obj['bindname'] = bindname
-                                if slotname:
+                                if has_slotname:
                                     obj['slotName'] = slotname
                                 obj['deformationRigSkinning'] = component_is_skinned
                                 obj.matrix_world = resolved_matrix @ obj.matrix_world
-                                if not component_enabled:
-                                    obj.hide_set(True)
+                                if hide_disabled:
+                                    obj.hide_viewport = True
                                     obj.hide_render = True
                                 if can_bind_bone:
-                                    if 'Child Of' not in obj.constraints:
-                                        co = obj.constraints.new(type='CHILD_OF')
+                                    constraints = obj.constraints
+                                    if 'Child Of' not in constraints:
+                                        co = constraints.new(type='CHILD_OF')
                                         co.target = rig
                                         co.subtarget = bindname
                                         co.inverse_matrix = child_inverse
                                     if copy_wheel_rotation:
-                                        cr = obj.constraints.new(type='COPY_ROTATION')
+                                        cr = constraints.new(type='COPY_ROTATION')
                                         cr.target = rig
                                         if set_steering_subtarget:
                                             cr.subtarget = bindname
 
 
-                            if (len(objs) > 0):
-                                move_coll=new
-                                move_coll['depotPath']=depot_path
-                                move_coll['meshAppearance']=meshApp
+                            if objs:
+                                move_coll = new
+                                move_coll['depotPath'] = depot_path
+                                move_coll['meshAppearance'] = meshApp
                                 if 'meshpath' not in move_coll:
-                                    move_coll['meshpath']="its an entity"
+                                    move_coll['meshpath'] = "its an entity"
                                 if bindname:
-                                    move_coll['bindname']=bindname
-                                if move_coll.name in coll_scene.children:
-                                    coll_scene.children.unlink(move_coll)
+                                    move_coll['bindname'] = bindname
 
                             if 'chunkMask' in c:
                                 cm_int = int(c['chunkMask'])
@@ -1853,71 +2024,51 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
                                     subnum = submesh_index_for_object(obj)
                                     if subnum is None:
                                         continue
-                                    hidden = (not component_enabled) or not bool((cm_int >> subnum) & 1)
-                                    obj.hide_set(hidden)
+                                    hidden = hide_disabled or not bool((cm_int >> subnum) & 1)
+                                    obj.hide_viewport = hidden
                                     obj.hide_render = hidden
+
+                            if new is not None:
+                                ent_coll.children.link(new)
 
                         except:
                             print("Failed on ",meshname)
                             print(traceback.format_exc())
 
-            for c in ent_component_data:
-                if (c['$type']=='entLightChannelComponent'):
-                    print('Light channel found')
-                    mesh_obj=None
-                    lcgroup=None
-                    lcgroupname=c['name']['$value']
-                    if lcgroupname not in bpy.data.collections.get("MasterInstances").children:
-                        if 'shape' in c and 'Data' in c['shape'] and 'vertices' in c['shape']['Data']:
-                            vertices=c['shape']['Data']['vertices']
-                            if len(vertices)>0 and 'indices' in c['shape']['Data']:
-                                indices=c['shape']['Data']['indices']
-                                if len(indices)>0:
-                                    lcgroup=bpy.data.collections.new(lcgroupname)
-                                    mesh_data = bpy.data.meshes.new(lcgroupname)
-                                    mesh_obj = bpy.data.objects.new(mesh_data.name, mesh_data)
-                                    mesh_obj.display_type = 'WIRE'
-                                    mesh_obj.color = (0.005, 0.79105, 1, 1)
-                                    mesh_obj.show_wire = True
-                                    mesh_obj.show_in_front = True
-                                    mesh_obj.display.show_shadows = False
-                                    mesh_obj.rotation_mode = 'QUATERNION'
-                                    verts=[]
-                                    for v in vertices:
-                                        verts.append((v['X'],v['Y'],v['Z']))
-                                    edges=[]
-                                    Faces=[indices[i:i+3] for i in range(0, len(indices), 3)]
-                                    mesh_data.from_pydata(verts, edges, Faces)
-                                    mesh_obj['ntype'] = 'entLightChannelComponent'
-                                    mesh_obj['name'] = c['name']['$value']
-                                    mesh_obj['entJSON'] = filepath
+            for c in light_channel_components:
+                lcgroupname = component_name(c) or 'LightChannel'
+                mesh_obj = create_light_channel_mesh(c, shape_lookup, filepath)
+                if mesh_obj is None:
+                    continue
 
-                                    bindname=c['parentTransform']['Data']['bindName']['$value']
-                                    if bindname=='vehicle_slots':
-                                        if vehicle_slots:
-                                            slotname=c['parentTransform']['Data']['slotName']['$value']
-                                            if slotname=='None':
-                                                slotname='Base'
-                                            for slot in vehicle_slots:
-                                                if slot['slotName']['$value']==slotname:
-                                                    bindname=slot['boneName']['$value']
-                                                    mesh_obj['bindname']=bindname
-                                    lcgroup.objects.link(mesh_obj)
-                                    Masters.children.link(lcgroup)
-                    if lcgroupname in bpy.data.collections.get("MasterInstances").children:
-                        Mastlcgroup=bpy.data.collections.get(lcgroupname)
-                        if (Mastlcgroup):
-                            lcgroup=bpy.data.collections.new(lcgroupname)
-                            ent_coll.children.link(lcgroup)
-                            for old_obj in Mastlcgroup.all_objects:
-                                obj=old_obj.copy()
-                                lcgroup.objects.link(obj)
-                            mesh_obj=lcgroup.all_objects[0]
-                            bindname=mesh_obj.get('bindname','')
-                        if bindname and rig and lcgroup and mesh_obj:
-                            co=mesh_obj.constraints.new(type='COPY_LOCATION')
-                            co.target=rig
-                            co.subtarget= bindname
+                lcgroup = bpy.data.collections.new(lcgroupname)
+                lcgroup.objects.link(mesh_obj)
+
+                resolved_matrix, bindname, slotname, binding_type = transform_resolver.resolve_hard_component_matrix(c)
+                mesh_obj['bindingType'] = binding_type
+                if bindname:
+                    mesh_obj['bindname'] = bindname
+                    lcgroup['bindname'] = bindname
+                if slotname:
+                    mesh_obj['slotName'] = slotname
+                component_enabled = is_component_enabled(c)
+                mesh_obj['componentEnabled'] = component_enabled
+                mesh_obj.matrix_world = resolved_matrix @ mesh_obj.matrix_world
+                if not component_enabled:
+                    mesh_obj.hide_viewport = True
+                    mesh_obj.hide_render = True
+
+                if binding_type in {'slot', 'bone'} and bindname and armature_has_bone(rig, bindname):
+                    co = mesh_obj.constraints.new(type='CHILD_OF')
+                    co.target = rig
+                    co.subtarget = bindname
+                    co.inverse_matrix = child_of_inverse_matrix(rig, bindname)
+
+                lcgroup['componentName'] = lcgroupname
+                lcgroup['nodeType'] = 'entLightChannelComponent'
+                lcgroup['bindingType'] = binding_type
+                lcgroup['entAppearance'] = app_name
+                ent_coll.children.link(lcgroup)
             print('Appearance import time:', time.time() - app_start_time, 'Seconds')
 
 
@@ -1949,35 +2100,30 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
                     print('No entColliderComponent or entSimpleColliderComponents found')
                     return('FINISHED')
                 else:
-                    for index, i in enumerate(ent_component_data):
-                        if i['$type'] in ('entColliderComponent', 'entSimpleColliderComponent'):
-                            collision_type = 'ENTITY'
-                            col_name = i['$type']
-                            
-                            # Find or create a sub-collection for these collider types
-                            new_col = None
-                            for child in collision_collection.children:
-                                if child.name == col_name:
-                                    new_col = child
-                                    break
-                            
-                            if not new_col:
-                                new_col = bpy.data.collections.new(col_name)
-                                collision_collection.children.link(new_col)
-                                
-                            cdata = i['colliders'][0]['Data']
-                            collision_shape = cdata['$type']
-                            submeshName = '_' + collision_shape
-                            
-                            # Pass to pxbridge to create a native PhysX actor instead of a mesh representation
-                            try:
-                                obj = import_collider_as_actor(cdata, submeshName, new_col)
-                                if obj:
-                                    # Add extra properties for reference
-                                    if 'simulationType' in i:
-                                        obj['simulationType'] = i['simulationType']
-                            except Exception as e:
-                                print(f'Error importing {collision_shape} via pxbridge: {e}')
+                    for i in ent_colliderComps + ent_simpleCollComps:
+                        collision_type = 'ENTITY'
+                        col_name = i['$type']
+                        new_col = collision_collection.children.get(col_name)
+
+                        if not new_col:
+                            new_col = bpy.data.collections.new(col_name)
+                            collision_collection.children.link(new_col)
+
+                        colliders = i.get('colliders') or []
+                        if not colliders or type(colliders[0]) is not dict:
+                            continue
+                        cdata = colliders[0].get('Data')
+                        if type(cdata) is not dict:
+                            continue
+                        collision_shape = cdata.get('$type', 'physicsColliderBox')
+                        submeshName = '_' + collision_shape
+
+                        try:
+                            obj = import_collider_as_actor(cdata, submeshName, new_col)
+                            if obj and 'simulationType' in i:
+                                obj['simulationType'] = i['simulationType']
+                        except Exception as e:
+                            print(f'Error importing {collision_shape} via pxbridge: {e}')
     if rig and getattr(rig, 'type', None) == 'ARMATURE' and getattr(rig, 'data', None):
         rig.data.pose_position = 'REST'
     if entinitiatedcache:

--- a/i_scene_cp77_gltf/importers/entity_import.py
+++ b/i_scene_cp77_gltf/importers/entity_import.py
@@ -7,25 +7,26 @@ import bpy
 import time
 import math
 import traceback
-from math import sin,cos
 from mathutils import Vector, Matrix , Quaternion
-import bmesh
 from ..main.common import *
 from ..jsontool import JSONTool
 from .phys_import import cp77_phys_import
 from ..collisiontools.pxbridge.io_phys import import_collider_as_actor
-from io_scene_gltf2.io.imp.gltf2_io_gltf import glTFImporter
 from .import_common import *
 from ..datakrash import DepotAssetIndex
 from .read_rig import create_armature_from_data
 from bpy_extras import anim_utils
 
 SUBMESH_PATTERN = re.compile(r"submesh_(\d+)", re.IGNORECASE)
+_SUBMESH_INDEX_CACHE = {}
 ARMATURE_TYPE = 'ARMATURE'
+_RIG_ARMATURE_OBJECT_CACHE = {}
+_ARMATURE_BONE_SET_CACHE = {}
+FIXED_POINT_DIVISOR = 131072
 
 
 def create_axes(ent_coll,name):
-    if name not in ent_coll.objects.keys():
+    if name not in ent_coll.objects:
         o = bpy.data.objects.new( name , None )
 
         ent_coll.objects.link( o )
@@ -76,13 +77,24 @@ def red_quaternion(value):
     ))
 
 
+def position_axis_value(data, fixed_key, float_key):
+    value = data.get(fixed_key) if isinstance(data, dict) else None
+    if isinstance(value, dict):
+        return value.get('Bits', 0) / FIXED_POINT_DIVISOR
+    return data.get(float_key, 0) if isinstance(data, dict) else 0
+
+
+def position_vector(data):
+    return Vector((
+        position_axis_value(data, 'x', 'X'),
+        position_axis_value(data, 'y', 'Y'),
+        position_axis_value(data, 'z', 'Z'),
+    ))
+
+
 def fixed_point_position(transform):
     position = transform.get('Position', {}) if isinstance(transform, dict) else {}
-    return Vector((
-        position.get('x', {}).get('Bits', 0) / 131072,
-        position.get('y', {}).get('Bits', 0) / 131072,
-        position.get('z', {}).get('Bits', 0) / 131072,
-    ))
+    return position_vector(position)
 
 
 def component_local_transform(component):
@@ -111,6 +123,28 @@ def norm_path_key(value):
 
 def anim_json_path_from_glb(anim_path):
     return os.path.splitext(anim_path)[0] + '.json'
+
+
+def submesh_index_for_object(obj):
+    name = getattr(obj, 'name', '')
+    cached = _SUBMESH_INDEX_CACHE.get(name)
+    if cached is not None:
+        return None if cached < 0 else cached
+    match = SUBMESH_PATTERN.search(name)
+    if match:
+        index = int(match.group(1))
+        _SUBMESH_INDEX_CACHE[name] = index
+        return index
+    data = getattr(obj, 'data', None)
+    for mat in getattr(data, 'materials', ()) if data is not None else ():
+        mat_name = getattr(mat, 'name', '') if mat else ''
+        match = SUBMESH_PATTERN.search(mat_name) if mat_name else None
+        if match:
+            index = int(match.group(1))
+            _SUBMESH_INDEX_CACHE[name] = index
+            return index
+    _SUBMESH_INDEX_CACHE[name] = -1
+    return None
 
 
 ASSET_INDEX_EXTENSIONS = (
@@ -178,20 +212,24 @@ def resolve_anim_json_path_from_glb(asset_index, anim_path):
 
 
 def build_component_lookup(components):
-    return {component_name(component): component for component in components if component_name(component)}
+    lookup = {}
+    for component in components or []:
+        name = component_name(component)
+        if name:
+            lookup[name] = component
+    return lookup
 
 
 def build_ent_app_lookup(ent_apps):
-    by_appearance = {
-        cname_value(app.get('appearanceName')): index
-        for index, app in enumerate(ent_apps)
-        if cname_value(app.get('appearanceName'))
-    }
-    by_name = {
-        cname_value(app.get('name')): index
-        for index, app in enumerate(ent_apps)
-        if cname_value(app.get('name'))
-    }
+    by_appearance = {}
+    by_name = {}
+    for index, app in enumerate(ent_apps or []):
+        appearance = cname_value(app.get('appearanceName'))
+        if appearance:
+            by_appearance[appearance] = index
+        name = cname_value(app.get('name'))
+        if name:
+            by_name[name] = index
     return by_appearance, by_name
 
 
@@ -250,26 +288,23 @@ def resolve_ent_app(app_name, ent_apps, by_appearance, by_name, ent_default=None
     return 0, cname_value(ent_apps[0].get('appearanceName'), app_name) if ent_apps else app_name
 
 
-def build_parent_transform_lookup(chunks):
+def build_chunk_lookup(chunks, target_key, handle_key='HandleId'):
     lookup = {}
-    if not chunks:
-        return lookup
-    for chunk in chunks:
-        parent_transform = chunk.get('parentTransform') if isinstance(chunk, dict) else None
-        if isinstance(parent_transform, dict) and 'HandleId' in parent_transform:
-            lookup[parent_transform['HandleId']] = parent_transform
+    for chunk in chunks or []:
+        if not isinstance(chunk, dict):
+            continue
+        target_data = chunk.get(target_key)
+        if isinstance(target_data, dict) and handle_key in target_data:
+            lookup[target_data[handle_key]] = target_data
     return lookup
+
+
+def build_parent_transform_lookup(chunks):
+    return build_chunk_lookup(chunks, 'parentTransform')
 
 
 def build_skinning_lookup(chunks):
-    lookup = {}
-    if not chunks:
-        return lookup
-    for chunk in chunks:
-        skinning = chunk.get('skinning') if isinstance(chunk, dict) else None
-        if isinstance(skinning, dict) and 'HandleId' in skinning:
-            lookup[skinning['HandleId']] = skinning
-    return lookup
+    return build_chunk_lookup(chunks, 'skinning')
 
 
 class ComponentHandleLookup:
@@ -306,7 +341,12 @@ def build_anim_impl_lookup(chunks):
 
 
 def build_slot_lookup(vehicle_slots):
-    return {cname_value(slot.get('slotName')): slot for slot in vehicle_slots or [] if cname_value(slot.get('slotName'))}
+    lookup = {}
+    for slot in vehicle_slots or []:
+        name = cname_value(slot.get('slotName'))
+        if name:
+            lookup[name] = slot
+    return lookup
 
 
 def resolve_slot_bone(slot_lookup, slotname, fallback=None):
@@ -314,29 +354,54 @@ def resolve_slot_bone(slot_lookup, slotname, fallback=None):
     return cname_value(slot.get('boneName'), fallback) if slot else fallback
 
 
+_RIG_BONE_INDEX_CACHE = {}
+_RIG_BONE_MATRIX_CACHE = {}
+
+
 def build_rig_bone_index(rig_j):
     if not rig_j or not rig_j.get('boneNames'):
         return {}
-    return {cname_value(bone): index for index, bone in enumerate(rig_j['boneNames']) if cname_value(bone)}
+    out = {}
+    for index, bone in enumerate(rig_j['boneNames']):
+        name = cname_value(bone)
+        if name:
+            out[name] = index
+    return out
 
-def rig_json_bone_matrix(rig_j, bone_name):
+
+def rig_bone_index_for(rig_j):
+    if not isinstance(rig_j, dict):
+        return {}
+    cache_key = id(rig_j)
+    index = _RIG_BONE_INDEX_CACHE.get(cache_key)
+    if index is None:
+        index = build_rig_bone_index(rig_j)
+        _RIG_BONE_INDEX_CACHE[cache_key] = index
+    return index
+
+
+def rig_json_bone_matrix(rig_j, bone_name, rig_bone_index=None):
     if not isinstance(rig_j, dict) or not bone_name:
         return Matrix.Identity(4)
-    bone_names = rig_j.get('boneNames')
-    if not isinstance(bone_names, list):
-        return Matrix.Identity(4)
-    index = None
-    for candidate_index, bone in enumerate(bone_names):
-        if cname_value(bone) == bone_name:
-            index = candidate_index
-            break
+    rig_id = id(rig_j)
+    matrices = _RIG_BONE_MATRIX_CACHE.get(rig_id)
+    if matrices is None:
+        matrices = {}
+        _RIG_BONE_MATRIX_CACHE[rig_id] = matrices
+    cached = matrices.get(bone_name)
+    if cached is not None:
+        return cached
+    index = (rig_bone_index or rig_bone_index_for(rig_j)).get(bone_name)
     if index is None:
-        return Matrix.Identity(4)
+        matrices[bone_name] = Matrix.Identity(4)
+        return matrices[bone_name]
     for key in ('aPoseMS', 'boneTransforms', 'aPoseLS'):
         transforms = rig_j.get(key)
         if isinstance(transforms, list) and index < len(transforms):
-            return qs_transform_matrix(transforms[index])
-    return Matrix.Identity(4)
+            matrices[bone_name] = qs_transform_matrix(transforms[index])
+            return matrices[bone_name]
+    matrices[bone_name] = Matrix.Identity(4)
+    return matrices[bone_name]
 
 
 def build_slot_owner_rig_jsons(components, parent_transform_lookup, rig_json_by_component_name):
@@ -378,9 +443,16 @@ def build_slot_owner_rig_owner_names(components, parent_transform_lookup, rig_co
 def is_excluded_mesh(depot_path, meshpath, meshname, excluded_meshes):
     if not excluded_meshes:
         return False
-    candidates = {depot_path, meshpath, meshname, os.path.basename(depot_path.replace('\\', os.sep)) if depot_path else ''}
-    norm_candidates = {norm_path_key(candidate) for candidate in candidates if candidate}
-    return bool(norm_candidates.intersection(excluded_meshes))
+    if meshpath and norm_path_key(meshpath) in excluded_meshes:
+        return True
+    if meshname and norm_path_key(meshname) in excluded_meshes:
+        return True
+    if depot_path:
+        if norm_path_key(depot_path) in excluded_meshes:
+            return True
+        if norm_path_key(os.path.basename(depot_path.replace('\\', os.sep))) in excluded_meshes:
+            return True
+    return False
 
 
 
@@ -397,28 +469,52 @@ def red_scale(transform, visual_scale=None):
     ))
 
 
-def red_transform_matrix(transform, visual_scale=None):
+def vector_from_transform_position(transform, keys):
+    if not isinstance(transform, dict):
+        return Vector((0, 0, 0))
+    for key in keys:
+        data = transform.get(key)
+        if isinstance(data, dict):
+            return position_vector(data)
+    return Vector((0, 0, 0))
+
+
+def first_transform_value(transform, keys):
+    if not isinstance(transform, dict):
+        return {}
+    for key in keys:
+        value = transform.get(key)
+        if isinstance(value, dict):
+            return value
+    return {}
+
+
+def transform_dict_matrix(transform, pos_keys=('Position', 'Translation', 'relativePosition'), rot_keys=('Orientation', 'Rotation', 'relativeRotation'), scale=None):
     if not isinstance(transform, dict):
         return Matrix.Identity(4)
     return Matrix.LocRotScale(
-        fixed_point_position(transform),
-        red_quaternion(transform.get('Orientation')),
+        vector_from_transform_position(transform, pos_keys),
+        red_quaternion(first_transform_value(transform, rot_keys)),
+        scale if scale is not None else red_scale(transform),
+    )
+
+
+def red_transform_matrix(transform, visual_scale=None):
+    if not isinstance(transform, dict):
+        return Matrix.Identity(4)
+    return transform_dict_matrix(
+        transform,
+        ('Position',),
+        ('Orientation',),
         red_scale(transform, visual_scale),
     )
 
 
 def slot_transform_matrix(slot):
-    if not isinstance(slot, dict):
-        return Matrix.Identity(4)
-    pos_data = slot.get('relativePosition') if isinstance(slot.get('relativePosition'), dict) else {}
-    pos = Vector((
-        pos_data.get('X', 0),
-        pos_data.get('Y', 0),
-        pos_data.get('Z', 0),
-    ))
-    return Matrix.LocRotScale(
-        pos,
-        red_quaternion(slot.get('relativeRotation')),
+    return transform_dict_matrix(
+        slot,
+        ('relativePosition',),
+        ('relativeRotation',),
         Vector((1, 1, 1)),
     )
 
@@ -426,69 +522,44 @@ def slot_transform_matrix(slot):
 def slot_translation_matrix(slot):
     if not isinstance(slot, dict):
         return Matrix.Identity(4)
-    pos_data = slot.get('relativePosition') if isinstance(slot.get('relativePosition'), dict) else {}
-    return Matrix.Translation(Vector((
-        pos_data.get('X', 0),
-        pos_data.get('Y', 0),
-        pos_data.get('Z', 0),
-    )))
+    return Matrix.Translation(vector_from_transform_position(slot, ('relativePosition',)))
 
 
 def qs_transform_matrix(transform):
-    if not isinstance(transform, dict):
-        return Matrix.Identity(4)
-    translation = transform.get('Translation')
-    if isinstance(translation, dict):
-        location = Vector((
-            translation.get('X', 0),
-            translation.get('Y', 0),
-            translation.get('Z', 0),
-        ))
+    return transform_dict_matrix(
+        transform,
+        ('Translation', 'Position'),
+        ('Rotation', 'Orientation'),
+        red_scale(transform),
+    )
+
+
+def resolve_handle_data(component, lookup, key, fallback_to_inline=False):
+    data = component.get(key) if isinstance(component, dict) else None
+    if not isinstance(data, dict):
+        return None
+    if isinstance(data.get('Data'), dict):
+        return data.get('Data')
+
+    handle_id = data.get('HandleRefId')
+    if handle_id is None:
+        return data if fallback_to_inline else None
+
+    if hasattr(lookup, 'get_for_component'):
+        referenced = lookup.get_for_component(component, handle_id)
     else:
-        location = fixed_point_position(transform)
-    scale_data = transform.get('Scale') if isinstance(transform.get('Scale'), dict) else None
-    scale = Vector((
-        scale_data.get('X', 1),
-        scale_data.get('Y', 1),
-        scale_data.get('Z', 1),
-    )) if scale_data else Vector((1, 1, 1))
-    return Matrix.LocRotScale(location, red_quaternion(transform.get('Rotation') or transform.get('Orientation')), scale)
+        referenced = lookup.get(handle_id) if lookup else None
+    if isinstance(referenced, dict):
+        return referenced.get('Data')
+    return data if fallback_to_inline else None
 
 
 def parent_transform_data(component, parent_transform_lookup):
-    parent_transform = component.get('parentTransform') if isinstance(component, dict) else None
-    if not isinstance(parent_transform, dict):
-        return None
-    if 'Data' in parent_transform:
-        return parent_transform.get('Data')
-    handle_id = parent_transform.get('HandleRefId')
-    if handle_id is None:
-        return None
-    if hasattr(parent_transform_lookup, 'get_for_component'):
-        referenced = parent_transform_lookup.get_for_component(component, handle_id)
-    else:
-        referenced = parent_transform_lookup.get(handle_id) if parent_transform_lookup else None
-    if isinstance(referenced, dict):
-        return referenced.get('Data')
-    return None
+    return resolve_handle_data(component, parent_transform_lookup, 'parentTransform')
 
 
 def skinning_binding_data(component, skinning_lookup=None):
-    skinning = component.get('skinning') if isinstance(component, dict) else None
-    if not isinstance(skinning, dict):
-        return None
-    if isinstance(skinning.get('Data'), dict):
-        return skinning.get('Data')
-    handle_id = skinning.get('HandleRefId')
-    if handle_id is None:
-        return skinning
-    if hasattr(skinning_lookup, 'get_for_component'):
-        referenced = skinning_lookup.get_for_component(component, handle_id)
-    else:
-        referenced = skinning_lookup.get(handle_id) if skinning_lookup else None
-    if isinstance(referenced, dict):
-        return referenced.get('Data')
-    return skinning
+    return resolve_handle_data(component, skinning_lookup, 'skinning', fallback_to_inline=True)
 
 
 def skinning_bind_name(component, skinning_lookup=None):
@@ -519,37 +590,52 @@ def find_collection_armature(objects):
     return None
 
 
-def current_armature_names():
-    return {obj.name for obj in bpy.data.objects if getattr(obj, 'type', None) == ARMATURE_TYPE}
+def selected_armatures():
+    return [obj for obj in bpy.context.selected_objects if getattr(obj, 'type', None) == ARMATURE_TYPE]
 
 
-def imported_armatures_since(previous_names):
-    selected = [obj for obj in bpy.context.selected_objects if getattr(obj, 'type', None) == ARMATURE_TYPE and obj.name not in previous_names]
+def active_armature():
+    obj = bpy.context.view_layer.objects.active
+    return obj if getattr(obj, 'type', None) == ARMATURE_TYPE else None
+
+
+def imported_armatures_from_selection():
+    selected = selected_armatures()
     if selected:
         return selected
-    return [obj for obj in bpy.data.objects if getattr(obj, 'type', None) == ARMATURE_TYPE and obj.name not in previous_names]
+    active = active_armature()
+    return [active] if active is not None else []
 
 
-def set_child_of_inverse(constraint, target, subtarget_name=''):
+def child_of_inverse_matrix(target, subtarget_name=''):
     target_matrix = target.matrix_world.copy()
     if subtarget_name and getattr(target, 'pose', None) and subtarget_name in target.pose.bones:
         target_matrix = target.matrix_world @ target.pose.bones[subtarget_name].matrix
     try:
-        constraint.inverse_matrix = target_matrix.inverted()
+        return target_matrix.inverted()
     except Exception:
-        constraint.inverse_matrix = Matrix.Identity(4)
+        return Matrix.Identity(4)
+
+
+def set_child_of_inverse(constraint, target, subtarget_name=''):
+    constraint.inverse_matrix = child_of_inverse_matrix(target, subtarget_name)
 
 def existing_armature_for_rig_json(rig_json_path):
     target = norm_path_key(rig_json_path)
     if not target:
         return None
-    for obj in bpy.data.objects:
-        if getattr(obj, 'type', None) != ARMATURE_TYPE:
-            continue
-        candidates = [obj.get('rig'), obj.get('source_rig_file'), obj.get('sourceRigFile')]
-        for candidate in candidates:
-            if candidate and norm_path_key(candidate) == target:
-                return obj
+    cached = _RIG_ARMATURE_OBJECT_CACHE.get(target)
+    if cached is not None and cached.name in bpy.data.objects:
+        cache_armature_bones(cached)
+        return cached
+
+    expected_name = os.path.basename(rig_json_path).replace('.rig.json', '')
+    direct = bpy.data.objects.get(expected_name)
+    if getattr(direct, 'type', None) == ARMATURE_TYPE:
+        cache_armature_bones(direct)
+        _RIG_ARMATURE_OBJECT_CACHE[target] = direct
+        return direct
+
     return None
 
 
@@ -560,7 +646,6 @@ def ensure_armature_from_rig_json(rig_json_path, component_name_value='', ent_na
     if existing is not None:
         return existing
 
-    old_armature_names = current_armature_names()
     created = create_armature_from_data(rig_json_path, "T-Pose", False)
 
     if getattr(created, 'type', None) == ARMATURE_TYPE:
@@ -573,11 +658,13 @@ def ensure_armature_from_rig_json(rig_json_path, component_name_value='', ent_na
                     armature = item
                     break
         if armature is None:
-            new_armatures = imported_armatures_since(old_armature_names)
-            if new_armatures:
-                armature = new_armatures[0]
+            selected = imported_armatures_from_selection()
+            if selected:
+                armature = selected[0]
 
     if armature is not None:
+        cache_armature_bones(armature)
+        _RIG_ARMATURE_OBJECT_CACHE[norm_path_key(rig_json_path)] = armature
         armature['rig'] = rig_json_path
         armature['source_rig_file'] = rig_json_path
         if component_name_value:
@@ -587,13 +674,20 @@ def ensure_armature_from_rig_json(rig_json_path, component_name_value='', ent_na
     return armature
 
 
+def cache_armature_bones(armature):
+    if not armature or getattr(armature, 'type', None) != ARMATURE_TYPE or not getattr(armature, 'pose', None):
+        return set()
+    cache_key = id(armature)
+    cached = _ARMATURE_BONE_SET_CACHE.get(cache_key)
+    if cached is not None and cached[0] is armature:
+        return cached[1]
+    bone_set = set(armature.pose.bones.keys())
+    _ARMATURE_BONE_SET_CACHE[cache_key] = (armature, bone_set)
+    return bone_set
+
+
 def armature_has_bone(armature, bone_name):
-    return bool(
-        armature
-        and bone_name
-        and getattr(armature, 'pose', None)
-        and bone_name in armature.pose.bones
-    )
+    return bool(armature and bone_name and bone_name in cache_armature_bones(armature))
 
 
 def remap_copied_object_references(copied_objects, object_map):
@@ -675,6 +769,15 @@ class EntityTransformResolver:
             self.rig_json_bone_indices[id(self.rig_j)] = self.rig_bone_index
         self.default_slot_lookup = default_slot_lookup or {}
         self.cache = {}
+        self.local_matrix_cache = {}
+        self.binding_cache = {}
+        self.slot_matrix_cache = {}
+        self.armature_for_bone_cache = {}
+        self.bone_matrix_cache = {}
+        self.bone_rotation_cache = {}
+        self.bone_head_cache = {}
+        self.rig_space_bone_matrix_cache = {}
+        self.rig_json_for_bone_cache = {}
         self.resolving = set()
 
     def _slot_owner_rig_json(self, slot_owner=None):
@@ -682,22 +785,51 @@ class EntityTransformResolver:
             return self.slot_owner_rig_jsons[slot_owner]
         return self.rig_j
 
-    def _rig_json_has_bone(self, bone_name, rig_j=None):
-        if not bone_name or not isinstance(rig_j, dict) or not rig_j.get('boneNames'):
-            return False
+    def _binding_data(self, component):
+        key = id(component)
+        binding = self.binding_cache.get(key)
+        if binding is None and key not in self.binding_cache:
+            binding = parent_transform_data(component, self.parent_transform_lookup)
+            self.binding_cache[key] = binding
+        return binding
+
+    def _local_matrix(self, component, transform=None, visual_scale=None):
+        key = id(component)
+        matrix = self.local_matrix_cache.get(key)
+        if matrix is None:
+            if transform is None:
+                transform = component.get('localTransform', {}) if isinstance(component, dict) else {}
+            if visual_scale is None and isinstance(component, dict):
+                visual_scale = component.get('visualScale')
+            matrix = red_transform_matrix(transform, visual_scale)
+            self.local_matrix_cache[key] = matrix
+        return matrix
+
+    def _rig_json_index(self, rig_j):
+        if not isinstance(rig_j, dict):
+            return {}
         index = self.rig_json_bone_indices.get(id(rig_j))
         if index is None:
-            index = build_rig_bone_index(rig_j)
+            index = rig_bone_index_for(rig_j)
             self.rig_json_bone_indices[id(rig_j)] = index
-        return bone_name in index
+        return index
+
+    def _rig_json_has_bone(self, bone_name, rig_j=None):
+        return bool(bone_name and bone_name in self._rig_json_index(rig_j))
 
     def _rig_json_for_bone(self, bone_name, slot_owner=None):
+        cache_key = (bone_name, slot_owner)
+        if cache_key in self.rig_json_for_bone_cache:
+            return self.rig_json_for_bone_cache[cache_key]
         preferred = self._slot_owner_rig_json(slot_owner)
         if self._rig_json_has_bone(bone_name, preferred):
+            self.rig_json_for_bone_cache[cache_key] = preferred
             return preferred
         for rig_json in self.rig_json_by_component_name.values():
             if rig_json is not preferred and self._rig_json_has_bone(bone_name, rig_json):
+                self.rig_json_for_bone_cache[cache_key] = rig_json
                 return rig_json
+        self.rig_json_for_bone_cache[cache_key] = preferred
         return preferred
 
     def _slot_owner_rig_owner_name(self, slot_owner=None):
@@ -706,16 +838,25 @@ class EntityTransformResolver:
         return ''
 
     def _armature_for_bone(self, bone_name, slot_owner=None):
+        if not bone_name:
+            return None
+        cache_key = (bone_name, slot_owner)
+        if cache_key in self.armature_for_bone_cache:
+            return self.armature_for_bone_cache[cache_key]
         owner_name = self._slot_owner_rig_owner_name(slot_owner)
         if owner_name:
             armature = self.armature_by_component_name.get(owner_name)
             if armature_has_bone(armature, bone_name):
+                self.armature_for_bone_cache[cache_key] = armature
                 return armature
         if armature_has_bone(self.rig, bone_name):
+            self.armature_for_bone_cache[cache_key] = self.rig
             return self.rig
         for armature in self.armature_by_component_name.values():
             if armature_has_bone(armature, bone_name):
+                self.armature_for_bone_cache[cache_key] = armature
                 return armature
+        self.armature_for_bone_cache[cache_key] = None
         return None
 
     def _pose_bone(self, bone_name, slot_owner=None):
@@ -725,26 +866,38 @@ class EntityTransformResolver:
         return None, None
 
     def bone_matrix(self, bone_name, slot_owner=None):
+        cache_key = (bone_name, slot_owner)
+        cached = self.bone_matrix_cache.get(cache_key)
+        if cached is not None:
+            return cached
         armature, pose_bone = self._pose_bone(bone_name, slot_owner)
         if pose_bone is not None:
-            return armature.matrix_world @ pose_bone.matrix
-        rig_j = self._rig_json_for_bone(bone_name, slot_owner)
-        if self._rig_json_has_bone(bone_name, rig_j):
-            return rig_json_bone_matrix(rig_j, bone_name)
-        return Matrix.Identity(4)
+            matrix = armature.matrix_world @ pose_bone.matrix
+        else:
+            rig_j = self._rig_json_for_bone(bone_name, slot_owner)
+            if self._rig_json_has_bone(bone_name, rig_j):
+                matrix = rig_json_bone_matrix(rig_j, bone_name, self._rig_json_index(rig_j))
+            else:
+                matrix = Matrix.Identity(4)
+        self.bone_matrix_cache[cache_key] = matrix
+        return matrix
 
     def resolve_slot_matrix(self, slot_owner, slot_name):
-        slot_lookup = self.slot_component_lookups.get(slot_owner) or {}
-        if slot_owner in ('vehicle_slots', 'slots') and self.default_slot_lookup:
-            slot_lookup = slot_lookup or self.default_slot_lookup
-        slot = slot_lookup.get(slot_name)
+        cache_key = (slot_owner, slot_name)
+        cached = self.slot_matrix_cache.get(cache_key)
+        if cached is not None:
+            return cached
+        slot = self._slot(slot_owner, slot_name)
         if not slot:
-            return Matrix.Identity(4), slot_owner, slot_name
-        bone_name = cname_value(slot.get('boneName'), slot_name)
-        return self.bone_matrix(bone_name, slot_owner) @ slot_transform_matrix(slot), bone_name, slot_name
+            result = (Matrix.Identity(4), slot_owner, slot_name)
+        else:
+            bone_name = cname_value(slot.get('boneName'), slot_name)
+            result = (self.bone_matrix(bone_name, slot_owner) @ slot_transform_matrix(slot), bone_name, slot_name)
+        self.slot_matrix_cache[cache_key] = result
+        return result
 
     def resolve_binding(self, component):
-        binding = parent_transform_data(component, self.parent_transform_lookup)
+        binding = self._binding_data(component)
         if not isinstance(binding, dict):
             return Matrix.Identity(4), '', '', 'none'
 
@@ -779,14 +932,14 @@ class EntityTransformResolver:
         return Matrix.Identity(4), bind_name, slot_name, 'unresolved'
 
     def resolve_component_matrix(self, component):
-        key = component_name(component) or str(id(component))
+        key = ('component', id(component))
         if key in self.cache:
             return self.cache[key]
         if key in self.resolving:
             return Matrix.Identity(4), '', '', 'cycle'
         self.resolving.add(key)
         parent_matrix, bind_name, slot_name, binding_type = self.resolve_binding(component)
-        local_matrix = red_transform_matrix(component.get('localTransform', {}), component.get('visualScale'))
+        local_matrix = self._local_matrix(component)
         matrix = parent_matrix @ local_matrix
         result = (matrix, bind_name, slot_name, binding_type)
         self.cache[key] = result
@@ -794,22 +947,38 @@ class EntityTransformResolver:
         return result
 
     def _bone_rotation(self, bone_name, slot_owner=None):
+        cache_key = (bone_name, slot_owner)
+        cached = self.bone_rotation_cache.get(cache_key)
+        if cached is not None:
+            return cached
         _, pose_bone = self._pose_bone(bone_name, slot_owner)
         if pose_bone is not None:
-            return pose_bone.rotation_quaternion.copy()
-        rig_j = self._rig_json_for_bone(bone_name, slot_owner)
-        if self._rig_json_has_bone(bone_name, rig_j):
-            return rig_json_bone_matrix(rig_j, bone_name).to_quaternion()
-        return Quaternion((1, 0, 0, 0))
+            rotation = pose_bone.rotation_quaternion.copy()
+        else:
+            rig_j = self._rig_json_for_bone(bone_name, slot_owner)
+            if self._rig_json_has_bone(bone_name, rig_j):
+                rotation = rig_json_bone_matrix(rig_j, bone_name, self._rig_json_index(rig_j)).to_quaternion()
+            else:
+                rotation = Quaternion((1, 0, 0, 0))
+        self.bone_rotation_cache[cache_key] = rotation
+        return rotation
 
     def _bone_head(self, bone_name, slot_owner=None):
+        cache_key = (bone_name, slot_owner)
+        cached = self.bone_head_cache.get(cache_key)
+        if cached is not None:
+            return cached
         _, pose_bone = self._pose_bone(bone_name, slot_owner)
         if pose_bone is not None:
-            return pose_bone.head.copy()
-        rig_j = self._rig_json_for_bone(bone_name, slot_owner)
-        if self._rig_json_has_bone(bone_name, rig_j):
-            return rig_json_bone_matrix(rig_j, bone_name).to_translation()
-        return Vector((0, 0, 0))
+            head = pose_bone.head.copy()
+        else:
+            rig_j = self._rig_json_for_bone(bone_name, slot_owner)
+            if self._rig_json_has_bone(bone_name, rig_j):
+                head = rig_json_bone_matrix(rig_j, bone_name, self._rig_json_index(rig_j)).to_translation()
+            else:
+                head = Vector((0, 0, 0))
+        self.bone_head_cache[cache_key] = head
+        return head
 
     def _rig_bone_index(self, bone_name):
         if not bone_name:
@@ -817,18 +986,29 @@ class EntityTransformResolver:
         return self.rig_bone_index.get(bone_name)
 
     def _rig_space_bone_matrix(self, bone_name):
+        cached = self.rig_space_bone_matrix_cache.get(bone_name)
+        if cached is not None:
+            return cached
         index = self._rig_bone_index(bone_name)
         if index is None:
             if self.rig and getattr(self.rig, 'pose', None) and bone_name in self.rig.pose.bones:
-                return self.rig.pose.bones[bone_name].matrix.copy()
-            return Matrix.Identity(4)
+                matrix = self.rig.pose.bones[bone_name].matrix.copy()
+            else:
+                matrix = Matrix.Identity(4)
+            self.rig_space_bone_matrix_cache[bone_name] = matrix
+            return matrix
         for key in ('aPoseMS', 'boneTransforms', 'aPoseLS'):
             transforms = self.rig_j.get(key) if isinstance(self.rig_j, dict) else None
             if isinstance(transforms, list) and index < len(transforms):
-                return qs_transform_matrix(transforms[index])
+                matrix = qs_transform_matrix(transforms[index])
+                self.rig_space_bone_matrix_cache[bone_name] = matrix
+                return matrix
         if self.rig and getattr(self.rig, 'pose', None) and bone_name in self.rig.pose.bones:
-            return self.rig.pose.bones[bone_name].matrix.copy()
-        return Matrix.Identity(4)
+            matrix = self.rig.pose.bones[bone_name].matrix.copy()
+        else:
+            matrix = Matrix.Identity(4)
+        self.rig_space_bone_matrix_cache[bone_name] = matrix
+        return matrix
 
     def _rig_bone_delta_matrix(self, base_bone_name, target_bone_name):
         if not target_bone_name or target_bone_name == 'None' or target_bone_name == base_bone_name:
@@ -863,10 +1043,10 @@ class EntityTransformResolver:
         return Matrix.Rotation(yaw, 4, 'Z')
 
     def _slot(self, owner, slot_name):
-        slot_lookup = self.slot_component_lookups.get(owner) or {}
-        if owner in ('vehicle_slots', 'slots') and self.default_slot_lookup:
-            slot_lookup = slot_lookup or self.default_slot_lookup
-        return slot_lookup.get(slot_name)
+        slot_lookup = self.slot_component_lookups.get(owner)
+        if not slot_lookup and owner in ('vehicle_slots', 'slots'):
+            slot_lookup = self.default_slot_lookup
+        return slot_lookup.get(slot_name) if slot_lookup else None
 
     def _slot_bone_name(self, owner, slot_name):
         slot = self._slot(owner, slot_name)
@@ -875,7 +1055,7 @@ class EntityTransformResolver:
         return slot_name or owner
 
     def _binding_name(self, component):
-        binding = parent_transform_data(component, self.parent_transform_lookup)
+        binding = self._binding_data(component)
         return cname_value(binding.get('bindName')) if isinstance(binding, dict) else ''
 
     def _component_is_rig_owner(self, component):
@@ -948,20 +1128,14 @@ class EntityTransformResolver:
         local_pos = fixed_point_position(local_transform)
         if bone_name and bone_name != 'Base':
             z_ang = self.bone_matrix(bone_name, slot_owner).to_euler().z
-            x = local_pos.x
-            y = local_pos.y
-            local_pos = Vector((
-                x * cos(z_ang) + y * sin(z_ang),
-                x * sin(z_ang) + y * cos(z_ang),
-                local_pos.z,
-            ))
+            local_pos = Matrix.Rotation(z_ang, 4, 'Z') @ local_pos
 
         rotation = self._bone_rotation(bone_name, slot_owner) @ slot_rot @ red_quaternion(local_transform.get('Orientation'))
         scale = red_scale(local_transform, visual_scale)
         return Matrix.LocRotScale(self._bone_head(bone_name, slot_owner) + slot_pos + local_pos, rotation, scale)
 
     def resolve_hard_component_matrix(self, component):
-        key = 'hard:' + (component_name(component) or str(id(component)))
+        key = ('hard', id(component))
         if key in self.cache:
             return self.cache[key]
         if key in self.resolving:
@@ -972,13 +1146,13 @@ class EntityTransformResolver:
         visual_scale = component.get('visualScale') if isinstance(component, dict) else None
         animated_slot_basis = self._animated_slot_component_basis(component)
         if animated_slot_basis is not None:
-            result = (animated_slot_basis @ red_transform_matrix(local_transform, visual_scale), self._binding_name(component), '', 'animated_slot_component')
+            result = (animated_slot_basis @ self._local_matrix(component, local_transform, visual_scale), self._binding_name(component), '', 'animated_slot_component')
             self.cache[key] = result
             self.resolving.remove(key)
             return result
-        binding = parent_transform_data(component, self.parent_transform_lookup)
+        binding = self._binding_data(component)
         if not isinstance(binding, dict):
-            result = (red_transform_matrix(local_transform, visual_scale), '', '', 'none')
+            result = (self._local_matrix(component, local_transform, visual_scale), '', '', 'none')
             self.cache[key] = result
             self.resolving.remove(key)
             return result
@@ -986,7 +1160,7 @@ class EntityTransformResolver:
         bind_name = cname_value(binding.get('bindName'))
         slot_name = cname_value(binding.get('slotName'))
         if not bind_name or bind_name == 'None':
-            result = (red_transform_matrix(local_transform, visual_scale), bind_name, slot_name, 'none')
+            result = (self._local_matrix(component, local_transform, visual_scale), bind_name, slot_name, 'none')
             self.cache[key] = result
             self.resolving.remove(key)
             return result
@@ -1000,7 +1174,7 @@ class EntityTransformResolver:
 
         if bind_name == 'deformation_rig':
             base = self.rig.matrix_world.copy() if self.rig else Matrix.Identity(4)
-            result = (base @ red_transform_matrix(local_transform, visual_scale), bind_name, slot_name, 'deformation_rig')
+            result = (base @ self._local_matrix(component, local_transform, visual_scale), bind_name, slot_name, 'deformation_rig')
             self.cache[key] = result
             self.resolving.remove(key)
             return result
@@ -1028,6 +1202,7 @@ class EntityTransformResolver:
                             animated_parent_matrix
                             @ self._rig_bone_translation_matrix(bone_name)
                             @ self._rig_bone_yaw_matrix(bone_name)
+                            @ slot_translation_matrix(slot)
                         )
                         parent_bind = bone_name or parent_bind or bind_name
                         parent_slot = slot_name
@@ -1035,7 +1210,7 @@ class EntityTransformResolver:
                     elif not skip_animated_base_slot:
                         parent_matrix = parent_matrix @ slot_transform_matrix(slot)
                         parent_type = 'component_slot'
-            result = (parent_matrix @ red_transform_matrix(local_transform, visual_scale), parent_bind or bind_name, parent_slot or slot_name, parent_type if parent_type != 'none' else 'component')
+            result = (parent_matrix @ self._local_matrix(component, local_transform, visual_scale), parent_bind or bind_name, parent_slot or slot_name, parent_type if parent_type != 'none' else 'component')
             self.cache[key] = result
             self.resolving.remove(key)
             return result
@@ -1046,7 +1221,7 @@ class EntityTransformResolver:
             self.resolving.remove(key)
             return result
 
-        result = (red_transform_matrix(local_transform, visual_scale), bind_name, slot_name, 'unresolved')
+        result = (self._local_matrix(component, local_transform, visual_scale), bind_name, slot_name, 'unresolved')
         self.cache[key] = result
         self.resolving.remove(key)
         return result
@@ -1092,6 +1267,7 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
         ent_apps, ent_components, ent_component_data, res, ent_default = JSONTool.jsonload(filepath, error_messages)
 
     ent_applist=[cname_value(app.get('appearanceName')) for app in ent_apps]
+    ent_app_index_by_name = {name: index for index, name in enumerate(ent_applist) if name}
     ent_app_by_appearance, ent_app_by_name = build_ent_app_lookup(ent_apps)
     ent_default = normalize_default_appearance(ent_default, ent_apps, ent_app_by_appearance, ent_app_by_name, filepath)
 
@@ -1181,6 +1357,7 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
 
     # Discover exported resources from the indexed source/raw tree.
     app_path = indexed_asset_files(asset_index, '.app.json', app_path)
+    app_resource = app_path[0] if app_path else ''
     if ent_apps and len(ent_apps) > 0 and len(app_path) == 0:
         print('No Appearance file JSONs found in path, run the Ent export script first')
 
@@ -1201,8 +1378,6 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
     if len(anim_files) == 0 or len(ent_rigs) == 0: # we have glbs and we have rigs called up in the ent
         print('no anim rig found')
     else:
-        # get the armatures already in the model
-        old_armature_names = current_armature_names()
         resolved_keys = {norm_path_key(resolved_path) for resolved_path in resolved}
         ent_rig_keys = {norm_path_key(rig_path) for rig_path in ent_rigs}
         animsinres=[x for x in anim_files if norm_path_key(os.path.splitext(x)[0]) in resolved_keys]
@@ -1220,9 +1395,10 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
         if len(animsinres)>0:
             bpy.ops.io_scene_gltf.cp77(with_materials, filepath=animsinres[0],scripting=True)
             #find what we just loaded
-            arms = imported_armatures_since(old_armature_names)
+            arms = imported_armatures_from_selection()
             if arms:
                 rig=arms[0]
+                cache_armature_bones(rig)
                 bones=rig.pose.bones
                 print('anim rig loaded')
             else:
@@ -1295,7 +1471,7 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
     else:
         coll_scene = C.scene.collection
         mis={}
-        if "MasterInstances" not in coll_scene.children.keys():
+        if "MasterInstances" not in coll_scene.children:
             Masters=bpy.data.collections.new("MasterInstances")
             coll_scene.children.link(Masters)
         else:
@@ -1309,6 +1485,25 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
         ent_chunks={}
         app_json_cache={}
         app_lookup={}
+        component_mesh_info_cache = {}
+
+        def component_mesh_info(component):
+            cache_key = id(component)
+            cached = component_mesh_info_cache.get(cache_key)
+            if cached is not None:
+                return cached
+            depot_path = mesh_component_depot(component)
+            if not depot_path:
+                cached = ('', '', '', '', True)
+            else:
+                meshpath = resolve_mesh_glb_path(asset_index, depot_path)
+                meshname = os.path.basename(depot_path.replace('\\', os.sep))
+                meshapp = mesh_appearance_value(component)
+                enabled = is_component_enabled(component)
+                cached = (depot_path, meshname, meshpath, meshapp, enabled)
+            component_mesh_info_cache[cache_key] = cached
+            return cached
+
         for x,requested_app_name in enumerate(appearances):
             app_name = resolve_requested_appearance_name(requested_app_name, ent_default, ent_apps, ent_app_by_appearance, ent_app_by_name)
             app_comps[requested_app_name]=[]
@@ -1361,18 +1556,13 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
             if chunks is not None and requested_app_name not in ent_chunks:
                 ent_chunks[requested_app_name] = chunks
             for c in app_comps[requested_app_name]:
-                depot_path = mesh_component_depot(c)
-                if not depot_path:
-                    continue
-                meshname=depot_to_local_path(path, depot_path)
-                meshpath=resolve_mesh_glb_path(asset_index, depot_path)
-                if meshname and meshpath and not is_excluded_mesh(depot_path, meshpath, os.path.basename(meshname), excluded_meshes):
-                    meshApp=mesh_appearance_value(c)
-                    if(meshname != 0):
-                        if meshname not in meshes:
-                            meshes[meshname] = {'appearances':[meshApp],'sector':'ALL'}
-                        else:
-                            meshes[meshname]['appearances'].append(meshApp)
+                depot_path, meshname, meshpath, meshApp, _ = component_mesh_info(c)
+                if depot_path and meshname and meshpath and not is_excluded_mesh(depot_path, meshpath, meshname, excluded_meshes):
+                    mesh_key = depot_to_local_path(path, depot_path)
+                    if mesh_key not in meshes:
+                        meshes[mesh_key] = {'appearances':[meshApp],'sector':'ALL'}
+                    else:
+                        meshes[mesh_key]['appearances'].append(meshApp)
 
         meshes_w_apps={}
 
@@ -1393,7 +1583,7 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
             chunks = None
             ent_coll = bpy.data.collections.new(ent_name+'_'+app_name)
             app_name = app_lookup.get(requested_app_name, app_name)
-            if inColl and inColl in coll_scene.children.keys():
+            if inColl and inColl in coll_scene.children:
                 par_coll=bpy.data.collections.get(inColl)
                 par_coll.children.link(ent_coll)
             else:
@@ -1408,30 +1598,11 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
             if not chunks:
                 chunks=ent_chunks.get(requested_app_name) or ent_chunks.get(app_name) or ent_component_data
 
-
-            enum_items = []
-            default_index = None
-
-            for idx, variant in enumerate(ent_applist):
-                enum_items.append((str(idx), variant, f"appearanceName {idx + 1}"))
-                if variant == app_name:  # Check if the variant matches the passed app_name
-                    default_index = str(idx)  # Set the default index if found
-
-            if default_index is None:
-                default_index = '0'
-
-            if len(enum_items)>0:
-                bpy.types.Collection.appearanceName = bpy.props.EnumProperty(
-                    name="Ent Appearances",
-                    items=enum_items,
-                    default=default_index,
-                )
+            ent_coll['appearanceName'] = app_name
+            ent_coll['appearanceIndex'] = ent_app_index_by_name.get(app_name, 0)
 
             comps=app_comps.get(requested_app_name) or app_comps.get(app_name) or ent_components
-            transform_components = list(ent_components)
-            for comp in comps:
-                if comp not in transform_components:
-                    transform_components.append(comp)
+            transform_components = list({id(comp): comp for comp in list(ent_components) + list(comps)}.values())
             ent_component_ids = {id(comp) for comp in ent_components}
             ent_parent_transform_lookup = build_parent_transform_lookup(ent_component_data)
             app_parent_transform_lookup = build_parent_transform_lookup(chunks)
@@ -1477,15 +1648,15 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
                                         print('rig json loaded')
                                 gameplay_anims = c.get('animations', {}).get('gameplay')
                                 if gameplay_anims is not None and len(gameplay_anims)>0:
-                                    old_armature_names = current_armature_names()
                                     anim_depot = gameplay_anims[0]['animSet']['DepotPath']['$value']
                                     animpath=resolve_anim_glb_path(asset_index, anim_depot)
                                     if animpath:
                                         bpy.ops.io_scene_gltf.cp77(with_materials, filepath=animpath, scripting=True)
                                         # find the armature we just loaded
-                                        arms = imported_armatures_since(old_armature_names)
+                                        arms = imported_armatures_from_selection()
                                         if arms:
                                             rig=arms[0]
+                                            cache_armature_bones(rig)
                                             bones=rig.pose.bones
                                             rig["animset"] = animpath
                                             rig["rig"] = rig_path
@@ -1520,12 +1691,14 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
                             print(f"rig armature created from json for {rig_name}")
                     if armature is not None and (rig is None or rig_name == 'deformation_rig'):
                         rig = armature
+                        cache_armature_bones(rig)
                         bones = rig.pose.bones
                         rig_j = rig_json_by_component_name.get(rig_name, rig_j)
                         rig_bone_index = build_rig_bone_index(rig_j)
             else:
                 component_name_value = rig.get('componentName') if hasattr(rig, 'get') else None
                 if component_name_value and component_name_value not in armature_by_component_name:
+                    cache_armature_bones(rig)
                     armature_by_component_name[component_name_value] = rig
 
             if not vehicle_slots:
@@ -1550,15 +1723,13 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
 
             for c in comps:
                 comp_name = component_name(c)
-                vs_rot=None
-                if not (c.get('$type')=='gameTransformAnimatorComponent' or 'mesh' in c.keys() or 'graphicsMesh' in c.keys()):
+                if not (c.get('$type')=='gameTransformAnimatorComponent' or 'mesh' in c or 'graphicsMesh' in c):
                     continue
 
                 if c.get('$type')=='gameTransformAnimatorComponent' and c['animations'][0]['$type']=='gameTransformAnimationDefinition':
                     duration=c['animations'][0]['timeline']['items'][0]['duration']
                     HRID=c['animations'][0]['timeline']['items'][0]['impl']['HandleRefId']
                     chunk_anim = anim_impl_lookup.get(int(HRID), 0)
-                    anim_HId=0
                     if isinstance(chunk_anim, dict) and chunk_anim['$type']=='gameTransformAnimation_RotateOnAxis':
                         rot_axis=chunk_anim['axis']
                         axis_no=0 # default to x
@@ -1584,65 +1755,64 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
                             modifier.mode_after = 'REPEAT'
                             for pt in obj_fcu.keyframe_points:
                                 pt.interpolation = 'LINEAR'
-                elif 'mesh' in c.keys() or 'graphicsMesh' in c.keys():
-                    #print(c['mesh']['DepotPath']['$value'])
-                    depot_path = mesh_component_depot(c)
-                    meshname=os.path.basename(depot_path.replace('\\',os.sep)) if depot_path else ''
-                    meshpath=resolve_mesh_glb_path(asset_index, depot_path)
-                    component_enabled = is_component_enabled(c)
+                elif 'mesh' in c or 'graphicsMesh' in c:
+                    depot_path, meshname, meshpath, meshApp, component_enabled = component_mesh_info(c)
                     if meshname and meshpath and not is_excluded_mesh(depot_path, meshpath, meshname, excluded_meshes):
                         new=None
                         try:
-                            meshApp=mesh_appearance_value(c)
-                            try:
-                                # TODO: sim, this is broken, pls fix Y_Y
-                                # make this instance from masters rather than loading multiple times
-                                #bpy.ops.io_scene_gltf.cp77(with_materials, filepath=meshpath, appearances=meshApp,scripting=True,generate_overrides=generate_overrides)
-                                group, groupname = get_group(meshpath,meshApp,Masters)
-                                if (group):
-                                    new=bpy.data.collections.new(groupname)                                       
-                                    ent_coll.children.link(new)
-                                    copied_objects = []
-                                    object_copy_map = {}
-                                    for old_obj in group.all_objects:
-                                        obj=old_obj.copy()
-                                        object_copy_map[old_obj] = obj
-                                        copied_objects.append(obj)
-                                        new.objects.link(obj)
-                                    remap_copied_object_references(copied_objects, object_copy_map)
-                                    for obj in copied_objects:
-                                        obj['componentName'] = comp_name
-                                        obj['sourcePath'] = meshpath
-                                        obj['meshAppearance'] = meshApp
-                                        obj['componentEnabled'] = component_enabled
-                                        if app_path:
-                                            obj['appResource'] = app_path[0]
-                                        obj['entAppearance'] = app_name
-                                        if not component_enabled:
-                                            obj.hide_set(True)
-                                            obj.hide_render = True
-                                        if 'Armature' in obj.name:
-                                            obj.hide_set(True)
-                                else:
-                                    print('BREAK collection not found after import - ', meshname)
-                            except:
-                                print('import threw an error:')
-                                print(traceback.format_exc())
-                                continue
+                            # TODO: sim, this is broken, pls fix Y_Y
+                            # make this instance from masters rather than loading multiple times
+                            #bpy.ops.io_scene_gltf.cp77(with_materials, filepath=meshpath, appearances=meshApp,scripting=True,generate_overrides=generate_overrides)
+                            group, groupname = get_group(meshpath,meshApp,Masters)
+                            if (group):
+                                new=bpy.data.collections.new(groupname)                                       
+                                ent_coll.children.link(new)
+                                copied_objects = []
+                                object_copy_map = {}
+                                link_object = new.objects.link
+                                for old_obj in tuple(group.all_objects):
+                                    obj=old_obj.copy()
+                                    object_copy_map[old_obj] = obj
+                                    copied_objects.append(obj)
+                                    link_object(obj)
+                                remap_copied_object_references(copied_objects, object_copy_map)
+                                for obj in copied_objects:
+                                    obj['componentName'] = comp_name
+                                    obj['sourcePath'] = meshpath
+                                    obj['meshAppearance'] = meshApp
+                                    obj['componentEnabled'] = component_enabled
+                                    if app_resource:
+                                        obj['appResource'] = app_resource
+                                    obj['entAppearance'] = app_name
+                                    if not component_enabled:
+                                        obj.hide_set(True)
+                                        obj.hide_render = True
+                                    if 'Armature' in obj.name:
+                                        obj.hide_set(True)
+                            else:
+                                print('BREAK collection not found after import - ', meshname)
                             print('checking for collection - ', meshname)
                             if new is None:
                                 print('collection not found after import - ', meshname)
                                 continue
-                            objs = new.objects
+                            objs = copied_objects
                             component_is_skinned = component_uses_deformation_skinning(c, skinning_lookup)
-                            skinning_bind = skinning_bind_name(c, skinning_lookup)
                             if component_is_skinned:
                                 resolved_matrix, bindname, slotname, binding_type = transform_resolver.resolve_component_matrix(c)
                             else:
                                 resolved_matrix, bindname, slotname, binding_type = transform_resolver.resolve_hard_component_matrix(c)
                             if component_is_skinned:
-                                bind_skinned_objects_to_rig(new.objects, rig)
-                            for obj in new.objects:
+                                bind_skinned_objects_to_rig(objs, rig)
+                            can_bind_bone = (
+                                not component_is_skinned
+                                and binding_type in {'slot', 'bone'}
+                                and bindname
+                                and armature_has_bone(rig, bindname)
+                            )
+                            child_inverse = child_of_inverse_matrix(rig, bindname) if can_bind_bone else None
+                            copy_wheel_rotation = can_bind_bone and 'wheel' in bindname
+                            set_steering_subtarget = copy_wheel_rotation and 'steering' not in bindname
+                            for obj in objs:
                                 obj['bindingType'] = binding_type
                                 if bindname:
                                     obj['bindname'] = bindname
@@ -1653,18 +1823,16 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
                                 if not component_enabled:
                                     obj.hide_set(True)
                                     obj.hide_render = True
-                                if component_is_skinned:
-                                    continue
-                                if binding_type in {'slot', 'bone'} and rig and bindname and getattr(rig, 'pose', None) and bindname in rig.pose.bones:
-                                    if 'Child Of' not in obj.constraints.keys():
+                                if can_bind_bone:
+                                    if 'Child Of' not in obj.constraints:
                                         co = obj.constraints.new(type='CHILD_OF')
                                         co.target = rig
                                         co.subtarget = bindname
-                                        set_child_of_inverse(co, rig, bindname)
-                                    if 'wheel' in bindname:
+                                        co.inverse_matrix = child_inverse
+                                    if copy_wheel_rotation:
                                         cr = obj.constraints.new(type='COPY_ROTATION')
                                         cr.target = rig
-                                        if 'steering' not in bindname:
+                                        if set_steering_subtarget:
                                             cr.subtarget = bindname
 
 
@@ -1679,35 +1847,13 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
                                 if move_coll.name in coll_scene.children:
                                     coll_scene.children.unlink(move_coll)
 
-                            # New chunkMask reading
-                            # convert the value to a list of bools, then apply those statuses to the submeshes.
-                            if 'chunkMask' in c.keys():
-                                cm= c['chunkMask']
-                                if isinstance(cm,str):
-                                    bin_str = bin(int(cm))[2:]
-                                else:
-                                    bin_str = bin(cm)[2:]
-                                cm_list = [bool(int(bit)) for bit in bin_str]
-                                cm_list.reverse()
+                            if 'chunkMask' in c:
+                                cm_int = int(c['chunkMask'])
                                 for obj in objs:
-                                    subnum = None
-                                    # Try to parse index from object name like 'submesh_00'
-                                    m = SUBMESH_PATTERN.search(obj.name)
-                                    if m:
-                                        subnum = int(m.group(1))
-                                    else:
-                                        # Fallback: try from material names
-                                        mats = getattr(obj.data, 'materials', []) if hasattr(obj, 'data') else []
-                                        for mat in mats:
-                                            if mat and getattr(mat, 'name', None):
-                                                m2 = SUBMESH_PATTERN.search(mat.name)
-                                                if m2:
-                                                    subnum = int(m2.group(1))
-                                                    break
+                                    subnum = submesh_index_for_object(obj)
                                     if subnum is None:
                                         continue
-                                    bit = cm_list[subnum] if subnum < len(cm_list) else True
-                                    hidden = (not component_enabled) or (not bit)
+                                    hidden = (not component_enabled) or not bool((cm_int >> subnum) & 1)
                                     obj.hide_set(hidden)
                                     obj.hide_render = hidden
 
@@ -1721,10 +1867,10 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
                     mesh_obj=None
                     lcgroup=None
                     lcgroupname=c['name']['$value']
-                    if not lcgroupname in bpy.data.collections.get("MasterInstances").children.keys():
-                        if 'shape' in c.keys() and 'Data' in c['shape'].keys() and 'vertices' in c['shape']['Data'].keys():
+                    if lcgroupname not in bpy.data.collections.get("MasterInstances").children:
+                        if 'shape' in c and 'Data' in c['shape'] and 'vertices' in c['shape']['Data']:
                             vertices=c['shape']['Data']['vertices']
-                            if len(vertices)>0 and 'indices' in c['shape']['Data'].keys():
+                            if len(vertices)>0 and 'indices' in c['shape']['Data']:
                                 indices=c['shape']['Data']['indices']
                                 if len(indices)>0:
                                     lcgroup=bpy.data.collections.new(lcgroupname)
@@ -1758,7 +1904,7 @@ def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None
                                                     mesh_obj['bindname']=bindname
                                     lcgroup.objects.link(mesh_obj)
                                     Masters.children.link(lcgroup)
-                    if lcgroupname in bpy.data.collections.get("MasterInstances").children.keys():
+                    if lcgroupname in bpy.data.collections.get("MasterInstances").children:
                         Mastlcgroup=bpy.data.collections.get(lcgroupname)
                         if (Mastlcgroup):
                             lcgroup=bpy.data.collections.new(lcgroupname)

--- a/i_scene_cp77_gltf/importers/entity_import.py
+++ b/i_scene_cp77_gltf/importers/entity_import.py
@@ -2,7 +2,6 @@
 # Updated May 23 with vehicle rig support
 import json
 import re
-import glob
 import os
 import bpy
 import time
@@ -17,7 +16,12 @@ from .phys_import import cp77_phys_import
 from ..collisiontools.pxbridge.io_phys import import_collider_as_actor
 from io_scene_gltf2.io.imp.gltf2_io_gltf import glTFImporter
 from .import_common import *
+from ..datakrash import DepotAssetIndex
+from .read_rig import create_armature_from_data
 from bpy_extras import anim_utils
+
+SUBMESH_PATTERN = re.compile(r"submesh_(\d+)", re.IGNORECASE)
+ARMATURE_TYPE = 'ARMATURE'
 
 
 def create_axes(ent_coll,name):
@@ -33,14 +37,1035 @@ def create_axes(ent_coll,name):
         o=ent_coll.objects[name]
     return o
 
+
+def cname_value(value, default=''):
+    if isinstance(value, dict):
+        return value.get('$value', default)
+    return value if value is not None else default
+
+
+def component_name(component, default=''):
+    return cname_value(component.get('name'), default) if isinstance(component, dict) else default
+
+
+def depot_path_value(component, key):
+    resource = component.get(key) if isinstance(component, dict) else None
+    if not isinstance(resource, dict):
+        return ''
+    depot_path = resource.get('DepotPath')
+    return cname_value(depot_path)
+
+
+def mesh_component_depot(component):
+    return depot_path_value(component, 'mesh') or depot_path_value(component, 'graphicsMesh')
+
+
+def mesh_appearance_value(component):
+    value = component.get('meshAppearance') if isinstance(component, dict) else None
+    return cname_value(value, 'default')
+
+
+def red_quaternion(value):
+    if not isinstance(value, dict):
+        return Quaternion((1, 0, 0, 0))
+    return Quaternion((
+        value.get('r', 1),
+        value.get('i', 0),
+        value.get('j', 0),
+        value.get('k', 0),
+    ))
+
+
+def fixed_point_position(transform):
+    position = transform.get('Position', {}) if isinstance(transform, dict) else {}
+    return Vector((
+        position.get('x', {}).get('Bits', 0) / 131072,
+        position.get('y', {}).get('Bits', 0) / 131072,
+        position.get('z', {}).get('Bits', 0) / 131072,
+    ))
+
+
+def component_local_transform(component):
+    transform = component.get('localTransform', {}) if isinstance(component, dict) else {}
+    return fixed_point_position(transform), red_quaternion(transform.get('Orientation'))
+
+
+def is_component_enabled(component):
+    return component.get('isEnabled', 1) != 0 if isinstance(component, dict) else True
+
+
+def depot_to_local_path(root, depot_path):
+    return os.path.join(root, depot_path).replace('\\', os.sep) if depot_path else ''
+
+
+def depot_to_glb_path(root, depot_path):
+    local_path = depot_to_local_path(root, depot_path)
+    if not local_path:
+        return ''
+    return os.path.splitext(local_path)[0] + '.glb'
+
+
+def norm_path_key(value):
+    return os.path.normcase(os.path.normpath(value)) if value else ''
+
+
+def anim_json_path_from_glb(anim_path):
+    return os.path.splitext(anim_path)[0] + '.json'
+
+
+ASSET_INDEX_EXTENSIONS = (
+    '.app.json',
+    '.glb',
+    '.mesh.json',
+    '.anims.glb',
+    '.anims.json',
+    '.rig.json',
+    '.phys.json',
+)
+
+
+def split_source_raw_root(filepath):
+    if not filepath:
+        return '', ''
+    normalized = os.path.normpath(filepath)
+    lowered = normalized.replace('\\', '/').lower()
+    marker = '/source/raw'
+    marker_index = lowered.find(marker)
+    if marker_index < 0:
+        marker = 'source/raw'
+        marker_index = lowered.find(marker)
+    if marker_index < 0:
+        root = os.path.dirname(normalized)
+        return root, os.path.basename(normalized)
+    end = marker_index + len(marker)
+    root = normalized[:end].replace('/', os.sep)
+    remainder = normalized[end:].lstrip('/\\')
+    return root, remainder.replace('/', os.sep)
+
+
+def build_asset_index(root):
+    return DepotAssetIndex.cached(root, ASSET_INDEX_EXTENSIONS)
+
+
+def indexed_asset_files(asset_index, extension, provided=None):
+    if provided:
+        return sorted(os.path.normpath(path) for path in provided)
+    return asset_index.get_files_by_extension(extension)
+
+
+def resolve_app_json_path(asset_index, depot_path):
+    return asset_index.resolve_app_json(depot_path)
+
+
+def resolve_mesh_glb_path(asset_index, depot_path):
+    return asset_index.resolve_mesh_glb(depot_path)
+
+
+def resolve_mesh_json_path(asset_index, depot_path):
+    return asset_index.resolve_mesh_json(depot_path)
+
+
+def resolve_rig_json_path(asset_index, depot_path):
+    return asset_index.resolve_rig_json(depot_path)
+
+
+def resolve_anim_glb_path(asset_index, depot_path):
+    return asset_index.resolve_anim_glb(depot_path)
+
+
+def resolve_anim_json_path_from_glb(asset_index, anim_path):
+    return asset_index.resolve_anim_json_from_glb(anim_path)
+
+
+def build_component_lookup(components):
+    return {component_name(component): component for component in components if component_name(component)}
+
+
+def build_ent_app_lookup(ent_apps):
+    by_appearance = {
+        cname_value(app.get('appearanceName')): index
+        for index, app in enumerate(ent_apps)
+        if cname_value(app.get('appearanceName'))
+    }
+    by_name = {
+        cname_value(app.get('name')): index
+        for index, app in enumerate(ent_apps)
+        if cname_value(app.get('name'))
+    }
+    return by_appearance, by_name
+
+
+def default_appearance_from_json(filepath):
+    try:
+        with open(filepath, 'r', encoding='utf-8') as handle:
+            root = json.load(handle)
+    except Exception:
+        return ''
+    root_chunk = root.get('Data', {}).get('RootChunk', {}) if isinstance(root, dict) else {}
+    return cname_value(root_chunk.get('defaultAppearance'))
+
+
+def normalize_default_appearance(ent_default, ent_apps, by_appearance, by_name, filepath):
+    candidates = []
+    if ent_default and ent_default != 'None':
+        candidates.append(ent_default)
+    json_default = default_appearance_from_json(filepath)
+    if json_default and json_default != 'None' and json_default not in candidates:
+        candidates.append(json_default)
+
+    for candidate in candidates:
+        if candidate in by_appearance:
+            return candidate
+        by_name_idx = by_name.get(candidate, -1)
+        if by_name_idx >= 0:
+            return cname_value(ent_apps[by_name_idx].get('appearanceName'), candidate)
+    return candidates[0] if candidates else ''
+
+
+def resolve_requested_appearance_name(app_name, ent_default, ent_apps, by_appearance, by_name):
+    if app_name == 'default':
+        return ent_default or 'default'
+    return app_name
+
+
+def resolve_ent_app(app_name, ent_apps, by_appearance, by_name, ent_default=None):
+    ent_app_idx = by_appearance.get(app_name, -1)
+    if ent_app_idx >= 0:
+        print('appearance matched, id = ', ent_app_idx)
+        return ent_app_idx, app_name
+    ent_app_idx = by_name.get(app_name, -1)
+    if ent_app_idx >= 0:
+        print('appearance matched, id = ', ent_app_idx)
+        return ent_app_idx, cname_value(ent_apps[ent_app_idx].get('appearanceName'), app_name)
+    if app_name != 'default':
+        return 0, cname_value(ent_apps[0].get('appearanceName'), app_name) if ent_apps else app_name
+    ent_app_idx = by_name.get(ent_default, -1)
+    if ent_app_idx >= 0:
+        print('appearance matched, id = ', ent_app_idx)
+        return ent_app_idx, cname_value(ent_apps[ent_app_idx].get('appearanceName'), app_name)
+    ent_app_idx = by_appearance.get(ent_default, -1)
+    if ent_app_idx >= 0:
+        print('appearance matched, id = ', ent_app_idx)
+        return ent_app_idx, cname_value(ent_apps[ent_app_idx].get('appearanceName'), app_name)
+    return 0, cname_value(ent_apps[0].get('appearanceName'), app_name) if ent_apps else app_name
+
+
+def build_parent_transform_lookup(chunks):
+    lookup = {}
+    if not chunks:
+        return lookup
+    for chunk in chunks:
+        parent_transform = chunk.get('parentTransform') if isinstance(chunk, dict) else None
+        if isinstance(parent_transform, dict) and 'HandleId' in parent_transform:
+            lookup[parent_transform['HandleId']] = parent_transform
+    return lookup
+
+
+def build_skinning_lookup(chunks):
+    lookup = {}
+    if not chunks:
+        return lookup
+    for chunk in chunks:
+        skinning = chunk.get('skinning') if isinstance(chunk, dict) else None
+        if isinstance(skinning, dict) and 'HandleId' in skinning:
+            lookup[skinning['HandleId']] = skinning
+    return lookup
+
+
+class ComponentHandleLookup:
+    def __init__(self, default_lookup=None):
+        self.default_lookup = default_lookup or {}
+        self.by_component_id = {}
+
+    def set_component_lookup(self, component, lookup):
+        if isinstance(component, dict):
+            self.by_component_id[id(component)] = lookup or {}
+
+    def get_for_component(self, component, handle_id):
+        lookup = self.by_component_id.get(id(component), self.default_lookup)
+        return lookup.get(handle_id)
+
+    def get(self, handle_id):
+        return self.default_lookup.get(handle_id)
+
+
+def build_anim_impl_lookup(chunks):
+    lookup = {}
+    if not chunks:
+        return lookup
+    for chunk in chunks:
+        if not isinstance(chunk, dict) or chunk.get('$type') != 'gameTransformAnimatorComponent':
+            continue
+        try:
+            impl = chunk['animations'][0]['timeline']['items'][0]['impl']
+        except (KeyError, IndexError, TypeError):
+            continue
+        if 'HandleId' in impl:
+            lookup[int(impl['HandleId'])] = impl.get('Data')
+    return lookup
+
+
+def build_slot_lookup(vehicle_slots):
+    return {cname_value(slot.get('slotName')): slot for slot in vehicle_slots or [] if cname_value(slot.get('slotName'))}
+
+
+def resolve_slot_bone(slot_lookup, slotname, fallback=None):
+    slot = slot_lookup.get(slotname) if slot_lookup else None
+    return cname_value(slot.get('boneName'), fallback) if slot else fallback
+
+
+def build_rig_bone_index(rig_j):
+    if not rig_j or not rig_j.get('boneNames'):
+        return {}
+    return {cname_value(bone): index for index, bone in enumerate(rig_j['boneNames']) if cname_value(bone)}
+
+def rig_json_bone_matrix(rig_j, bone_name):
+    if not isinstance(rig_j, dict) or not bone_name:
+        return Matrix.Identity(4)
+    bone_names = rig_j.get('boneNames')
+    if not isinstance(bone_names, list):
+        return Matrix.Identity(4)
+    index = None
+    for candidate_index, bone in enumerate(bone_names):
+        if cname_value(bone) == bone_name:
+            index = candidate_index
+            break
+    if index is None:
+        return Matrix.Identity(4)
+    for key in ('aPoseMS', 'boneTransforms', 'aPoseLS'):
+        transforms = rig_j.get(key)
+        if isinstance(transforms, list) and index < len(transforms):
+            return qs_transform_matrix(transforms[index])
+    return Matrix.Identity(4)
+
+
+def build_slot_owner_rig_jsons(components, parent_transform_lookup, rig_json_by_component_name):
+    slot_owner_rig_jsons = {}
+    if not components or not rig_json_by_component_name:
+        return slot_owner_rig_jsons
+    for component in components:
+        if not isinstance(component, dict) or component.get('$type') != 'entSlotComponent':
+            continue
+        owner_name = component_name(component)
+        if not owner_name:
+            continue
+        binding = parent_transform_data(component, parent_transform_lookup)
+        bind_name = cname_value(binding.get('bindName')) if isinstance(binding, dict) else ''
+        rig_json = rig_json_by_component_name.get(bind_name)
+        if rig_json is not None:
+            slot_owner_rig_jsons[owner_name] = rig_json
+    return slot_owner_rig_jsons
+
+
+def build_slot_owner_rig_owner_names(components, parent_transform_lookup, rig_component_names):
+    slot_owner_rig_owner_names = {}
+    if not components or not rig_component_names:
+        return slot_owner_rig_owner_names
+    for component in components:
+        if not isinstance(component, dict) or component.get('$type') != 'entSlotComponent':
+            continue
+        owner_name = component_name(component)
+        if not owner_name:
+            continue
+        binding = parent_transform_data(component, parent_transform_lookup)
+        bind_name = cname_value(binding.get('bindName')) if isinstance(binding, dict) else ''
+        if bind_name in rig_component_names:
+            slot_owner_rig_owner_names[owner_name] = bind_name
+    return slot_owner_rig_owner_names
+
+
+
+def is_excluded_mesh(depot_path, meshpath, meshname, excluded_meshes):
+    if not excluded_meshes:
+        return False
+    candidates = {depot_path, meshpath, meshname, os.path.basename(depot_path.replace('\\', os.sep)) if depot_path else ''}
+    norm_candidates = {norm_path_key(candidate) for candidate in candidates if candidate}
+    return bool(norm_candidates.intersection(excluded_meshes))
+
+
+
+def red_scale(transform, visual_scale=None):
+    scale = transform.get('Scale') or transform.get('scale') if isinstance(transform, dict) else None
+    if not isinstance(scale, dict) and isinstance(visual_scale, dict):
+        scale = visual_scale
+    if not isinstance(scale, dict):
+        return Vector((1, 1, 1))
+    return Vector((
+        scale.get('X', 1),
+        scale.get('Y', 1),
+        scale.get('Z', 1),
+    ))
+
+
+def red_transform_matrix(transform, visual_scale=None):
+    if not isinstance(transform, dict):
+        return Matrix.Identity(4)
+    return Matrix.LocRotScale(
+        fixed_point_position(transform),
+        red_quaternion(transform.get('Orientation')),
+        red_scale(transform, visual_scale),
+    )
+
+
+def slot_transform_matrix(slot):
+    if not isinstance(slot, dict):
+        return Matrix.Identity(4)
+    pos_data = slot.get('relativePosition') if isinstance(slot.get('relativePosition'), dict) else {}
+    pos = Vector((
+        pos_data.get('X', 0),
+        pos_data.get('Y', 0),
+        pos_data.get('Z', 0),
+    ))
+    return Matrix.LocRotScale(
+        pos,
+        red_quaternion(slot.get('relativeRotation')),
+        Vector((1, 1, 1)),
+    )
+
+
+def slot_translation_matrix(slot):
+    if not isinstance(slot, dict):
+        return Matrix.Identity(4)
+    pos_data = slot.get('relativePosition') if isinstance(slot.get('relativePosition'), dict) else {}
+    return Matrix.Translation(Vector((
+        pos_data.get('X', 0),
+        pos_data.get('Y', 0),
+        pos_data.get('Z', 0),
+    )))
+
+
+def qs_transform_matrix(transform):
+    if not isinstance(transform, dict):
+        return Matrix.Identity(4)
+    translation = transform.get('Translation')
+    if isinstance(translation, dict):
+        location = Vector((
+            translation.get('X', 0),
+            translation.get('Y', 0),
+            translation.get('Z', 0),
+        ))
+    else:
+        location = fixed_point_position(transform)
+    scale_data = transform.get('Scale') if isinstance(transform.get('Scale'), dict) else None
+    scale = Vector((
+        scale_data.get('X', 1),
+        scale_data.get('Y', 1),
+        scale_data.get('Z', 1),
+    )) if scale_data else Vector((1, 1, 1))
+    return Matrix.LocRotScale(location, red_quaternion(transform.get('Rotation') or transform.get('Orientation')), scale)
+
+
+def parent_transform_data(component, parent_transform_lookup):
+    parent_transform = component.get('parentTransform') if isinstance(component, dict) else None
+    if not isinstance(parent_transform, dict):
+        return None
+    if 'Data' in parent_transform:
+        return parent_transform.get('Data')
+    handle_id = parent_transform.get('HandleRefId')
+    if handle_id is None:
+        return None
+    if hasattr(parent_transform_lookup, 'get_for_component'):
+        referenced = parent_transform_lookup.get_for_component(component, handle_id)
+    else:
+        referenced = parent_transform_lookup.get(handle_id) if parent_transform_lookup else None
+    if isinstance(referenced, dict):
+        return referenced.get('Data')
+    return None
+
+
+def skinning_binding_data(component, skinning_lookup=None):
+    skinning = component.get('skinning') if isinstance(component, dict) else None
+    if not isinstance(skinning, dict):
+        return None
+    if isinstance(skinning.get('Data'), dict):
+        return skinning.get('Data')
+    handle_id = skinning.get('HandleRefId')
+    if handle_id is None:
+        return skinning
+    if hasattr(skinning_lookup, 'get_for_component'):
+        referenced = skinning_lookup.get_for_component(component, handle_id)
+    else:
+        referenced = skinning_lookup.get(handle_id) if skinning_lookup else None
+    if isinstance(referenced, dict):
+        return referenced.get('Data')
+    return skinning
+
+
+def skinning_bind_name(component, skinning_lookup=None):
+    data = skinning_binding_data(component, skinning_lookup)
+    return cname_value(data.get('bindName')) if isinstance(data, dict) else ''
+
+
+def component_uses_skinning(component, skinning_lookup=None):
+    bind_name = skinning_bind_name(component, skinning_lookup)
+    return bool(bind_name and bind_name != 'None')
+
+
+def component_uses_deformation_skinning(component, skinning_lookup=None):
+    return component_uses_skinning(component, skinning_lookup)
+
+
+def find_collection_armature(objects):
+    for obj in objects:
+        if getattr(obj, 'type', None) == ARMATURE_TYPE:
+            return obj
+    for obj in objects:
+        parent = getattr(obj, 'parent', None)
+        if parent is not None and getattr(parent, 'type', None) == ARMATURE_TYPE:
+            return parent
+        for modifier in getattr(obj, 'modifiers', []):
+            if modifier.type == 'ARMATURE' and getattr(modifier, 'object', None):
+                return modifier.object
+    return None
+
+
+def current_armature_names():
+    return {obj.name for obj in bpy.data.objects if getattr(obj, 'type', None) == ARMATURE_TYPE}
+
+
+def imported_armatures_since(previous_names):
+    selected = [obj for obj in bpy.context.selected_objects if getattr(obj, 'type', None) == ARMATURE_TYPE and obj.name not in previous_names]
+    if selected:
+        return selected
+    return [obj for obj in bpy.data.objects if getattr(obj, 'type', None) == ARMATURE_TYPE and obj.name not in previous_names]
+
+
+def set_child_of_inverse(constraint, target, subtarget_name=''):
+    target_matrix = target.matrix_world.copy()
+    if subtarget_name and getattr(target, 'pose', None) and subtarget_name in target.pose.bones:
+        target_matrix = target.matrix_world @ target.pose.bones[subtarget_name].matrix
+    try:
+        constraint.inverse_matrix = target_matrix.inverted()
+    except Exception:
+        constraint.inverse_matrix = Matrix.Identity(4)
+
+def existing_armature_for_rig_json(rig_json_path):
+    target = norm_path_key(rig_json_path)
+    if not target:
+        return None
+    for obj in bpy.data.objects:
+        if getattr(obj, 'type', None) != ARMATURE_TYPE:
+            continue
+        candidates = [obj.get('rig'), obj.get('source_rig_file'), obj.get('sourceRigFile')]
+        for candidate in candidates:
+            if candidate and norm_path_key(candidate) == target:
+                return obj
+    return None
+
+
+def ensure_armature_from_rig_json(rig_json_path, component_name_value='', ent_name=''):
+    if not rig_json_path:
+        return None
+    existing = existing_armature_for_rig_json(rig_json_path)
+    if existing is not None:
+        return existing
+
+    old_armature_names = current_armature_names()
+    created = create_armature_from_data(rig_json_path, "T-Pose", False)
+
+    if getattr(created, 'type', None) == ARMATURE_TYPE:
+        armature = created
+    else:
+        armature = None
+        if isinstance(created, (list, tuple)):
+            for item in created:
+                if getattr(item, 'type', None) == ARMATURE_TYPE:
+                    armature = item
+                    break
+        if armature is None:
+            new_armatures = imported_armatures_since(old_armature_names)
+            if new_armatures:
+                armature = new_armatures[0]
+
+    if armature is not None:
+        armature['rig'] = rig_json_path
+        armature['source_rig_file'] = rig_json_path
+        if component_name_value:
+            armature['componentName'] = component_name_value
+        if ent_name:
+            armature['ent'] = ent_name + '.ent.json'
+    return armature
+
+
+def armature_has_bone(armature, bone_name):
+    return bool(
+        armature
+        and bone_name
+        and getattr(armature, 'pose', None)
+        and bone_name in armature.pose.bones
+    )
+
+
+def remap_copied_object_references(copied_objects, object_map):
+    modifier_targets = 0
+    parent_targets = 0
+    constraint_targets = 0
+    for obj in copied_objects:
+        parent = getattr(obj, 'parent', None)
+        if parent in object_map:
+            world = obj.matrix_world.copy()
+            obj.parent = object_map[parent]
+            obj.matrix_world = world
+            parent_targets += 1
+        for modifier in getattr(obj, 'modifiers', []):
+            target = getattr(modifier, 'object', None)
+            if target in object_map:
+                modifier.object = object_map[target]
+                modifier_targets += 1
+        for constraint in getattr(obj, 'constraints', []):
+            target = getattr(constraint, 'target', None)
+            if target in object_map:
+                constraint.target = object_map[target]
+                constraint_targets += 1
+    return modifier_targets, parent_targets, constraint_targets
+
+
+def bind_skinned_objects_to_rig(objects, rig):
+    if rig is None:
+        return 0, 0
+    retargeted = 0
+    reparented = 0
+    for obj in objects:
+        if getattr(obj, 'type', None) != 'MESH':
+            continue
+        for modifier in getattr(obj, 'modifiers', []):
+            if modifier.type != 'ARMATURE':
+                continue
+            if modifier.object != rig:
+                modifier.object = rig
+                retargeted += 1
+        parent = getattr(obj, 'parent', None)
+        if parent is not None and getattr(parent, 'type', None) == 'ARMATURE' and parent != rig:
+            world = obj.matrix_world.copy()
+            obj.parent = rig
+            obj.matrix_parent_inverse = rig.matrix_world.inverted()
+            obj.matrix_world = world
+            reparented += 1
+    return retargeted, reparented
+
+
+
+
+def build_slot_component_lookups(components):
+    lookups = {}
+    for component in components or []:
+        slots = component.get('slots') if isinstance(component, dict) else None
+        name = component_name(component)
+        if name and isinstance(slots, list):
+            lookups[name] = build_slot_lookup(slots)
+    return lookups
+
+
+class EntityTransformResolver:
+    def __init__(self, components, parent_transform_lookup, skinning_lookup=None, rig=None, rig_j=None, rig_bone_index=None, default_slot_lookup=None, slot_owner_rig_jsons=None, rig_json_by_component_name=None, armature_by_component_name=None, slot_owner_rig_owner_names=None):
+        self.components = components or []
+        self.components_by_name = build_component_lookup(self.components)
+        self.parent_transform_lookup = parent_transform_lookup or {}
+        self.skinning_lookup = skinning_lookup or {}
+        self.slot_component_lookups = build_slot_component_lookups(self.components)
+        self.rig = rig
+        self.rig_j = rig_j
+        self.rig_bone_index = rig_bone_index or build_rig_bone_index(rig_j)
+        self.slot_owner_rig_jsons = slot_owner_rig_jsons or {}
+        self.rig_json_by_component_name = rig_json_by_component_name or {}
+        self.armature_by_component_name = armature_by_component_name or {}
+        self.slot_owner_rig_owner_names = slot_owner_rig_owner_names or {}
+        self.rig_json_bone_indices = {id(rig_json): build_rig_bone_index(rig_json) for rig_json in self.rig_json_by_component_name.values() if isinstance(rig_json, dict)}
+        if isinstance(self.rig_j, dict):
+            self.rig_json_bone_indices[id(self.rig_j)] = self.rig_bone_index
+        self.default_slot_lookup = default_slot_lookup or {}
+        self.cache = {}
+        self.resolving = set()
+
+    def _slot_owner_rig_json(self, slot_owner=None):
+        if slot_owner and slot_owner in self.slot_owner_rig_jsons:
+            return self.slot_owner_rig_jsons[slot_owner]
+        return self.rig_j
+
+    def _rig_json_has_bone(self, bone_name, rig_j=None):
+        if not bone_name or not isinstance(rig_j, dict) or not rig_j.get('boneNames'):
+            return False
+        index = self.rig_json_bone_indices.get(id(rig_j))
+        if index is None:
+            index = build_rig_bone_index(rig_j)
+            self.rig_json_bone_indices[id(rig_j)] = index
+        return bone_name in index
+
+    def _rig_json_for_bone(self, bone_name, slot_owner=None):
+        preferred = self._slot_owner_rig_json(slot_owner)
+        if self._rig_json_has_bone(bone_name, preferred):
+            return preferred
+        for rig_json in self.rig_json_by_component_name.values():
+            if rig_json is not preferred and self._rig_json_has_bone(bone_name, rig_json):
+                return rig_json
+        return preferred
+
+    def _slot_owner_rig_owner_name(self, slot_owner=None):
+        if slot_owner and slot_owner in self.slot_owner_rig_owner_names:
+            return self.slot_owner_rig_owner_names[slot_owner]
+        return ''
+
+    def _armature_for_bone(self, bone_name, slot_owner=None):
+        owner_name = self._slot_owner_rig_owner_name(slot_owner)
+        if owner_name:
+            armature = self.armature_by_component_name.get(owner_name)
+            if armature_has_bone(armature, bone_name):
+                return armature
+        if armature_has_bone(self.rig, bone_name):
+            return self.rig
+        for armature in self.armature_by_component_name.values():
+            if armature_has_bone(armature, bone_name):
+                return armature
+        return None
+
+    def _pose_bone(self, bone_name, slot_owner=None):
+        armature = self._armature_for_bone(bone_name, slot_owner)
+        if armature is not None:
+            return armature, armature.pose.bones[bone_name]
+        return None, None
+
+    def bone_matrix(self, bone_name, slot_owner=None):
+        armature, pose_bone = self._pose_bone(bone_name, slot_owner)
+        if pose_bone is not None:
+            return armature.matrix_world @ pose_bone.matrix
+        rig_j = self._rig_json_for_bone(bone_name, slot_owner)
+        if self._rig_json_has_bone(bone_name, rig_j):
+            return rig_json_bone_matrix(rig_j, bone_name)
+        return Matrix.Identity(4)
+
+    def resolve_slot_matrix(self, slot_owner, slot_name):
+        slot_lookup = self.slot_component_lookups.get(slot_owner) or {}
+        if slot_owner in ('vehicle_slots', 'slots') and self.default_slot_lookup:
+            slot_lookup = slot_lookup or self.default_slot_lookup
+        slot = slot_lookup.get(slot_name)
+        if not slot:
+            return Matrix.Identity(4), slot_owner, slot_name
+        bone_name = cname_value(slot.get('boneName'), slot_name)
+        return self.bone_matrix(bone_name, slot_owner) @ slot_transform_matrix(slot), bone_name, slot_name
+
+    def resolve_binding(self, component):
+        binding = parent_transform_data(component, self.parent_transform_lookup)
+        if not isinstance(binding, dict):
+            return Matrix.Identity(4), '', '', 'none'
+
+        bind_name = cname_value(binding.get('bindName'))
+        slot_name = cname_value(binding.get('slotName'))
+        if not bind_name or bind_name == 'None':
+            return Matrix.Identity(4), bind_name, slot_name, 'none'
+
+        if bind_name in ('vehicle_slots', 'slots'):
+            matrix, bone_name, slot_name = self.resolve_slot_matrix(bind_name, slot_name)
+            return matrix, bone_name, slot_name, 'slot'
+
+        if bind_name == 'deformation_rig':
+            base = self.rig.matrix_world.copy() if self.rig else Matrix.Identity(4)
+            return base, bind_name, slot_name, 'deformation_rig'
+
+        if bind_name in self.components_by_name:
+            bound_component = self.components_by_name[bind_name]
+            if component_uses_skinning(component, self.skinning_lookup) and self._component_is_rig_owner(bound_component):
+                base = self.rig.matrix_world.copy() if self.rig else Matrix.Identity(4)
+                return base, bind_name, slot_name, 'skinning_root'
+            parent_matrix, _, _, _ = self.resolve_component_matrix(bound_component)
+            if slot_name and slot_name != 'None':
+                slot_lookup = self.slot_component_lookups.get(bind_name)
+                if slot_lookup and slot_name in slot_lookup:
+                    return parent_matrix @ slot_transform_matrix(slot_lookup[slot_name]), bind_name, slot_name, 'component_slot'
+            return parent_matrix, bind_name, slot_name, 'component'
+
+        if self.rig and getattr(self.rig, 'pose', None) and bind_name in self.rig.pose.bones:
+            return self.bone_matrix(bind_name), bind_name, slot_name, 'bone'
+
+        return Matrix.Identity(4), bind_name, slot_name, 'unresolved'
+
+    def resolve_component_matrix(self, component):
+        key = component_name(component) or str(id(component))
+        if key in self.cache:
+            return self.cache[key]
+        if key in self.resolving:
+            return Matrix.Identity(4), '', '', 'cycle'
+        self.resolving.add(key)
+        parent_matrix, bind_name, slot_name, binding_type = self.resolve_binding(component)
+        local_matrix = red_transform_matrix(component.get('localTransform', {}), component.get('visualScale'))
+        matrix = parent_matrix @ local_matrix
+        result = (matrix, bind_name, slot_name, binding_type)
+        self.cache[key] = result
+        self.resolving.remove(key)
+        return result
+
+    def _bone_rotation(self, bone_name, slot_owner=None):
+        _, pose_bone = self._pose_bone(bone_name, slot_owner)
+        if pose_bone is not None:
+            return pose_bone.rotation_quaternion.copy()
+        rig_j = self._rig_json_for_bone(bone_name, slot_owner)
+        if self._rig_json_has_bone(bone_name, rig_j):
+            return rig_json_bone_matrix(rig_j, bone_name).to_quaternion()
+        return Quaternion((1, 0, 0, 0))
+
+    def _bone_head(self, bone_name, slot_owner=None):
+        _, pose_bone = self._pose_bone(bone_name, slot_owner)
+        if pose_bone is not None:
+            return pose_bone.head.copy()
+        rig_j = self._rig_json_for_bone(bone_name, slot_owner)
+        if self._rig_json_has_bone(bone_name, rig_j):
+            return rig_json_bone_matrix(rig_j, bone_name).to_translation()
+        return Vector((0, 0, 0))
+
+    def _rig_bone_index(self, bone_name):
+        if not bone_name:
+            return None
+        return self.rig_bone_index.get(bone_name)
+
+    def _rig_space_bone_matrix(self, bone_name):
+        index = self._rig_bone_index(bone_name)
+        if index is None:
+            if self.rig and getattr(self.rig, 'pose', None) and bone_name in self.rig.pose.bones:
+                return self.rig.pose.bones[bone_name].matrix.copy()
+            return Matrix.Identity(4)
+        for key in ('aPoseMS', 'boneTransforms', 'aPoseLS'):
+            transforms = self.rig_j.get(key) if isinstance(self.rig_j, dict) else None
+            if isinstance(transforms, list) and index < len(transforms):
+                return qs_transform_matrix(transforms[index])
+        if self.rig and getattr(self.rig, 'pose', None) and bone_name in self.rig.pose.bones:
+            return self.rig.pose.bones[bone_name].matrix.copy()
+        return Matrix.Identity(4)
+
+    def _rig_bone_delta_matrix(self, base_bone_name, target_bone_name):
+        if not target_bone_name or target_bone_name == 'None' or target_bone_name == base_bone_name:
+            return Matrix.Identity(4)
+        base_matrix = self._rig_space_bone_matrix(base_bone_name)
+        target_matrix = self._rig_space_bone_matrix(target_bone_name)
+        try:
+            return base_matrix.inverted() @ target_matrix
+        except Exception:
+            return target_matrix
+
+    def _rig_bone_translation_delta_matrix(self, base_bone_name, target_bone_name):
+        if not target_bone_name or target_bone_name == 'None' or target_bone_name == base_bone_name:
+            return Matrix.Identity(4)
+        base_matrix = self._rig_space_bone_matrix(base_bone_name)
+        target_matrix = self._rig_space_bone_matrix(target_bone_name)
+        delta = target_matrix.to_translation() - base_matrix.to_translation()
+        return Matrix.Translation(delta)
+
+    def _rig_bone_translation_matrix(self, bone_name):
+        if not bone_name or bone_name == 'None':
+            return Matrix.Identity(4)
+        return Matrix.Translation(self._rig_space_bone_matrix(bone_name).to_translation())
+
+    def _rig_bone_yaw_matrix(self, bone_name):
+        if not bone_name or bone_name == 'None':
+            return Matrix.Identity(4)
+        try:
+            yaw = self._rig_space_bone_matrix(bone_name).to_euler().z
+        except Exception:
+            yaw = 0
+        return Matrix.Rotation(yaw, 4, 'Z')
+
+    def _slot(self, owner, slot_name):
+        slot_lookup = self.slot_component_lookups.get(owner) or {}
+        if owner in ('vehicle_slots', 'slots') and self.default_slot_lookup:
+            slot_lookup = slot_lookup or self.default_slot_lookup
+        return slot_lookup.get(slot_name)
+
+    def _slot_bone_name(self, owner, slot_name):
+        slot = self._slot(owner, slot_name)
+        if slot:
+            return cname_value(slot.get('boneName'), slot_name)
+        return slot_name or owner
+
+    def _binding_name(self, component):
+        binding = parent_transform_data(component, self.parent_transform_lookup)
+        return cname_value(binding.get('bindName')) if isinstance(binding, dict) else ''
+
+    def _component_is_rig_owner(self, component):
+        return isinstance(component, dict) and bool(depot_path_value(component, 'rig'))
+
+    def _slot_component_is_animated_child(self, component):
+        parent_name = self._binding_name(component)
+        parent = self.components_by_name.get(parent_name)
+        return bool(parent_name and self._component_is_rig_owner(parent))
+
+    def _animated_base_slot(self, animated_component_name):
+        for slot_owner in self.components:
+            if not isinstance(slot_owner, dict) or slot_owner.get('$type') != 'entSlotComponent':
+                continue
+            if self._binding_name(slot_owner) != animated_component_name:
+                continue
+            slots = slot_owner.get('slots')
+            if not isinstance(slots, list):
+                continue
+            for slot in slots:
+                slot_name = cname_value(slot.get('slotName'))
+                bone_name = cname_value(slot.get('boneName'))
+                if slot_name == 'base' or bone_name == 'base':
+                    return slot
+        return None
+
+    def _animated_base_slot_matrix(self, animated_component_name):
+        return slot_transform_matrix(self._animated_base_slot(animated_component_name))
+
+    def _slot_component_primary_bone(self, component):
+        slots = component.get('slots') if isinstance(component, dict) else None
+        if not isinstance(slots, list):
+            return None
+        for slot in slots:
+            bone_name = cname_value(slot.get('boneName'))
+            if bone_name and bone_name != 'None':
+                return bone_name
+        return None
+
+    def _animated_slot_component_basis(self, component):
+        parent_name = self._binding_name(component)
+        if not parent_name:
+            return None
+        parent = self.components_by_name.get(parent_name)
+        if not self._component_is_rig_owner(parent):
+            return None
+        name = component_name(component)
+        if name == 'base':
+            return None
+        base_slot = self._animated_base_slot(parent_name)
+        if not isinstance(base_slot, dict):
+            return None
+        base_bone_name = cname_value(base_slot.get('boneName'))
+        target_bone_name = self._slot_component_primary_bone(component)
+        return self._animated_base_slot_matrix(parent_name) @ self._rig_bone_translation_delta_matrix(base_bone_name or 'base', target_bone_name)
+
+    def _hard_bone_slot_matrix(self, bone_name, slot_owner, slot_name, local_transform, visual_scale=None):
+        slot = self._slot(slot_owner, slot_name)
+        slot_pos = Vector((0, 0, 0))
+        slot_rot = Quaternion((1, 0, 0, 0))
+        if slot:
+            slot_pos_data = slot.get('relativePosition') if isinstance(slot.get('relativePosition'), dict) else {}
+            slot_pos = Vector((
+                slot_pos_data.get('X', 0),
+                slot_pos_data.get('Y', 0),
+                slot_pos_data.get('Z', 0),
+            ))
+            slot_rot = red_quaternion(slot.get('relativeRotation'))
+
+        local_pos = fixed_point_position(local_transform)
+        if bone_name and bone_name != 'Base':
+            z_ang = self.bone_matrix(bone_name, slot_owner).to_euler().z
+            x = local_pos.x
+            y = local_pos.y
+            local_pos = Vector((
+                x * cos(z_ang) + y * sin(z_ang),
+                x * sin(z_ang) + y * cos(z_ang),
+                local_pos.z,
+            ))
+
+        rotation = self._bone_rotation(bone_name, slot_owner) @ slot_rot @ red_quaternion(local_transform.get('Orientation'))
+        scale = red_scale(local_transform, visual_scale)
+        return Matrix.LocRotScale(self._bone_head(bone_name, slot_owner) + slot_pos + local_pos, rotation, scale)
+
+    def resolve_hard_component_matrix(self, component):
+        key = 'hard:' + (component_name(component) or str(id(component)))
+        if key in self.cache:
+            return self.cache[key]
+        if key in self.resolving:
+            return Matrix.Identity(4), '', '', 'cycle'
+        self.resolving.add(key)
+
+        local_transform = component.get('localTransform', {}) if isinstance(component, dict) else {}
+        visual_scale = component.get('visualScale') if isinstance(component, dict) else None
+        animated_slot_basis = self._animated_slot_component_basis(component)
+        if animated_slot_basis is not None:
+            result = (animated_slot_basis @ red_transform_matrix(local_transform, visual_scale), self._binding_name(component), '', 'animated_slot_component')
+            self.cache[key] = result
+            self.resolving.remove(key)
+            return result
+        binding = parent_transform_data(component, self.parent_transform_lookup)
+        if not isinstance(binding, dict):
+            result = (red_transform_matrix(local_transform, visual_scale), '', '', 'none')
+            self.cache[key] = result
+            self.resolving.remove(key)
+            return result
+
+        bind_name = cname_value(binding.get('bindName'))
+        slot_name = cname_value(binding.get('slotName'))
+        if not bind_name or bind_name == 'None':
+            result = (red_transform_matrix(local_transform, visual_scale), bind_name, slot_name, 'none')
+            self.cache[key] = result
+            self.resolving.remove(key)
+            return result
+
+        if bind_name in ('vehicle_slots', 'slots'):
+            bone_name = self._slot_bone_name(bind_name, slot_name)
+            result = (self._hard_bone_slot_matrix(bone_name, bind_name, slot_name, local_transform, visual_scale), bone_name, slot_name, 'slot')
+            self.cache[key] = result
+            self.resolving.remove(key)
+            return result
+
+        if bind_name == 'deformation_rig':
+            base = self.rig.matrix_world.copy() if self.rig else Matrix.Identity(4)
+            result = (base @ red_transform_matrix(local_transform, visual_scale), bind_name, slot_name, 'deformation_rig')
+            self.cache[key] = result
+            self.resolving.remove(key)
+            return result
+
+        if bind_name in self.components_by_name:
+            bound_component = self.components_by_name[bind_name]
+            parent_matrix, parent_bind, parent_slot, parent_type = self.resolve_hard_component_matrix(bound_component)
+            if slot_name and slot_name != 'None':
+                slot = self._slot(bind_name, slot_name)
+                if slot:
+                    skip_animated_base_slot = (
+                        bind_name == 'base'
+                        and slot_name == 'base'
+                        and self._slot_component_is_animated_child(bound_component)
+                    )
+                    animated_parent_name = self._binding_name(bound_component) if self._slot_component_is_animated_child(bound_component) else ''
+                    animated_base_slot = self._animated_base_slot(animated_parent_name) if animated_parent_name else None
+                    bone_name = cname_value(slot.get('boneName'), slot_name)
+                    if animated_parent_name and not isinstance(animated_base_slot, dict):
+                        animated_parent = self.components_by_name.get(animated_parent_name)
+                        animated_parent_matrix = Matrix.Identity(4)
+                        if animated_parent is not None:
+                            animated_parent_matrix, _, _, _ = self.resolve_hard_component_matrix(animated_parent)
+                        parent_matrix = (
+                            animated_parent_matrix
+                            @ self._rig_bone_translation_matrix(bone_name)
+                            @ self._rig_bone_yaw_matrix(bone_name)
+                        )
+                        parent_bind = bone_name or parent_bind or bind_name
+                        parent_slot = slot_name
+                        parent_type = 'slot'
+                    elif not skip_animated_base_slot:
+                        parent_matrix = parent_matrix @ slot_transform_matrix(slot)
+                        parent_type = 'component_slot'
+            result = (parent_matrix @ red_transform_matrix(local_transform, visual_scale), parent_bind or bind_name, parent_slot or slot_name, parent_type if parent_type != 'none' else 'component')
+            self.cache[key] = result
+            self.resolving.remove(key)
+            return result
+
+        if self.rig and getattr(self.rig, 'pose', None) and bind_name in self.rig.pose.bones:
+            result = (self._hard_bone_slot_matrix(bind_name, bind_name, slot_name, local_transform, visual_scale), bind_name, slot_name, 'bone')
+            self.cache[key] = result
+            self.resolving.remove(key)
+            return result
+
+        result = (red_transform_matrix(local_transform, visual_scale), bind_name, slot_name, 'unresolved')
+        self.cache[key] = result
+        self.resolving.remove(key)
+        return result
+
 # The appearance list needs to be the appearanceNames for each ent that you want to import, will import all if not specified
 # if you've already imported the body/head and set the rig up you can exclude them by putting them in the exclude_meshes list
 # presto_stash=[]
 
-def importEnt(with_materials, filepath='', appearances=[], exclude_meshes=[], include_collisions=False, include_phys=False,
+def importEnt(with_materials, filepath='', appearances=None, exclude_meshes=None, include_collisions=False, include_phys=False,
                    include_entCollider=False, inColl='', remapdepot=False, meshes=None, mesh_jsons=None, escaped_path=None,
                    app_path=None, anim_files=None, rigjsons=None,generate_overrides=False):
     cp77_addon_prefs = bpy.context.preferences.addons['i_scene_cp77_gltf'].preferences
+    if appearances is None:
+        appearances = ['']
+    elif isinstance(appearances, str):
+        appearances = [appearances]
+    else:
+        appearances = list(appearances)
+    excluded_meshes = {norm_path_key(mesh) for mesh in (exclude_meshes or []) if mesh}
     with_materials = with_materials
     if not cp77_addon_prefs.non_verbose:
         print('\n-------------------- Importing Cyberpunk 2077 Entity --------------------')
@@ -48,8 +1073,8 @@ def importEnt(with_materials, filepath='', appearances=[], exclude_meshes=[], in
     coll_scene = C.scene.collection
     start_time = time.time()
 
-    before,mid,after=filepath.partition(os.path.join('source','raw'))
-    path=before+mid
+    path, after = split_source_raw_root(filepath)
+    asset_index = build_asset_index(path)
 
     error_messages = []
     entinitiatedcache = False
@@ -66,9 +1091,9 @@ def importEnt(with_materials, filepath='', appearances=[], exclude_meshes=[], in
     if filepath is not None:
         ent_apps, ent_components, ent_component_data, res, ent_default = JSONTool.jsonload(filepath, error_messages)
 
-    ent_applist=[]
-    for app in ent_apps:
-        ent_applist.append(app['appearanceName']['$value'])
+    ent_applist=[cname_value(app.get('appearanceName')) for app in ent_apps]
+    ent_app_by_appearance, ent_app_by_name = build_ent_app_lookup(ent_apps)
+    ent_default = normalize_default_appearance(ent_default, ent_apps, ent_app_by_appearance, ent_app_by_name, filepath)
 
     if len(ent_applist) == 0:
         print(f"No appearances found in entity file {ent_name}. Imported objects may be incomplete or missing.")
@@ -86,24 +1111,20 @@ def importEnt(with_materials, filepath='', appearances=[], exclude_meshes=[], in
         else:
             print("No appearances available to select a random default from.")
 
-    for appidx,app in enumerate(appearances):
-        if app not in ent_applist and app.upper() !='ALL' and app !='default':
-            print(f"Appearance {app} not found in entity {ent_name}. Available appearances: {', '.join(ent_applist)}")
-            #show_message(f"Appearance {app} not found in entity {ent_name}. Available appearances: {', '.join(ent_applist)}")
-            # this check is not actually checking all the options for how the app name is stored so its popping this up then loading it fine.
-        if app not in ent_applist and app.upper() !='ALL' and app =='default':
-            if ent_default and len(ent_default)>0 and ent_default!='None':
+    for appidx, app in enumerate(appearances):
+        if app == 'default':
+            if ent_default:
                 print(f"Using default appearance {ent_default} for entity {ent_name}.")
-                #appearances[appidx]=ent_default
-                print(appearances)
-            else:                
-                if len(ent_applist)>0:
-                    print(f"No default appearance specified in entity {ent_name}. Using first available appearance {ent_applist[0]}.")
-                    ent_default=ent_applist[0]
-                else:
-                    print(f"No appearances specified in entity {ent_name}. Using root entities.")    
-                    appearances[0]= 'BASE_COMPONENTS_ONLY'          
-                    app='BASE_COMPONENTS_ONLY'
+                continue
+            if ent_applist:
+                print(f"No default appearance specified in entity {ent_name}. Using first available appearance {ent_applist[0]}.")
+                ent_default = ent_applist[0]
+                continue
+            print(f"No appearances specified in entity {ent_name}. Using root entities.")
+            appearances[appidx] = 'BASE_COMPONENTS_ONLY'
+            continue
+        if app.upper() != 'ALL' and app not in ent_applist:
+            print(f"Appearance {app} not found in entity {ent_name}. Available appearances: {', '.join(ent_applist)}")
 
 
     #presto_stash.append(ent_components)
@@ -112,18 +1133,21 @@ def importEnt(with_materials, filepath='', appearances=[], exclude_meshes=[], in
     ent_colliderComps=[]
     ent_simpleCollComps=[]
     chassis_info=[]
-    includes_license_plates=False
     for comp in ent_components:
-        ent_complist.append(comp['name'])
-        if 'rig' in comp.keys():
-            print(f"Rig found in entity: {comp['rig']['DepotPath']['$value']}")
-            ent_rigs.append(os.path.join(path,comp['rig']['DepotPath']['$value']))
-        if comp['name']['$value'] == 'Chassis':
+        comp_name = component_name(comp)
+        if comp_name:
+            ent_complist.append(comp['name'])
+        rig_depot = depot_path_value(comp, 'rig')
+        if rig_depot:
+            print(f"Rig found in entity: {rig_depot}")
+            ent_rigs.append(depot_to_local_path(path, rig_depot))
+        if comp_name == 'Chassis':
             chassis_info = comp
     for comp in ent_component_data:
-        if comp['$type'] == 'entColliderComponent':
+        comp_type = comp.get('$type')
+        if comp_type == 'entColliderComponent':
             ent_colliderComps.append(comp)
-        if comp['$type'] == 'entSimpleColliderComponent':
+        if comp_type == 'entSimpleColliderComponent':
             ent_simpleCollComps.append(comp)
     #print('collider components:', ent_colliderComps)
     #print('simple collider components:', ent_simpleCollComps)
@@ -131,7 +1155,11 @@ def importEnt(with_materials, filepath='', appearances=[], exclude_meshes=[], in
 
     resolved=[]
     for res_p in res:
-        resolved.append(os.path.join(path,res_p['DepotPath']['$value']))
+        depot_value = depot_path_value({'resource': res_p}, 'resource')
+        if not depot_value and isinstance(res_p, dict) and isinstance(res_p.get('DepotPath'), dict):
+            depot_value = cname_value(res_p.get('DepotPath'))
+        if depot_value:
+            resolved.append(depot_to_local_path(path, depot_value))
 
     # if no apps requested populate the list with all available.
 
@@ -145,35 +1173,26 @@ def importEnt(with_materials, filepath='', appearances=[], exclude_meshes=[], in
     VS=[]
     vehicle_slots=None
     for x in ent_components:
-        if 'name' in x.keys() and x['name']['$value']=='vehicle_slots' or x['name']['$value']=='slots':
+        if component_name(x) in ('vehicle_slots', 'slots'):
             VS.append(x)
     if len(VS)>0:
         vehicle_slots= VS[0]['slots']
+    vehicle_slot_lookup = build_slot_lookup(vehicle_slots)
 
-    # find the appearance file jsons
-    if not escaped_path:
-        escaped_path = glob.escape(path)
-    if ent_apps and len(ent_apps)>0:
-        if not app_path:
-            app_path = glob.glob(os.path.join(escaped_path,"**","*.app.json"), recursive = True)
-        if len(app_path)==0 and len(ent_apps)>0:
-            print('No Appearance file JSONs found in path, run the Ent export script first')
+    # Discover exported resources from the indexed source/raw tree.
+    app_path = indexed_asset_files(asset_index, '.app.json', app_path)
+    if ent_apps and len(ent_apps) > 0 and len(app_path) == 0:
+        print('No Appearance file JSONs found in path, run the Ent export script first')
 
-    # find the meshes
-    if not meshes:
-        meshes =  glob.glob(os.path.join(escaped_path,"**","*.glb"), recursive = True)
-    if len(meshes)==0:
+    mesh_files = indexed_asset_files(asset_index, '.glb', meshes)
+    if len(mesh_files) == 0:
         print('No Meshes found in path, run the Ent export script first')
-    if not mesh_jsons:
-        mesh_jsons =  glob.glob(os.path.join(escaped_path,"**","*mesh.json"), recursive = True)
 
-    # find the anims
-    # look through the components and find an anim, and load that,
-    # then check for an anim in the project thats using the rig (some things like the arch bike dont ref the anim in the ent)
-    # otherwise just skip this section
-    #
-    if not anim_files:
-        anim_files = glob.glob(os.path.join(escaped_path,"**","*anims.glb"), recursive = True)
+    mesh_jsons = indexed_asset_files(asset_index, '.mesh.json', mesh_jsons)
+    mesh_json_set = {norm_path_key(mesh_json) for mesh_json in mesh_jsons}
+
+    # Find anims through the asset index, then match by resolved entity rig dependency.
+    anim_files = indexed_asset_files(asset_index, '.anims.glb', anim_files)
 
     rig=None
     bones=None
@@ -183,26 +1202,33 @@ def importEnt(with_materials, filepath='', appearances=[], exclude_meshes=[], in
         print('no anim rig found')
     else:
         # get the armatures already in the model
-        oldarms= [x for x in bpy.data.objects if 'Armature' in x.name]
-        animsinres=[x for x in anim_files if x[:-4] in resolved]
+        old_armature_names = current_armature_names()
+        resolved_keys = {norm_path_key(resolved_path) for resolved_path in resolved}
+        ent_rig_keys = {norm_path_key(rig_path) for rig_path in ent_rigs}
+        animsinres=[x for x in anim_files if norm_path_key(os.path.splitext(x)[0]) in resolved_keys]
         if len(animsinres)==0:
             for anim in anim_files:
-                if os.path.exists(anim[:-3]+'anims.json'):
-                    anm_j=JSONTool.jsonload(f"{anim[:-3]+'anims.json'}", error_messages)
+                anim_json_path = resolve_anim_json_path_from_glb(asset_index, anim)
+                if anim_json_path:
+                    anm_j=JSONTool.jsonload(anim_json_path, error_messages)
                     if anm_j is not None:
-                        if os.path.join(path,anm_j['Data']['RootChunk']['rig']['DepotPath']['$value']) in ent_rigs:
-                            animsinres.append(os.path.join(path,anim))
+                        rig_depot = anm_j.get('Data', {}).get('RootChunk', {}).get('rig', {}).get('DepotPath', {}).get('$value')
+                        if rig_depot and norm_path_key(depot_to_local_path(path, rig_depot)) in ent_rig_keys:
+                            animsinres.append(anim)
                         # presto_stash.append(animsinres)
 
-        if len(animsinres)>0 and os.path.exists(animsinres[0]):
+        if len(animsinres)>0:
             bpy.ops.io_scene_gltf.cp77(with_materials, filepath=animsinres[0],scripting=True)
             #find what we just loaded
-            arms=[x for x in bpy.data.objects if 'Armature' in x.name and x not in oldarms]
-            rig=arms[0]
-            bones=rig.pose.bones
-            print('anim rig loaded')
+            arms = imported_armatures_since(old_armature_names)
+            if arms:
+                rig=arms[0]
+                bones=rig.pose.bones
+                print('anim rig loaded')
+            else:
+                print('anim rig import did not create an armature')
 
-            if animsinres[0].endswith(".glb"):
+            if rig and animsinres[0].endswith(".glb"):
                 anim_file_name = (animsinres[0])
                 rig_file_name = anim_file_name + ".rig.json"
                 rig["animset"] = anim_file_name
@@ -210,21 +1236,59 @@ def importEnt(with_materials, filepath='', appearances=[], exclude_meshes=[], in
                 rig["ent"] = ent_name + ".ent.json"
 
     # find the rig json associated with the ent
-    if not rigjsons:
-        rigjsons = glob.glob(os.path.join(escaped_path,"**","*.rig.json"), recursive = True)
+    rigjsons = indexed_asset_files(asset_index, '.rig.json', rigjsons)
     rig_j=None
     if len(rigjsons)==0 or len(ent_rigs)==0:
         print('no rig json loaded')
     else:
-        entrigjsons=[x for x in rigjsons if x[:-5] in ent_rigs]
+        ent_rig_keys = {norm_path_key(rig_path) for rig_path in ent_rigs}
+        entrigjsons=[x for x in rigjsons if norm_path_key(x[:-5]) in ent_rig_keys]
         if len(entrigjsons)>0:
             for entrig in entrigjsons:
                 rig_j=JSONTool.jsonload(entrig, error_messages)
                 if rig_j is not None:
-                    rig_j=rig_j['Data']['RootChunk']
-                    print('rig json loaded')
+                    rig_j=rig_j.get('Data', {}).get('RootChunk')
+                    if rig_j is not None:
+                        print('rig json loaded')
+    rig_bone_index = build_rig_bone_index(rig_j)
 
-    if len(meshes)<1 or (not app_path or len(app_path)<1) and len(ent_components)<1:
+    rig_json_by_component_name = {}
+    rig_json_path_by_component_name = {}
+    armature_by_component_name = {}
+    rig_json_cache = {}
+    rig_json_path_cache = {}
+
+    def rig_json_path_for_depot(rig_depot):
+        if not rig_depot:
+            return ''
+        if rig_depot not in rig_json_path_cache:
+            rig_json_path_cache[rig_depot] = resolve_rig_json_path(asset_index, rig_depot) or ''
+        return rig_json_path_cache[rig_depot]
+
+    def rig_json_for_depot(rig_depot):
+        if not rig_depot:
+            return None
+        if rig_depot in rig_json_cache:
+            return rig_json_cache[rig_depot]
+        rig_json_path = rig_json_path_for_depot(rig_depot)
+        rig_root = None
+        if rig_json_path:
+            loaded_rig_json = JSONTool.jsonload(rig_json_path, error_messages)
+            if loaded_rig_json is not None:
+                rig_root = loaded_rig_json.get('Data', {}).get('RootChunk')
+        rig_json_cache[rig_depot] = rig_root
+        return rig_root
+
+    for rig_component in ent_components:
+        rig_depot = depot_path_value(rig_component, 'rig')
+        rig_name = component_name(rig_component)
+        if rig_depot and rig_name:
+            rig_json_by_component_name[rig_name] = rig_json_for_depot(rig_depot)
+            rig_json_path_by_component_name[rig_name] = rig_json_path_for_depot(rig_depot)
+
+
+    Masters = None
+    if len(mesh_files)<1 or (not app_path or len(app_path)<1) and len(ent_components)<1:
         print("You need to export the meshes and convert app and ent to json")
         pass
 
@@ -243,91 +1307,72 @@ def importEnt(with_materials, filepath='', appearances=[], exclude_meshes=[], in
         meshes={}
         app_comps={}
         ent_chunks={}
-        for x,app_name in enumerate(appearances):
-            app_comps[app_name]=[]
-            # try to get components. only cases here.
+        app_json_cache={}
+        app_lookup={}
+        for x,requested_app_name in enumerate(appearances):
+            app_name = resolve_requested_appearance_name(requested_app_name, ent_default, ent_apps, ent_app_by_appearance, ent_app_by_name)
+            app_comps[requested_app_name]=[]
+            chunks = None
             if len(ent_apps)==0 and ent_component_data:
                 chunks= ent_component_data
             elif len(ent_apps)>0:
-                ent_app_idx=-1
-                # Find the appearance in the entity app list
-                for i,a in enumerate(ent_apps):
-                    if a['appearanceName']['$value']==app_name:
-                        print('appearance matched, id = ',i)
-                        ent_app_idx=i
-
-                # apparently they sometimes just sack it off and use the name not the appearanceName after all. (single_doors.ent for instance)
-                if ent_app_idx<0:
-                    for i,a in enumerate(ent_apps):
-                        if a['name']['$value']==app_name:
-                            print('appearance matched, id = ',i)
-                            ent_app_idx=i
-                            app_name=a['appearanceName']['$value']
-
-                if ent_app_idx<0:
-                    if app_name != 'default':
-                        ent_app_idx=0
-                    else:
-                        for i,a in enumerate(ent_apps):
-                            if a['name']['$value']==ent_default:
-                                print('appearance matched, id = ',i)
-                                ent_app_idx=i
-                                app_name=a['appearanceName']['$value']
-                                continue
-
+                ent_app_idx, app_name = resolve_ent_app(app_name, ent_apps, ent_app_by_appearance, ent_app_by_name, ent_default)
+                app_lookup[requested_app_name] = app_name
 
                 app_file = ent_apps[ent_app_idx]['appearanceResource']['DepotPath']['$value']
-                appfilepath=os.path.join(path,app_file).replace('\\',os.sep)+'.json'
+                appfilepath=resolve_app_json_path(asset_index, app_file)
                 a_j=None
-                if not os.path.exists(appfilepath):
-                    print('app file not found -', filepath)
+                if not appfilepath:
+                    print('app file not found -', depot_to_local_path(path, app_file) + '.json')
                 else:
-                    a_j=JSONTool.jsonload(appfilepath, error_messages)
+                    if appfilepath not in app_json_cache:
+                        app_json_cache[appfilepath]=JSONTool.jsonload(appfilepath, error_messages)
+                    a_j=app_json_cache.get(appfilepath)
                     if a_j is not None:
                         apps=a_j['Data']['RootChunk']['appearances']
 
                         app_idx=0
-                        for i,a in enumerate(apps):
-                            #print(i,a['Data']['name'])
-                            if a['Data']['name']['$value']==app_name:
-                                print('appearance matched, id = ',i)
-                                app_idx=i
+                        app_definition_by_name = {cname_value(a.get('Data', {}).get('name')): i for i, a in enumerate(apps) if isinstance(a, dict)}
+                        matched_app_idx = app_definition_by_name.get(app_name)
+                        if matched_app_idx is not None:
+                            app_idx=matched_app_idx
+                            print('appearance matched, id = ',app_idx)
                         chunks=None
-                        if 'Data' in a_j['Data']['RootChunk']['appearances'][app_idx].keys():
-                            if a_j['Data']['RootChunk']['appearances'][app_idx]['Data']['components']:
-                                app_comps[app_name]= ent_components+a_j['Data']['RootChunk']['appearances'][app_idx]['Data']['components']
-                            if 'compiledData' in a_j['Data']['RootChunk']['appearances'][app_idx]['Data'].keys():
-                                chunks= a_j['Data']['RootChunk']['appearances'][app_idx]['Data']['compiledData']['Data']['Chunks']
-                                ent_chunks[app_name]=chunks
+                        app_data = a_j['Data']['RootChunk']['appearances'][app_idx].get('Data')
+                        if app_data:
+                            if app_data.get('components'):
+                                app_comps[requested_app_name]= ent_components+app_data['components']
+                                if app_name != requested_app_name:
+                                    app_comps[app_name]=app_comps[requested_app_name]
+                            compiled_data = app_data.get('compiledData')
+                            if compiled_data and compiled_data.get('Data', {}).get('Chunks'):
+                                chunks= compiled_data['Data']['Chunks']
+                                ent_chunks[requested_app_name]=chunks
+                                if app_name != requested_app_name:
+                                    ent_chunks[app_name]=chunks
                                 print('Chunks found')
 
 
-            if len(app_comps[app_name])==0:
+            if len(app_comps[requested_app_name])==0:
                 print('falling back to rootchunk components...')
-                app_comps[app_name]= ent_components
-            exclude_meshes=[]
-            for c in app_comps[app_name]:
-                if not ( 'mesh' in c.keys() or 'graphicsMesh' in c.keys()):
+                app_comps[requested_app_name]= ent_components
+                if app_name != requested_app_name:
+                    app_comps[app_name]=app_comps[requested_app_name]
+            if chunks is not None and requested_app_name not in ent_chunks:
+                ent_chunks[requested_app_name] = chunks
+            for c in app_comps[requested_app_name]:
+                depot_path = mesh_component_depot(c)
+                if not depot_path:
                     continue
-                if 'mesh' in c.keys() or 'graphicsMesh' in c.keys():
-                   # print(c['mesh']['DepotPath']['$value'])
-                    meshname=''
-                    if 'mesh' in c.keys() and isinstance( c['mesh']['DepotPath']['$value'], str):
-                        m=c['mesh']['DepotPath']['$value']
-                        meshname=os.path.join(path, m).replace('\\', os.sep)
-                    elif 'graphicsMesh' in c.keys() and isinstance( c['graphicsMesh']['DepotPath']['$value'], str):
-                        m=c['graphicsMesh']['DepotPath']['$value']
-                        meshname=os.path.join(path, m).replace('\\', os.sep)
-                    if meshname and meshname not in exclude_meshes and os.path.exists(meshname[:-4]+'glb'):
-                        meshApp='default'
-                        if 'meshAppearance' in c.keys():
-                            meshApp=c['meshAppearance']
-                            #print(meshApp)
-                        if(meshname != 0):
-                            if meshname not in meshes:
-                                meshes[meshname] = {'appearances':[meshApp],'sector':'ALL'}
-                            else:
-                                meshes[meshname]['appearances'].append(meshApp)
+                meshname=depot_to_local_path(path, depot_path)
+                meshpath=resolve_mesh_glb_path(asset_index, depot_path)
+                if meshname and meshpath and not is_excluded_mesh(depot_path, meshpath, os.path.basename(meshname), excluded_meshes):
+                    meshApp=mesh_appearance_value(c)
+                    if(meshname != 0):
+                        if meshname not in meshes:
+                            meshes[meshname] = {'appearances':[meshApp],'sector':'ALL'}
+                        else:
+                            meshes[meshname]['appearances'].append(meshApp)
 
         meshes_w_apps={}
 
@@ -341,11 +1386,13 @@ def importEnt(with_materials, filepath='', appearances=[], exclude_meshes=[], in
 
         # loop through again to actually build the appearances
         for x,app_name in enumerate(appearances):
+            requested_app_name = app_name
+            app_name = resolve_requested_appearance_name(app_name, ent_default, ent_apps, ent_app_by_appearance, ent_app_by_name)
             print(f"\nImporting appearance {x+1} of {len(appearances)}: {app_name}")
             app_start_time = time.time()
-            ent_coll = bpy.data.collections.new(ent_name+'_'+app_name)            
-            if app_name=='default' and not was_random:
-                app_name=ent_default
+            chunks = None
+            ent_coll = bpy.data.collections.new(ent_name+'_'+app_name)
+            app_name = app_lookup.get(requested_app_name, app_name)
             if inColl and inColl in coll_scene.children.keys():
                 par_coll=bpy.data.collections.get(inColl)
                 par_coll.children.link(ent_coll)
@@ -357,35 +1404,10 @@ def importEnt(with_materials, filepath='', appearances=[], exclude_meshes=[], in
             if len(ent_apps)==0 and ent_component_data:
                 chunks= ent_component_data
             elif len(ent_apps)>0:
-                ent_app_idx=-1
-                # Find the appearance in the entity app list
-                for i,a in enumerate(ent_apps):
-                    if a['appearanceName']['$value']==app_name:
-                        print('appearance matched, id = ',i)
-                        ent_app_idx=i
-                        continue
-
-                # apparently they sometimes just sack it off and use the name not the appearanceName after all. (single_doors.ent for instance)
-                if ent_app_idx<0:
-                    for i,a in enumerate(ent_apps):
-                        if a['name']['$value']==app_name:
-                            print('appearance matched, id = ',i)
-                            ent_app_idx=i
-                            app_name=a['appearanceName']['$value']
-                            continue
-
-                if ent_app_idx<0:
-                    if app_name != 'default':
-                        ent_app_idx=0
-                    else:
-                        for i,a in enumerate(ent_apps):
-                            if a['name']['$value']==ent_default:
-                                print('appearance matched, id = ',i)
-                                ent_app_idx=i
-                                app_name=a['appearanceName']['$value']
-                                continue
+                ent_app_idx, app_name = resolve_ent_app(app_name, ent_apps, ent_app_by_appearance, ent_app_by_name, ent_default)
             if not chunks:
-                chunks=ent_chunks[app_name]
+                chunks=ent_chunks.get(requested_app_name) or ent_chunks.get(app_name) or ent_component_data
+
 
             enum_items = []
             default_index = None
@@ -405,66 +1427,138 @@ def importEnt(with_materials, filepath='', appearances=[], exclude_meshes=[], in
                     default=default_index,
                 )
 
-            comps=app_comps[app_name]
-            comps_lookup = {o['name']['$value']: o for o in comps}
+            comps=app_comps.get(requested_app_name) or app_comps.get(app_name) or ent_components
+            transform_components = list(ent_components)
+            for comp in comps:
+                if comp not in transform_components:
+                    transform_components.append(comp)
+            ent_component_ids = {id(comp) for comp in ent_components}
+            ent_parent_transform_lookup = build_parent_transform_lookup(ent_component_data)
+            app_parent_transform_lookup = build_parent_transform_lookup(chunks)
+            parent_transform_lookup = ComponentHandleLookup(app_parent_transform_lookup)
+            ent_skinning_lookup = build_skinning_lookup(ent_component_data)
+            app_skinning_lookup = build_skinning_lookup(chunks)
+            skinning_lookup = ComponentHandleLookup(app_skinning_lookup)
+            for comp in transform_components:
+                if id(comp) in ent_component_ids:
+                    parent_transform_lookup.set_component_lookup(comp, ent_parent_transform_lookup)
+                    skinning_lookup.set_component_lookup(comp, ent_skinning_lookup)
+                else:
+                    parent_transform_lookup.set_component_lookup(comp, app_parent_transform_lookup)
+                    skinning_lookup.set_component_lookup(comp, app_skinning_lookup)
+                rig_depot = depot_path_value(comp, 'rig')
+                rig_name = component_name(comp)
+                if rig_depot and rig_name:
+                    if rig_name not in rig_json_by_component_name:
+                        rig_json_by_component_name[rig_name] = rig_json_for_depot(rig_depot)
+                    rig_json_path_by_component_name[rig_name] = rig_json_path_for_depot(rig_depot)
+            rig_component_names = set(rig_json_by_component_name.keys())
+            slot_owner_rig_jsons = build_slot_owner_rig_jsons(transform_components, parent_transform_lookup, rig_json_by_component_name)
+            slot_owner_rig_owner_names = build_slot_owner_rig_owner_names(transform_components, parent_transform_lookup, rig_component_names)
+            anim_impl_lookup = build_anim_impl_lookup(chunks)
 
             if not rig:
                 for c in comps:
-                    if 'name' in c.keys() and c['name']['$value']=='vehicle_slots' or c['name']['$value']=='slot':
+                    if component_name(c) in ('vehicle_slots', 'slot', 'slots'):
                         VS.append(c)
-                    if 'rig' in c.keys():
-                        rig_path = os.path.join(path, c['rig']['DepotPath']['$value'])
+                    rig_depot = depot_path_value(c, 'rig')
+                    if rig_depot:
+                        rig_path = depot_to_local_path(path, rig_depot)
                         ent_rigs.append(rig_path)
                         if rig_path in ent_rigs:
-                            print(f"Rig found in app components: {c['rig']['DepotPath']['$value']}")
+                            print(f"Rig found in app components: {rig_depot}")
                             if rig is None:
-                                rig_j=JSONTool.jsonload(rig_path+'.json', error_messages)
-                                if rig_j is not None:
-                                    rig_j=rig_j['Data']['RootChunk']
-                                    print('rig json loaded')
-                                if c['animations']['gameplay']!=None and len(c['animations']['gameplay'])>0 :                                # get the armatures already in the model
-                                    oldarms= [x for x in bpy.data.objects if 'Armature' in x.name]
-                                    animpath=os.path.join(path,c['animations']['gameplay'][0]['animSet']['DepotPath']['$value']+'.glb')
-                                    if os.path.exists(animpath):
+                                rig_json_path = resolve_rig_json_path(asset_index, rig_depot)
+                                if rig_json_path:
+                                    rig_j=JSONTool.jsonload(rig_json_path, error_messages)
+                                    if rig_j is not None:
+                                        rig_j=rig_j.get('Data', {}).get('RootChunk')
+                                        rig_bone_index = build_rig_bone_index(rig_j)
+                                        print('rig json loaded')
+                                gameplay_anims = c.get('animations', {}).get('gameplay')
+                                if gameplay_anims is not None and len(gameplay_anims)>0:
+                                    old_armature_names = current_armature_names()
+                                    anim_depot = gameplay_anims[0]['animSet']['DepotPath']['$value']
+                                    animpath=resolve_anim_glb_path(asset_index, anim_depot)
+                                    if animpath:
                                         bpy.ops.io_scene_gltf.cp77(with_materials, filepath=animpath, scripting=True)
                                         # find the armature we just loaded
-                                        arms=[x for x in bpy.data.objects if 'Armature' in x.name and x not in oldarms]
-                                        rig=arms[0]
-                                        bones=rig.pose.bones
-                                        rig["animset"] = animpath
-                                        rig["rig"] = rig_path
-                                        rig["ent"] = ent_name + ".ent.json"
-                                        print('anim rig loaded')
-                            elif rig['rig']==rig_path:
+                                        arms = imported_armatures_since(old_armature_names)
+                                        if arms:
+                                            rig=arms[0]
+                                            bones=rig.pose.bones
+                                            rig["animset"] = animpath
+                                            rig["rig"] = rig_path
+                                            rig["ent"] = ent_name + ".ent.json"
+                                            print('anim rig loaded')
+                                        else:
+                                            print('anim rig import did not create an armature')
+                            elif rig.get('rig')==rig_path:
                                 print('using existing rig')
                             else:
-                                print('another rig',rig['rig'],' is already loaded ',rig_path)
+                                print('another rig',rig.get('rig'),' is already loaded ',rig_path)
+            if rig is None:
+                required_rig_names = []
+                if 'deformation_rig' in rig_json_path_by_component_name:
+                    required_rig_names.append('deformation_rig')
+                for rig_owner_name in slot_owner_rig_owner_names.values():
+                    if rig_owner_name not in required_rig_names:
+                        required_rig_names.append(rig_owner_name)
+                for rig_name in rig_json_path_by_component_name:
+                    if rig_name not in required_rig_names:
+                        required_rig_names.append(rig_name)
+
+                for rig_name in required_rig_names:
+                    rig_json_path = rig_json_path_by_component_name.get(rig_name)
+                    if not rig_json_path:
+                        continue
+                    armature = armature_by_component_name.get(rig_name)
+                    if armature is None:
+                        armature = ensure_armature_from_rig_json(rig_json_path, rig_name, ent_name)
+                        if armature is not None:
+                            armature_by_component_name[rig_name] = armature
+                            print(f"rig armature created from json for {rig_name}")
+                    if armature is not None and (rig is None or rig_name == 'deformation_rig'):
+                        rig = armature
+                        bones = rig.pose.bones
+                        rig_j = rig_json_by_component_name.get(rig_name, rig_j)
+                        rig_bone_index = build_rig_bone_index(rig_j)
+            else:
+                component_name_value = rig.get('componentName') if hasattr(rig, 'get') else None
+                if component_name_value and component_name_value not in armature_by_component_name:
+                    armature_by_component_name[component_name_value] = rig
+
             if not vehicle_slots:
                 if len(VS)>0:
                     vehicle_slots= VS[0]['slots']
+                    vehicle_slot_lookup = build_slot_lookup(vehicle_slots)
 
+
+            transform_resolver = EntityTransformResolver(
+                transform_components,
+                parent_transform_lookup,
+                skinning_lookup=skinning_lookup,
+                rig=rig,
+                rig_j=rig_j,
+                rig_bone_index=rig_bone_index,
+                default_slot_lookup=vehicle_slot_lookup,
+                slot_owner_rig_jsons=slot_owner_rig_jsons,
+                rig_json_by_component_name=rig_json_by_component_name,
+                armature_by_component_name=armature_by_component_name,
+                slot_owner_rig_owner_names=slot_owner_rig_owner_names,
+            )
 
             for c in comps:
+                comp_name = component_name(c)
                 vs_rot=None
-                if 'license_plate' in c['name']['$value']:
-                    includes_license_plates = True
-                    print('License plate component found:', c['name']['$value'])
-                if not (c['$type']=='gameTransformAnimatorComponent' or 'mesh' in c.keys() or 'graphicsMesh' in c.keys()):
+                if not (c.get('$type')=='gameTransformAnimatorComponent' or 'mesh' in c.keys() or 'graphicsMesh' in c.keys()):
                     continue
 
-                if c['$type']=='gameTransformAnimatorComponent' and c['animations'][0]['$type']=='gameTransformAnimationDefinition':
+                if c.get('$type')=='gameTransformAnimatorComponent' and c['animations'][0]['$type']=='gameTransformAnimationDefinition':
                     duration=c['animations'][0]['timeline']['items'][0]['duration']
                     HRID=c['animations'][0]['timeline']['items'][0]['impl']['HandleRefId']
-                    chunk_anim = 0
+                    chunk_anim = anim_impl_lookup.get(int(HRID), 0)
                     anim_HId=0
-                    # find the anim data in the chunks
-                    if chunks:
-                        for chunk in chunks:
-                            if chunk['$type']!='gameTransformAnimatorComponent':
-                                continue
-                            if 'HandleId' in chunk['animations'][0]['timeline']['items'][0]['impl'].keys():
-                                if int(chunk['animations'][0]['timeline']['items'][0]['impl']['HandleId'])==int(HRID):
-                                    chunk_anim=chunk['animations'][0]['timeline']['items'][0]['impl']['Data']
                     if isinstance(chunk_anim, dict) and chunk_anim['$type']=='gameTransformAnimation_RotateOnAxis':
                         rot_axis=chunk_anim['axis']
                         axis_no=0 # default to x
@@ -476,7 +1570,7 @@ def importEnt(with_materials, filepath='', appearances=[], exclude_meshes=[], in
 
                         reverse=chunk_anim['reverseDirection']
                         no_rot=chunk_anim['numberOfFullRotations']
-                        o = create_axes(ent_coll=ent_coll,name=c['name']['$value'])
+                        o = create_axes(ent_coll=ent_coll,name=comp_name)
                         o.keyframe_insert('rotation_euler', index=axis_no ,frame=1)
                         o.rotation_euler[axis_no] = o.rotation_euler[axis_no] +math.radians(no_rot*(-1*reverse)*360)
                         o.keyframe_insert('rotation_euler', index=axis_no ,frame=duration*24)
@@ -492,22 +1586,14 @@ def importEnt(with_materials, filepath='', appearances=[], exclude_meshes=[], in
                                 pt.interpolation = 'LINEAR'
                 elif 'mesh' in c.keys() or 'graphicsMesh' in c.keys():
                     #print(c['mesh']['DepotPath']['$value'])
-                    meshname=''
-                    if 'mesh' in c.keys() and isinstance( c['mesh']['DepotPath']['$value'], str):
-                        m=c['mesh']['DepotPath']['$value']
-                        meshname=os.path.basename(m.replace('\\',os.sep))
-                        meshpath=os.path.join(path, m[:-1*len(os.path.splitext(m)[1])]+'.glb').replace('\\', os.sep)
-                    elif 'graphicsMesh' in c.keys() and isinstance( c['graphicsMesh']['DepotPath']['$value'], str):
-                        m=c['graphicsMesh']['DepotPath']['$value']
-                        meshname=os.path.basename(m)
-                        meshpath=os.path.join(path, m[:-1*len(os.path.splitext(m)[1])]+'.glb').replace('\\', os.sep)
-                    if meshname and meshname not in exclude_meshes and os.path.exists(meshpath):
+                    depot_path = mesh_component_depot(c)
+                    meshname=os.path.basename(depot_path.replace('\\',os.sep)) if depot_path else ''
+                    meshpath=resolve_mesh_glb_path(asset_index, depot_path)
+                    component_enabled = is_component_enabled(c)
+                    if meshname and meshpath and not is_excluded_mesh(depot_path, meshpath, meshname, excluded_meshes):
                         new=None
                         try:
-                            meshApp='default'
-                            if 'meshAppearance' in c.keys():
-                                meshApp=c['meshAppearance']['$value']
-                                #print(meshApp)
+                            meshApp=mesh_appearance_value(c)
                             try:
                                 # TODO: sim, this is broken, pls fix Y_Y
                                 # make this instance from masters rather than loading multiple times
@@ -516,16 +1602,25 @@ def importEnt(with_materials, filepath='', appearances=[], exclude_meshes=[], in
                                 if (group):
                                     new=bpy.data.collections.new(groupname)                                       
                                     ent_coll.children.link(new)
+                                    copied_objects = []
+                                    object_copy_map = {}
                                     for old_obj in group.all_objects:
                                         obj=old_obj.copy()
+                                        object_copy_map[old_obj] = obj
+                                        copied_objects.append(obj)
                                         new.objects.link(obj)
-                                    for obj in new.objects:
-                                        obj['componentName'] = c['name']['$value']
+                                    remap_copied_object_references(copied_objects, object_copy_map)
+                                    for obj in copied_objects:
+                                        obj['componentName'] = comp_name
                                         obj['sourcePath'] = meshpath
                                         obj['meshAppearance'] = meshApp
+                                        obj['componentEnabled'] = component_enabled
                                         if app_path:
                                             obj['appResource'] = app_path[0]
                                         obj['entAppearance'] = app_name
+                                        if not component_enabled:
+                                            obj.hide_set(True)
+                                            obj.hide_render = True
                                         if 'Armature' in obj.name:
                                             obj.hide_set(True)
                                 else:
@@ -539,299 +1634,43 @@ def importEnt(with_materials, filepath='', appearances=[], exclude_meshes=[], in
                                 print('collection not found after import - ', meshname)
                                 continue
                             objs = new.objects
-                            if 'body_01' in meshname:
-                                print('those annoying front forks')
-
-                            # NEW parentTransform stuff - fixes vehicles being exploded
-                            x=None
-                            y=None
-                            z=None
-                            bindname=None
-                            bindpt=None
-                            pt_trans=[0,0,0]
-                            pt_rot=[0,0,0,0]
-                            pt_eul=None
-                            pT=c['parentTransform']
-                            if pT:
-                                pT_HId=pT['HandleRefId']
-                                #print('pT_HId = ',pT_HId)
-                                chunk_pt = 0
-                                # find the parent transform in the chunks
-                                if chunks:
-                                    for chunk in chunks:
-                                        if 'parentTransform' in chunk.keys() and isinstance( chunk['parentTransform'], dict):
-                                                #print('pt found')
-                                                if 'HandleId' in chunk['parentTransform'].keys():
-
-                                                    if chunk['parentTransform']['HandleId']==pT_HId:
-                                                        chunk_pt=chunk['parentTransform']
-                                                        break
-                                                        #print('HandleId found',chunk['parentTransform']['HandleId'])
-
-                                # if we found it then process it, most chars etc will just skip this
-                                if chunk_pt:
-                                    #print('in chunk pt processing bindName = ',chunk_pt['Data']['bindName'],' slotname= ',chunk_pt['Data']['slotName'])
-                                    # parts have a bindname, and sometimes a slotname
-                                    bindname=chunk_pt['Data']['bindName']['$value']
-                                    slotname=chunk_pt['Data']['slotName']['$value']
-                                    # if it has a bindname of vehicle_slots, you may need to find the bone name in the vehicle slots in the root ent components
-                                    # this should have been loaded earlier, check for it in the vehicle slots if not just set to the slot value
-                                    if bindname=='vehicle_slots' or bindname=='slots':
-                                        if vehicle_slots:
-                                            for slot in vehicle_slots:
-                                                if slot['slotName']['$value']==slotname:
-                                                    bindname=slot['boneName']['$value']
-                                        else:
-                                            bindname= chunk_pt['Data']['slotName']['$value']
-
-                                    # some meshes have boneRigMatrices in the mesh file which means we need jsons for the meshes or we cant access it. oh joy
-                                    elif bindname=="deformation_rig" and (not chunk_pt['Data']['slotName']['$value'] or len(chunk_pt['Data']['slotName']['$value'])==1 or chunk_pt['Data']['slotName']['$value']=='None'):
-                                        json_name=os.path.join(path, c['mesh']['DepotPath']['$value']+'.json')
-                                        #print:("in the deformation rig bit",json_name)
-                                        if json_name in mesh_jsons:
-                                            mesh_j = JSONTool.jsonload(json_name, error_messages)
-                                            mesh_j=mesh_j['Data']['RootChunk']
-                                        if mesh_j is not None:
-                                            #print('bindname from json ' ,mesh_j['boneNames'][0],bindname)
-                                            if 'boneRigMatrices' in mesh_j.keys():
-                                                bm= mesh_j['boneRigMatrices'][0]
-                                                row0=[bm['X']['X'],bm['Y']['X'],bm['Z']['X'],bm['W']['X']]
-                                                row1=[bm['X']['Y'],bm['Y']['Y'],bm['Z']['Y'],bm['W']['Y']]
-                                                row2=[bm['X']['Z'],bm['Y']['Z'],bm['Z']['Z'],bm['W']['Z']]
-                                                row3=[bm['X']['W'],bm['Y']['W'],bm['Z']['W'],bm['W']['W']]
-
-                                                matrix = Matrix()
-                                                matrix[0]=Vector(row0)
-                                                matrix[1]=Vector(row1)
-                                                matrix[2]=Vector(row2)
-                                                matrix[3]=Vector(row3)
-                                                # mx = '\n'.join([''.join(['{:4.2f} '.format(item) for item in row]) for row in matrix])
-                                                # print(mx)
-                                                bones=rig.pose.bones
-                                                #there are occasionally more than 1 bone in here, not worked out what/how maps to those
-                                                bn=mesh_j['boneNames'][0]['$value']
-                                                xdisp=0
-                                                ydisp=0
-                                                zdisp=0
-
-                                                if bn in bones.keys():
-                                                    bone=bones[mesh_j['boneNames'][0]['$value']]
-                                                    # the transform matrix above is in the orientation of the bone that its linked to, so I'm doing a bodged job of correcting for that here.
-                                                    bone_mat_rot=bone.matrix.to_euler()
-                                                    #print(bone_mat_rot)
-                                                    if abs(bone_mat_rot.y)>0.001:
-                                                        xdisp = -matrix[1][3]/sin(bone_mat_rot.y)
-                                                    if abs(bone_mat_rot.x)>0.001:
-                                                        ydisp = -matrix[1][3]/sin(bone_mat_rot.x)
-                                                    if abs(bone_mat_rot.z)>0.001:
-                                                        zdisp = matrix[2][3]/sin(bone_mat_rot.z)
-                                                #print(xdisp, ydisp ,zdisp)
-                                                # now we have the displacements. move things
-                                                for obj in objs:
-                                                    #print(xdisp, ydisp ,zdisp)
-                                                    obj.location.x =  obj.location.x+xdisp
-                                                    obj.location.y = obj.location.y+ydisp
-                                                    obj.location.z =  obj.location.z+zdisp
-                                                    # Apply child of constraints to them and set the inverse
-
-                                                    co=obj.constraints.new(type='CHILD_OF')
-                                                    co.target=rig
-                                                    co.subtarget= mesh_j['boneNames'][0]['$value']
-                                                    bpy.context.view_layer.objects.active = obj
-                                                    bpy.ops.constraint.childof_set_inverse(constraint="Child Of", owner='OBJECT')
-
-
-                                    # things like the tvs have a bindname but no slotname, bindname appears to point at the name of the main component, and its the only one with a transform applied
-                                    elif bindname and chunk_pt.get('Data').get('slotName').get('$value')!=None:
-                                        #see if we can find a component that matches it
-                                        if bindname=='interior_02':
-                                            print('interior_02')
-                                        bindpt=comps_lookup.get(bindname)
-                                        slotname= chunk_pt.get('Data').get('slotName').get('$value')
-                                        #if bindpt and slotname:
-                                            # Have a bindpoint and a slotname, so we can use the local transform from the bindpoint
-                                            #print('bindpt and slotname found')
-
-                                        if bindpt and len(bindpt)==1:
-                                            if c['localTransform']['Position']['x']['Bits']==0 and c['localTransform']['Position']['y']['Bits']==0 and c['localTransform']['Position']['z']['Bits']==0 and 'localTransform' in bindpt:
-                                                c['localTransform']['Position']=bindpt['localTransform']['Position']
-                                            if c['localTransform']['Orientation']['i']==0 and c['localTransform']['Orientation']['j']==0 and c['localTransform']['Orientation']['k']==0 and c['localTransform']['Orientation']['r']==1 and 'localTransform' in bindpt:
-                                                c['localTransform']['Orientation']=bindpt['localTransform']['Orientation']
-                                    #print('bindname = ',bindname)
-                                    if rig:
-                                        bones=rig.pose.bones
-                                    if bindname and bones:
-                                        #print('bindname and bones')
-                                        if bindname not in bones.keys():
-                                            #print('bindname ',bindname, ' not in boneNames')
-                                            # if bindname isnt in the bones then its a part thats already bound to a bone,
-                                            # These inherit the parent and local transforms from the other part, find it and work out what the transform is
-                                            
-                                            o=comps_lookup.get(bindname)
-                                            if o and 'parentTransform' in o.keys():
-                                                pT=o['parentTransform']
-                                                if pT:
-
-                                                    x=o['localTransform']['Position']['x']['Bits']/131072
-                                                    y=o['localTransform']['Position']['y']['Bits']/131072
-                                                    z=o['localTransform']['Position']['z']['Bits']/131072
-
-                                                    pT_HId=pT['HandleRefId']
-                                                    #print(bindname, 'pT_HId = ',pT_HId)
-                                                    chunk_pt = 0
-                                                    for chunk in chunks:
-                                                        if 'parentTransform' in chunk.keys() and isinstance( chunk['parentTransform'], dict):
-                                                            if 'HandleId' in chunk['parentTransform'].keys():
-                                                                if chunk['parentTransform']['HandleId']==pT_HId:
-                                                                    chunk_pt=chunk['parentTransform']
-                                                                    #print('HandleId found',chunk['parentTransform']['HandleId'])
-                                                    if chunk_pt:
-                                                        #print('in chunk pt processing')
-                                                        bindname=chunk_pt['Data']['bindName']['$value']
-                                                        if bindname=='vehicle_slots':
-                                                            if vehicle_slots:
-                                                                slotname=chunk_pt['Data']['slotName']['$value']
-                                                                for slot in vehicle_slots:
-                                                                    if slot['slotName']['$value']==slotname:
-                                                                        bindname=slot['boneName']['$value']
-
-                                        ######
-                                        if bindname in bones.keys() and rig_j is not None and rig_j['boneNames'] is not None:
-                                            #print('bindname in bones')
-                                            bidx=0
-                                            for bid, b in enumerate(rig_j['boneNames']):
-                                                if b['$value']==bindname:
-                                                    bidx=bid
-                                                    #print('bone found - ',bidx)
-                                            btrans=rig_j['boneTransforms'][bidx]
-
-                                            for obj in objs:
-                                                #print(bindname, bones[bindname].head)
-                                                obj['bindname']=bindname
-                                                pt_trans=bones[bindname].head
-                                                pt_rot=bones[bindname].rotation_quaternion
-                                                vs=[slot for slot in vehicle_slots if slot['slotName']['$value']==slotname]
-                                                vs_rot=Quaternion([0,0,0,1])
-                                                vs_pos= Vector([0,0,0])
-                                                vs_scale=Vector([1,1,1])
-                                                if len(vs)>0:
-                                                    vs=vs[0]
-                                                    if 'relativeRotation' in vs.keys():
-                                                        vs_rot[0]=vs['relativeRotation']['i']
-                                                        vs_rot[1]=vs['relativeRotation']['j']
-                                                        vs_rot[2]=vs['relativeRotation']['k']
-                                                        vs_rot[3]=vs['relativeRotation']['r']
-                                                    if 'relativePosition' in vs.keys():
-                                                        vs_pos[0]=vs['relativePosition']['X']
-                                                        vs_pos[1]=vs['relativePosition']['Y']
-                                                        vs_pos[2]=vs['relativePosition']['Z']
-                                                        #print('vs_rot = ',vs_rot)
-                                                vs_mat=Matrix.LocRotScale(Vector([0,0,0]),vs_rot,vs_scale)
-                                                pt_mat=Matrix.LocRotScale(Vector([0,0,0]),pt_rot,Vector(vs_scale))
-                                                vs_z_ang=vs_mat.to_euler().z
-                                                pt_z_ang=pt_mat.to_euler().z
-
-                                                if obj.location != pt_trans:
-                                                    obj.location.x +=  pt_trans[0]+vs_pos[0]
-                                                    obj.location.y += pt_trans[1]+vs_pos[1]
-                                                    obj.location.z +=  pt_trans[2]+vs_pos[2]
-                                                else:    
-                                                    obj.location.x =   pt_trans[0]+vs_pos[0]
-                                                    obj.location.y = pt_trans[1]+vs_pos[1]
-                                                    obj.location.z =  pt_trans[2]+vs_pos[2]
-
-                                                obj.rotation_quaternion.x = btrans['Rotation']['i']
-                                                obj.rotation_quaternion.y = btrans['Rotation']['j']
-                                                obj.rotation_quaternion.z = btrans['Rotation']['k']
-                                                obj.rotation_quaternion.w = btrans['Rotation']['r']
-
-
-                                                obj.rotation_quaternion=obj.rotation_quaternion*Quaternion(vs_rot)
-                                                #obj.matrix_local=  obj.matrix_local @ vs_mat
-                                                #obj.matrix_world= pt_mat @ obj.matrix_world
-                                                
-                                                #Apply child of constraints to them and set the inverse
-                                                if 'fuel_cap' not in bindname:
-                                                    if 'Child Of' not in obj.constraints.keys():                                                        
-                                                        co=obj.constraints.new(type='CHILD_OF')
-                                                        co.target=rig
-                                                        co.subtarget= bindname
-                                                        bpy.context.view_layer.objects.active = obj
-                                                        bpy.ops.constraint.childof_set_inverse(constraint=loc("Child Of"), owner='OBJECT')
-                                                else:
-                                                    # Apply location constraint to the fuel cap
-                                                    co=obj.constraints.new(type='COPY_LOCATION')
-                                                    co.target=rig
-                                                    co.subtarget= bindname
-                                                if 'wheel' in bindname:
-                                                    # Apply Copy Rotation constraint to the wheels
-                                                    cr=obj.constraints.new(type='COPY_ROTATION')
-                                                    cr.target=rig
-                                                    if 'steering' not in bindname:
-                                                        cr.subtarget= bindname
-
-                                    # Deal with TransformAnimators
-                                    #if 'TransformAnimator' in bindname:
-                                    if bindpt and bindpt['$type']=='gameTransformAnimatorComponent':
-                                        ta=[tacmp for tacmp in comps if tacmp['name']['$value']==bindname ][0]
-                                        x=ta['localTransform']['Position']['x']['Bits']/131072
-                                        y=ta['localTransform']['Position']['y']['Bits']/131072
-                                        z=ta['localTransform']['Position']['z']['Bits']/131072
-                                        target=create_axes(ent_coll, bindname)
-                                        for ix,obj in enumerate(objs):
-                                            if target:
-                                                cr=obj.constraints.new(type='COPY_ROTATION')
-                                                cr.target=target
-                                            else:
-                                                target=obj
-
-                            # end new stuff
-                            # dont get the local transform here if we already did it before
-                            if not x:
-                                x=c['localTransform']['Position']['x']['Bits']/131072
-                            if not y:
-                                y=c['localTransform']['Position']['y']['Bits']/131072
-                            if not z:
-                                z=c['localTransform']['Position']['z']['Bits']/131072
-                            #print ('Local transform  x= ',x,'y= ',y,' z= ',z)
-
-                            # local transforms are in the original mesh coord sys, but get applied after its already re-oriented, mainly only matters for wheels.
-                            # this is hacky af as I cant be arsed dealing with doing it properly with quaternions or whatever right now. Feel free to fix it.
-                            if bindname and bones and bindname in bones.keys() and bindname!='Base':
-                                z_ang=bones[bindname].matrix.to_euler().z
-                                x_orig=x
-                                y_orig=y
-                                x=x_orig*cos(z_ang)+y_orig*sin(z_ang)
-                                y=x_orig*sin(z_ang)+y_orig*cos(z_ang)
-                                #print ('Local transform  x= ',x,'y= ',y,' z= ',z)
-
+                            component_is_skinned = component_uses_deformation_skinning(c, skinning_lookup)
+                            skinning_bind = skinning_bind_name(c, skinning_lookup)
+                            if component_is_skinned:
+                                resolved_matrix, bindname, slotname, binding_type = transform_resolver.resolve_component_matrix(c)
+                            else:
+                                resolved_matrix, bindname, slotname, binding_type = transform_resolver.resolve_hard_component_matrix(c)
+                            if component_is_skinned:
+                                bind_skinned_objects_to_rig(new.objects, rig)
                             for obj in new.objects:
-                                #print(obj.name, obj.type)
-                                obj.location.x =  obj.location.x+x
-                                obj.location.y = obj.location.y+y
-                                obj.location.z =  obj.location.z+z
-                                # shouldnt need the 0 check, pretty sure I've fuked up a default somewhere, but at this point I just want it to work.
-                                if 'Orientation' in c['localTransform'].keys() and (sum(obj.rotation_quaternion[:])<1.1  and sum(obj.rotation_quaternion[:])>0.9) or (sum(obj.rotation_quaternion[:])<0.1 and sum(obj.rotation_quaternion[:])>-0.1):
-                                    lrot=get_rot(c['localTransform'])
-                                    obj.rotation_quaternion = obj.rotation_quaternion * Quaternion(lrot)
-                                    obj.rotation_quaternion.x = c['localTransform']['Orientation']['i']
-                                    obj.rotation_quaternion.y = c['localTransform']['Orientation']['j']
-                                    obj.rotation_quaternion.z = c['localTransform']['Orientation']['k']
-                                    obj.rotation_quaternion.w = c['localTransform']['Orientation']['r']
-                                #if vs_rot:
-                                #    obj.matrix_local =  Matrix.LocRotScale(Vector(0,0,0),Quaternion(vs_rot),Vector(1,1,1)) @
-                                if 'scale' in c['localTransform'].keys():
-                                    obj.scale.x = c['localTransform']['scale']['X']
-                                    obj.scale.y = c['localTransform']['scale']['Y']
-                                    obj.scale.z = c['localTransform']['scale']['Z']
-                                if 'visualScale' in c.keys():
-                                    obj.scale.x = c['visualScale']['X']
-                                    obj.scale.y = c['visualScale']['Y']
-                                    obj.scale.z = c['visualScale']['Z']
+                                obj['bindingType'] = binding_type
+                                if bindname:
+                                    obj['bindname'] = bindname
+                                if slotname:
+                                    obj['slotName'] = slotname
+                                obj['deformationRigSkinning'] = component_is_skinned
+                                obj.matrix_world = resolved_matrix @ obj.matrix_world
+                                if not component_enabled:
+                                    obj.hide_set(True)
+                                    obj.hide_render = True
+                                if component_is_skinned:
+                                    continue
+                                if binding_type in {'slot', 'bone'} and rig and bindname and getattr(rig, 'pose', None) and bindname in rig.pose.bones:
+                                    if 'Child Of' not in obj.constraints.keys():
+                                        co = obj.constraints.new(type='CHILD_OF')
+                                        co.target = rig
+                                        co.subtarget = bindname
+                                        set_child_of_inverse(co, rig, bindname)
+                                    if 'wheel' in bindname:
+                                        cr = obj.constraints.new(type='COPY_ROTATION')
+                                        cr.target = rig
+                                        if 'steering' not in bindname:
+                                            cr.subtarget = bindname
+
 
                             if (len(objs) > 0):
                                 move_coll=new
-                                move_coll['depotPath']=c['mesh']['DepotPath']['$value']
+                                move_coll['depotPath']=depot_path
                                 move_coll['meshAppearance']=meshApp
                                 if 'meshpath' not in move_coll:
                                     move_coll['meshpath']="its an entity"
@@ -853,7 +1692,7 @@ def importEnt(with_materials, filepath='', appearances=[], exclude_meshes=[], in
                                 for obj in objs:
                                     subnum = None
                                     # Try to parse index from object name like 'submesh_00'
-                                    m = re.search(r"submesh_(\d+)", obj.name, re.IGNORECASE)
+                                    m = SUBMESH_PATTERN.search(obj.name)
                                     if m:
                                         subnum = int(m.group(1))
                                     else:
@@ -861,15 +1700,16 @@ def importEnt(with_materials, filepath='', appearances=[], exclude_meshes=[], in
                                         mats = getattr(obj.data, 'materials', []) if hasattr(obj, 'data') else []
                                         for mat in mats:
                                             if mat and getattr(mat, 'name', None):
-                                                m2 = re.search(r"submesh_(\d+)", mat.name, re.IGNORECASE)
+                                                m2 = SUBMESH_PATTERN.search(mat.name)
                                                 if m2:
                                                     subnum = int(m2.group(1))
                                                     break
                                     if subnum is None:
                                         continue
                                     bit = cm_list[subnum] if subnum < len(cm_list) else True
-                                    obj.hide_set(not bit)
-                                    obj.hide_render = not bit
+                                    hidden = (not component_enabled) or (not bit)
+                                    obj.hide_set(hidden)
+                                    obj.hide_render = hidden
 
                         except:
                             print("Failed on ",meshname)
@@ -935,45 +1775,13 @@ def importEnt(with_materials, filepath='', appearances=[], exclude_meshes=[], in
             print('Appearance import time:', time.time() - app_start_time, 'Seconds')
 
 
-        # am checking for license plates as we go rather than parsing all the components again.
-        if includes_license_plates:
-            license_plates = [obj for obj in bpy.data.objects if 'license_plate' in obj.get('componentName', '')]
-            bumper_f_objs = [obj for obj in bpy.data.objects if 'bumper_f' in obj.get('componentName', '')]
-            bumper_b_objs = [obj for obj in bpy.data.objects if 'bumper_b' in obj.get('componentName', '')]
-
-            if len(license_plates) > 0:
-                for obj in license_plates:
-                    #print(obj.name)
-                    if not len(obj.constraints)>0:
-                        try:
-                            # use the component name to figure out if this supposed to be attached to the front or back bumper
-                            componentName = obj.get('componentName', '')
-                            bumper_type = 'bumper_f' if 'license_plate_f' in componentName else 'bumper_b'
-                            # Find the correct bumper and match it to the license plate
-                            potential_parents = bumper_f_objs if bumper_type == 'bumper_f' else bumper_b_objs
-                            # Check if there's actually an object to parent the license plate to, if there is set it to obj.parent
-                            if potential_parents:
-                                obj.parent = potential_parents[0]
-                            # I'm pretty certain you have this stored somewhere else already - we should probably look at just adding all of the localTransforms
-                            # to a dict seperate from comp earlier on and just matching them by componnent name whenever we need to apply transforms
-                                lct = next((comp for comp in comps if comp["name"]["$value"] == componentName), None)
-                                #print(lct["localTransform"])
-                                if lct:
-                                    obj.location[0] = lct["localTransform"]["Position"]["x"]["Bits"]/ 131072
-                                    obj.location[1] = lct["localTransform"]["Position"]["y"]["Bits"]/ 131072
-                                    obj.location[2] = lct["localTransform"]["Position"]["z"]["Bits"]/ 131072
-                            else:
-                                print('no bumper found to parent license plate to')
-                        except Exception as e:
-                            print(e)
-
               # find the .phys file jsons
         if include_collisions:
             collision_collection = bpy.data.collections.new('colliders')
             ent_coll.children.link(collision_collection)
             if include_phys:
                 try:
-                    physJsonPaths = glob.glob(escaped_path + "\**\*.phys.json", recursive=True)
+                    physJsonPaths = asset_index.get_files_by_extension('.phys.json')
                     if len(physJsonPaths) == 0:
                         print('No phys file JSONs found in path')
                     else:
@@ -1024,34 +1832,14 @@ def importEnt(with_materials, filepath='', appearances=[], exclude_meshes=[], in
                                         obj['simulationType'] = i['simulationType']
                             except Exception as e:
                                 print(f'Error importing {collision_shape} via pxbridge: {e}')
-    if rig:
-        arm=bpy.data.armatures[rig.name]
-        arm.pose_position = 'REST'
+    if rig and getattr(rig, 'type', None) == 'ARMATURE' and getattr(rig, 'data', None):
+        rig.data.pose_position = 'REST'
     if entinitiatedcache:
         JSONTool.stop_caching()
     if len(error_messages) > 0:
         show_message('Errors during import:\n\t' + '\n\t'.join(error_messages))
-    Masters.hide_viewport=True
+    if Masters:
+        Masters.hide_viewport=True
     if not cp77_addon_prefs.non_verbose:
         print(f"Imported Entity in {time.time() - start_time} Seconds from {ent_name}.ent")
         print('-------------------- Finished Importing Cyberpunk 2077 Entity --------------------\n')
-
-# The above is  the code thats for the import plugin below is to allow testing/dev, you can run this file to import something
-
-if __name__ == "__main__":
-
-    path = 'F:\\CPmod\\heist_hotel\\source\\raw'
-    ent_name = 'single_door.ent'
-    # The list below needs to be the appearanceNames for each ent that you want to import
-    # NOT the name in appearances list, expand it and its the property inside, also its name in the app file
-    appearances =['kitsch_f']
-    escaped_path = glob.escape(path)
-    jsonpath = glob.glob(escaped_path+"\**\*.ent.json", recursive = True)
-    if len(jsonpath)==0:
-        print('No jsons found')
-
-    for i,e in enumerate(jsonpath):
-        if os.path.basename(e)== ent_name+'.json' :
-            filepath=e
-
-    importEnt( filepath, appearances )

--- a/i_scene_cp77_gltf/importers/import_common.py
+++ b/i_scene_cp77_gltf/importers/import_common.py
@@ -1,118 +1,167 @@
-import bpy
-import os
 import json
+import os
 import traceback
-from ..main.setup import MaterialBuilder, bcolors
-from .import_with_materials import CP77GLBimport
-vers = bpy.app.version
 
-if vers[0]  < 5:
-    NAME_MAX_LEN = 64
-else:
-    NAME_MAX_LEN = 256
+import bpy
+
+from ..main.setup import bcolors
+from .import_with_materials import CP77GLBimport
+
+NAME_MAX_LEN = 256
+
+
+def _appearance_name(meshAppearance):
+    if isinstance(meshAppearance, dict):
+        return meshAppearance.get('$value', '')
+    return meshAppearance or ''
 
 
 def get_groupname(meshname, meshAppearance):
-    groupname = os.path.splitext(os.path.split(meshname)[-1])[0]
+    groupname = os.path.splitext(os.path.basename(meshname))[0]
     if 'intersection' in meshname:
-        groupname = os.path.dirname(meshname).split(os.sep)[-1] + '_' + groupname
-    if len(meshAppearance)>0:
-        groupname += '@' + meshAppearance
-    
-    while len(groupname) > NAME_MAX_LEN:
-        groupname = groupname[:-1]
-    return groupname
+        groupname = os.path.basename(os.path.dirname(meshname)) + '_' + groupname
+    appearance = _appearance_name(meshAppearance)
+    if appearance:
+        groupname += '@' + appearance
+    return groupname[:NAME_MAX_LEN]
 
-# Get the group name for the mesh based on its name and appearance
-# group, groupname = get_group(meshname,meshAppearance)
-def get_group(meshname,meshAppearance,Masters):
-    groups= [g for g in Masters.children if 'meshpath' in g.keys() and g['meshpath']==meshname and 'appearance' in g.keys() and g['appearance']==meshAppearance]
-    if len(groups)>0:
-        group=groups[0]
-        groupname = group.name
-    else:
-        groupname = get_groupname(meshname, meshAppearance)
-        group = Masters.children.get(groupname)
-        
-    return group, groupname 
 
-# add_to_list(m , meshes_w_apps)
-def add_to_list(basename, meshes, dict):
-     mesh = meshes[basename]
-     if basename in dict:
-        for app in mesh['appearances']:
-            if app not in dict[basename]['apps'] and get_groupname(meshname, meshAppearance) not in bpy.data.collections.get("MasterInstances").children.keys():
-                dict[basename]['apps'].append(mesh['appearance'])
-        if mesh['sector'] not in dict[basename]['sectors']:
-            dict[basename]['sectors'].append(mesh['sector'])
-     else:
-        dict[basename]={'apps':[mesh['appearances']],'sectors':[mesh['sector']]}
+def build_master_group_index(Masters):
+    by_metadata = {}
+    if not Masters:
+        return by_metadata
+    for candidate in Masters.children:
+        meshpath = candidate.get('meshpath')
+        if meshpath is not None:
+            by_metadata[(meshpath, candidate.get('appearance', ''))] = candidate
+    return by_metadata
 
-def meshes_from_mesheswapps( meshes_w_apps,path='', from_mesh_no=0, to_mesh_no=10000000, with_mats=False, glbs=[], mesh_jsons=[],Masters=None,generate_overrides=False):
-    props = bpy.context.scene.cp77_panel_props 
-    C=bpy.context
-    coll_scene = C.scene.collection
-    for i,m in enumerate(meshes_w_apps):
-        if i>=from_mesh_no and i<=to_mesh_no and (m[-4:]=='mesh' or m[-13:]=='physicalscene' or m[-6:]=='w2mesh'):
-            apps=[]
-            for meshApp in meshes_w_apps[m]['apps'][0]:
-                if (
-                    not isinstance(meshApp, str)
-                    and meshApp["$value"] not in apps
-                    and meshApp["$value"] != ""
-                ):
-                    apps.append(meshApp['$value'])
-            if m[-13:]=='physicalscene' or m[-6:]=='w2mesh':
-                meshpath=os.path.join(path, m+'.glb').replace('\\', os.sep)
-                print('not a standard mesh')
-            else:
-                meshpath=os.path.join(path, m[:-1*len(os.path.splitext(m)[1])]+'.glb').replace('\\', os.sep)
-            print(meshpath)
-            groupname = get_groupname(meshpath, '')
 
-            if groupname not in Masters.children.keys() and os.path.exists(meshpath):
-                try:                    
-                    CP77GLBimport( with_materials=with_mats,remap_depot= props.remap_depot, filepath=meshpath, appearances=apps,
-                                    scripting=True, generate_overrides=generate_overrides)
+def get_group(meshname, meshAppearance, Masters, master_index=None):
+    groupname = get_groupname(meshname, meshAppearance)
+    group = Masters.children.get(groupname)
+    if group:
+        return group, groupname
 
-                    objs = C.selected_objects
-                    if objs[0].users_collection[0].name!= groupname:
-                        objs[0].users_collection[0].name= groupname
-                    move_coll= coll_scene.children.get( objs[0].users_collection[0].name )
-                    move_coll['meshpath']=m
-                    move_coll['appearance']='default'
-                    Masters.children.link(move_coll)
-                    for app in apps:
-                        # Create a completely new collection for this appearance
-                        new_coll = bpy.data.collections.new(groupname + '@' + app)
-                        Masters.children.link(new_coll)
-                        new_coll['meshpath']=m
-                        new_coll['appearance'] = app
-                        # Set the appearance property
-                        json_apps= None
-                        if 'json_apps' in move_coll.keys():
-                            json_apps =  json.loads(move_coll['json_apps'])
-                        else:
-                            print(f'{bcolors.FAIL}No material json found for - {m}{bcolors.ENDC}')
-                        for idx,obj in enumerate(move_coll.objects):
-                            obj_copy=obj.copy()
-                            obj_copy.data = obj.data.copy()
-                            if obj_copy.type == 'MESH':
-                                if json_apps and app in json_apps and idx < len(json_apps[app]):
-                                    # Assign the material from the json_apps if it exists
-                                    mat_name = json_apps.get(app)[idx]
-                                    if 'sidewalk' in m:
-                                        mat_name = 'sidewalksidewalksidewalksidewalksidewalksidewalksidewalksidewalksidewalk'
+    appearance = _appearance_name(meshAppearance)
+    if master_index is not None:
+        candidate = master_index.get((meshname, appearance))
+        if candidate:
+            return candidate, candidate.name
 
-                                    if len(mat_name)<63 and len(obj_copy.data.materials)>1 and mat_name in obj_copy.data.materials.keys():
-                                        for ii in range(len(obj_copy.data.materials)-1,-1,-1):
-                                            mat=obj_copy.data.materials.keys()[ii]
-                                            if mat.split('.')[0]!=mat_name:
-                                                obj_copy.data.materials.pop(index=ii)
-                            new_coll.objects.link(obj_copy)                    
-                    coll_scene.children.unlink(move_coll)
-                except:
-                    print('failed on ',os.path.basename(meshpath))                    
-                    print(traceback.format_exc())
-            elif not os.path.exists(meshpath):
-                print('Mesh ', meshpath, ' does not exist')
+    for candidate in Masters.children:
+        if candidate.get('meshpath') == meshname and candidate.get('appearance') == appearance:
+            return candidate, candidate.name
+    return None, groupname
+
+
+def add_to_list(basename, meshes, target):
+    mesh = meshes[basename]
+    entry = target.setdefault(basename, {'apps': [], 'sectors': []})
+    seen_apps = set(entry['apps'])
+    for app in mesh.get('appearances', []):
+        if app not in seen_apps:
+            seen_apps.add(app)
+            entry['apps'].append(app)
+    sector = mesh.get('sector')
+    if sector not in entry['sectors']:
+        entry['sectors'].append(sector)
+
+
+def _mesh_glb_path(path, mesh_ref):
+    if mesh_ref.endswith(('physicalscene', 'w2mesh')):
+        return os.path.join(path, mesh_ref + '.glb').replace('\\', os.sep)
+    return (os.path.splitext(mesh_ref)[0] + '.glb').replace('\\', os.sep)
+
+
+def _appearance_list(raw_apps):
+    if len(raw_apps) == 1 and isinstance(raw_apps[0], list):
+        raw_apps = raw_apps[0]
+
+    apps = []
+    seen = set()
+    for app in raw_apps:
+        value = _appearance_name(app)
+        if value and value not in seen:
+            seen.add(value)
+            apps.append(value)
+    return apps
+
+
+def _prune_materials(obj, mat_name):
+    materials = obj.data.materials
+    if len(mat_name) >= NAME_MAX_LEN or len(materials) <= 1:
+        return
+    names = list(materials.keys())
+    if mat_name not in names:
+        return
+    for index in range(len(names) - 1, -1, -1):
+        if names[index].split('.')[0] != mat_name:
+            materials.pop(index=index)
+
+
+def meshes_from_mesheswapps(meshes_w_apps, path='', from_mesh_no=0, to_mesh_no=10000000, with_mats=False, glbs=None, mesh_jsons=None, Masters=None, generate_overrides=False):
+    props = bpy.context.scene.cp77_panel_props
+    context = bpy.context
+    coll_scene = context.scene.collection
+    master_children = Masters.children
+
+    for index, mesh_ref in enumerate(meshes_w_apps):
+        if index < from_mesh_no or index > to_mesh_no:
+            continue
+        if not mesh_ref.endswith(('mesh', 'physicalscene', 'w2mesh')):
+            continue
+
+        apps = _appearance_list(meshes_w_apps[mesh_ref].get('apps', []))
+        meshpath = _mesh_glb_path(path, mesh_ref)
+        print(meshpath)
+
+        groupname = get_groupname(meshpath, '')
+        if master_children.get(groupname):
+            continue
+        if not os.path.exists(meshpath):
+            print('Mesh ', meshpath, ' does not exist')
+            continue
+
+        try:
+            CP77GLBimport(with_materials=with_mats, remap_depot=props.remap_depot, filepath=meshpath, appearances=apps, scripting=True, generate_overrides=generate_overrides)
+            objs = context.selected_objects
+            if not objs:
+                print('failed on ', os.path.basename(meshpath))
+                print('No objects selected after import')
+                continue
+
+            source_coll = objs[0].users_collection[0]
+            if source_coll.name != groupname:
+                source_coll.name = groupname
+            move_coll = coll_scene.children.get(source_coll.name)
+            move_coll['meshpath'] = mesh_ref
+            move_coll['appearance'] = 'default'
+            master_children.link(move_coll)
+
+            json_apps = json.loads(move_coll['json_apps']) if 'json_apps' in move_coll.keys() else None
+            if json_apps is None:
+                print(f'{bcolors.FAIL}No material json found for - {mesh_ref}{bcolors.ENDC}')
+
+            source_objects = tuple(move_coll.objects)
+            for app in apps:
+                new_coll = bpy.data.collections.new(groupname + '@' + app)
+                master_children.link(new_coll)
+                new_coll['meshpath'] = mesh_ref
+                new_coll['appearance'] = app
+                app_materials = json_apps.get(app) if json_apps else None
+
+                for obj_index, obj in enumerate(source_objects):
+                    obj_copy = obj.copy()
+                    obj_copy.data = obj.data.copy()
+                    if obj_copy.type == 'MESH' and app_materials and obj_index < len(app_materials):
+                        mat_name = app_materials[obj_index]
+                        if 'sidewalk' in mesh_ref:
+                            mat_name = 'sidewalksidewalksidewalksidewalksidewalksidewalksidewalksidewalksidewalk'
+                        _prune_materials(obj_copy, mat_name)
+                    new_coll.objects.link(obj_copy)
+
+            coll_scene.children.unlink(move_coll)
+        except Exception:
+            print('failed on ', os.path.basename(meshpath))
+            print(traceback.format_exc())

--- a/i_scene_cp77_gltf/importers/import_common.py
+++ b/i_scene_cp77_gltf/importers/import_common.py
@@ -26,52 +26,66 @@ def get_groupname(meshname, meshAppearance):
     return groupname[:NAME_MAX_LEN]
 
 
-def build_master_group_index(Masters):
-    by_metadata = {}
-    if not Masters:
-        return by_metadata
-    for candidate in Masters.children:
-        meshpath = candidate.get('meshpath')
-        if meshpath is not None:
-            by_metadata[(meshpath, candidate.get('appearance', ''))] = candidate
-    return by_metadata
-
-
-def get_group(meshname, meshAppearance, Masters, master_index=None):
+def get_group(meshname, meshAppearance, Masters):
     groupname = get_groupname(meshname, meshAppearance)
     group = Masters.children.get(groupname)
     if group:
         return group, groupname
 
     appearance = _appearance_name(meshAppearance)
-    if master_index is not None:
-        candidate = master_index.get((meshname, appearance))
-        if candidate:
-            return candidate, candidate.name
-
     for candidate in Masters.children:
         if candidate.get('meshpath') == meshname and candidate.get('appearance') == appearance:
             return candidate, candidate.name
     return None, groupname
 
 
+def _dedupe_key(value):
+    if isinstance(value, dict):
+        if '$value' in value:
+            return ('cname', value.get('$value'))
+        try:
+            return ('dict', json.dumps(value, sort_keys=True, separators=(',', ':'), default=str))
+        except TypeError:
+            return ('dict', repr(value))
+    if isinstance(value, (list, tuple)):
+        return tuple(_dedupe_key(item) for item in value)
+    try:
+        hash(value)
+    except TypeError:
+        return repr(value)
+    return value
+
+
 def add_to_list(basename, meshes, target):
     mesh = meshes[basename]
     entry = target.setdefault(basename, {'apps': [], 'sectors': []})
-    seen_apps = set(entry['apps'])
+
+    seen_apps = {_dedupe_key(app) for app in entry['apps']}
     for app in mesh.get('appearances', []):
-        if app not in seen_apps:
-            seen_apps.add(app)
+        key = _dedupe_key(app)
+        if key not in seen_apps:
+            seen_apps.add(key)
             entry['apps'].append(app)
+
     sector = mesh.get('sector')
-    if sector not in entry['sectors']:
+    sector_key = _dedupe_key(sector)
+    seen_sectors = {_dedupe_key(existing) for existing in entry['sectors']}
+    if sector_key not in seen_sectors:
         entry['sectors'].append(sector)
 
 
-def _mesh_glb_path(path, mesh_ref):
+def _mesh_glb_path(path, mesh_ref, asset_index=None):
+    if asset_index is not None:
+        if mesh_ref.endswith(('physicalscene', 'w2mesh')):
+            resolved = asset_index.resolve_expected(mesh_ref + '.glb', '.glb', warn=False)
+        else:
+            resolved = asset_index.resolve_mesh_glb(mesh_ref)
+        if resolved:
+            return resolved
+
     if mesh_ref.endswith(('physicalscene', 'w2mesh')):
         return os.path.join(path, mesh_ref + '.glb').replace('\\', os.sep)
-    return (os.path.splitext(mesh_ref)[0] + '.glb').replace('\\', os.sep)
+    return os.path.join(path, os.path.splitext(mesh_ref)[0] + '.glb').replace('\\', os.sep)
 
 
 def _appearance_list(raw_apps):
@@ -90,17 +104,14 @@ def _appearance_list(raw_apps):
 
 def _prune_materials(obj, mat_name):
     materials = obj.data.materials
-    if len(mat_name) >= NAME_MAX_LEN or len(materials) <= 1:
+    if len(mat_name) >= NAME_MAX_LEN or len(materials) <= 1 or mat_name not in materials.keys():
         return
-    names = list(materials.keys())
-    if mat_name not in names:
-        return
-    for index in range(len(names) - 1, -1, -1):
-        if names[index].split('.')[0] != mat_name:
+    for index in range(len(materials) - 1, -1, -1):
+        if materials.keys()[index].split('.')[0] != mat_name:
             materials.pop(index=index)
 
 
-def meshes_from_mesheswapps(meshes_w_apps, path='', from_mesh_no=0, to_mesh_no=10000000, with_mats=False, glbs=None, mesh_jsons=None, Masters=None, generate_overrides=False):
+def meshes_from_mesheswapps(meshes_w_apps, path='', from_mesh_no=0, to_mesh_no=10000000, with_mats=False, glbs=None, mesh_jsons=None, Masters=None, generate_overrides=False, asset_index=None):
     props = bpy.context.scene.cp77_panel_props
     context = bpy.context
     coll_scene = context.scene.collection
@@ -113,11 +124,11 @@ def meshes_from_mesheswapps(meshes_w_apps, path='', from_mesh_no=0, to_mesh_no=1
             continue
 
         apps = _appearance_list(meshes_w_apps[mesh_ref].get('apps', []))
-        meshpath = _mesh_glb_path(path, mesh_ref)
+        meshpath = _mesh_glb_path(path, mesh_ref, asset_index=asset_index)
         print(meshpath)
 
         groupname = get_groupname(meshpath, '')
-        if master_children.get(groupname):
+        if groupname in master_children.keys():
             continue
         if not os.path.exists(meshpath):
             print('Mesh ', meshpath, ' does not exist')

--- a/i_scene_cp77_gltf/importers/import_with_materials.py
+++ b/i_scene_cp77_gltf/importers/import_with_materials.py
@@ -73,16 +73,13 @@ def get_anim_info(animations, oldanims, import_tracks):
                     print("No action found for", animation.name)
 
 def objs_in_col(top_coll, objtype):
-    nested = sum(1 for col in top_coll.children_recursive for o in col.objects if o.type == objtype)
-    direct = sum(1 for o in top_coll.objects if o.type == objtype)
-    return nested + direct
+    return sum(1 for obj in top_coll.all_objects if obj.type == objtype)
 
 # will collapse glTF_not_exported collection in the outliner
 def disable_collection_by_name(collection_name):
-    target = collection_name.lower()
     for vl in bpy.context.scene.view_layers:
         for l in vl.layer_collection.children:
-             if l.name.lower() == target:
+             if l.name.lower() == collection_name.lower():
                 l.exclude = True
 
 
@@ -168,38 +165,28 @@ def CP77GLBimport( with_materials=False, remap_depot=False, exclude_unused_mats=
             gltf_importer = glTFImporter(filepath, { "files": None, "loglevel": 0, "import_pack_images" :True, "merge_vertices" :False, "import_shading" : 'NORMALS', "bone_heuristic":heuristic, "guess_original_bind_pose" : False, "import_user_extensions": "",'disable_bone_shape':octos, 'import_select_created_objects':True,})
         gltf_importer.read()
         gltf_importer.checks()
-        existingMeshes = bpy.data.meshes.keys()
+        existingMeshes = {mesh.name for mesh in bpy.data.meshes}
 
         current_file_base_path = os.path.join(os.path.dirname(filepath),filename)
         has_material_json = os.path.exists(current_file_base_path + ".Material.json")
 
-        existingMaterials = set(bpy.data.materials.keys())
+        existingMaterials = {mat.name for mat in bpy.data.materials}
         BlenderGlTF.create(gltf_importer)
         exclusion_cache.clear_cache()
         imported=context.selected_objects #the new stuff should be selected
 
         # if we're not importing a Cyberpunk mesh, not all submesh names will start with submesh_00, and they will be nested weirdly.
         # we want to clean this up.
-        # Single pass over `imported` for both the external-import heuristic and the
-        # multimesh flag; these were previously two separate loops over the same list.
-        multimesh = False
-        meshcount = 0
-        submesh_count = 0
-        imported_empties_present = False
-        for obj in imported:
-            obj_type = obj.type
-            if obj_type == "EMPTY":
-                imported_empties_present = True
-            if obj_type == 'MESH':
-                if obj.name.startswith("submesh"):
-                    submesh_count += 1
-                multimesh = obj.name.startswith(str(meshcount)+"_")
-                meshcount += 1
-            else:
-                multimesh = False
-                exclude_unused_mats = False
+        imported_meshes = [obj for obj in imported if obj.type == "MESH"]
+        imported_empties = [obj for obj in imported if obj.type == "EMPTY"]
+        isExternalImport = len(imported_empties) > 0 or sum(1 for mesh in imported_meshes if mesh.name.startswith("submesh")) != len(imported_meshes)
 
-        isExternalImport = imported_empties_present or submesh_count != meshcount
+        mesh_objects = [obj for obj in imported if obj.type == 'MESH']
+        multimesh = any(
+            obj.name and obj.name[0].isdigit() and '_' in obj.name
+            for obj in mesh_objects
+        )
+        exclude_unused_mats = exclude_unused_mats and all(obj.type == 'MESH' for obj in imported)
 
         if multimesh:
             isExternalImport = False
@@ -216,7 +203,7 @@ def CP77GLBimport( with_materials=False, remap_depot=False, exclude_unused_mats=
         collection = bpy.data.collections.new(filename)
         bpy.context.scene.collection.children.link(collection)
         for o in imported:
-            import_meshes_and_anims(collection, gltf_importer, hide_armatures, o, filename, oldanims, import_tracks, verbose)
+            import_meshes_and_anims(collection, gltf_importer, hide_armatures, o, filename, oldanims, import_tracks)
 
         collection['orig_filepath']=filepath
         collection['numMeshChildren']=objs_in_col(collection, 'MESH')
@@ -235,7 +222,7 @@ def CP77GLBimport( with_materials=False, remap_depot=False, exclude_unused_mats=
         #Kwek: Added another gate for materials
         DepotPath=None
 
-        blender_4_scale_armature_bones()
+        blender_4_scale_armature_bones(imported)
 
         if ".anims.glb" in filepath:
             continue
@@ -325,28 +312,31 @@ def CP77GLBimport( with_materials=False, remap_depot=False, exclude_unused_mats=
 
 def reload_mats(self, context):
     active_obj = bpy.context.active_object
-
     active_material = active_obj.active_material
+    if active_material is None:
+        self.report({'ERROR'}, "No active material selected")
+        return {'CANCELLED'}
 
     orig_mat_name = active_material.name
-    # JATO: "m" customprop introduced in addon ver 1.8. much safer to use than the bpy material.name
-    if 'm' in active_material.keys():
+    if 'm' in active_material:
         orig_mat_name = str(active_material['m']['Name'])
-
-    active_material.name = "to_be_deleted"
 
     BasePath = active_material.get('MeshPath')
     DepotPath = active_material.get('DepotPath')
     ProjPath = active_material.get('ProjPath')
 
-    # JATO: This is a workaround to get MeshPath from collection for old assets before we stored MeshPath within material.
     if BasePath is None:
         for collection in bpy.data.collections:
-             if active_obj.name in collection.objects:
-                  MeshPath = collection.get('mesh')
-                  MeshPathNoSuffix = MeshPath[0:MeshPath.rfind('.')]
-                  BasePath = os.path.join(ProjPath, MeshPathNoSuffix)
-                  break
+            if active_obj.name in collection.objects:
+                MeshPath = collection.get('mesh')
+                if MeshPath and ProjPath:
+                    MeshPathNoSuffix = MeshPath[:MeshPath.rfind('.')]
+                    BasePath = os.path.join(ProjPath, MeshPathNoSuffix)
+                break
+
+    if BasePath is None:
+        self.report({'ERROR'}, "Could not resolve material base path")
+        return {'CANCELLED'}
 
     errorMessages = []
     matjsonpath = BasePath + ".Material.json"
@@ -355,36 +345,41 @@ def reload_mats(self, context):
         self.report({'ERROR'}, ('Material.json not found: ' + matjsonpath))
         return {'CANCELLED'}
 
-    # JATO: hard-coded to PNG (who doesnt use PNG?) but could be exposed if we add image_format to material properties
-    image_format='png'
-
-    # JATO: no idea what caching does but the glb import function does it so...
-    # JATO: probably a better way to do this but idk how and dont want to rewrite the function
+    image_format = 'png'
+    initiated_cache = False
     if not JSONTool._use_cache:
         JSONTool.start_caching()
         initiated_cache = True
-    somejunk, otherjunk, mats = JSONTool.jsonload(matjsonpath, errorMessages)
-    Builder = MaterialBuilder(mats, DepotPath, str(image_format), BasePath)
-    if initiated_cache:
-        JSONTool.stop_caching()
+
+    try:
+        somejunk, otherjunk, mats = JSONTool.jsonload(matjsonpath, errorMessages)
+        Builder = MaterialBuilder(mats, DepotPath, str(image_format), BasePath)
+    finally:
+        if initiated_cache:
+            JSONTool.stop_caching()
+
     if len(errorMessages) > 0:
         show_message("\n".join(errorMessages))
 
-    index = 0
-    for rawmat in mats:
-        #old_mat_name_split = old_mat_name.split('.')[0]
-        if rawmat["Name"] == orig_mat_name.split('.')[0]:
-            newmat = Builder.create(mats,index)
+    newmat = None
+    old_base_name = orig_mat_name.split('.')[0]
+    for index, rawmat in enumerate(mats):
+        if rawmat.get("Name") == old_base_name:
+            newmat = Builder.create(mats, index)
             break
-        index = index + 1
 
-    if 'newmat' not in locals():
+    if newmat is None:
         self.report({'ERROR'}, "New material not created")
         return {'CANCELLED'}
-    # JATO: Copy custom material properties from old mat to new mat. Maybe we could regenerate from file, but I'm having a hard time understanding the code for that within import_mats function
+
     for k in active_material.keys():
-        if k in ('BaseMaterial','DiffuseMap','GlobalNormal','MultilayerMask'):
+        if k in ('BaseMaterial', 'DiffuseMap', 'GlobalNormal', 'MultilayerMask'):
             newmat[k] = active_material[k]
+
+    old_material = active_material
+    active_obj.material_slots[active_obj.active_material_index].material = newmat
+    if old_material.users == 0:
+        bpy.data.materials.remove(old_material, do_unlink=True, do_id_user=True, do_ui_user=True)
 
     return newmat
 
@@ -396,39 +391,26 @@ def import_mats(BasePath, DepotPath, exclude_unused_mats, existingMeshes, gltf_i
     verbose = not cp77_addon_prefs.non_verbose
     start_time = time.time()
     validmats = {}
-    mat_index_by_name = {}
-    for i, m in enumerate(mats): #obj['Materials']:
-        if 'Name' not in m:
-            # Sometimes a material has no name, for now we continue out, but we should figure out why
+    for m in mats: #obj['Materials']:
+        mat = m.get('Name')
+        if mat is None:
             continue
-        mat = m['Name']
-        mat_index_by_name[mat] = i
         if mat not in validmatnames:
             continue
         if 'BaseMaterial' in m:
-            if 'GlobalNormal' in m['Data']:
-                GlobalNormal = m['Data']['GlobalNormal']
-            else:
-                GlobalNormal = 'None'
-            if 'MultilayerMask' in m['Data']:
-                MultilayerMask = m['Data']['MultilayerMask']
-            else:
-                MultilayerMask = 'None'
-            if 'DiffuseMap' in m['Data']:
-                DiffuseMap = m['Data']['DiffuseMap']
-            elif 'BaseColor' in m['Data']:
-                DiffuseMap = m['Data']['BaseColor']
-            elif 'DiffuseTexture' in m['Data']:
-                DiffuseMap = m['Data']['DiffuseTexture']
-            else:
-                DiffuseMap = 'None'
+            data = m.get('Data', {})
+            GlobalNormal = data.get('GlobalNormal', 'None')
+            MultilayerMask = data.get('MultilayerMask', 'None')
+            DiffuseMap = data.get('DiffuseMap', data.get('BaseColor', data.get('DiffuseTexture', 'None')))
 
-            validmats[mat] = {'Name': m['Name'], 'BaseMaterial': m['BaseMaterial'],
+            validmats[mat] = {'Name': mat, 'BaseMaterial': m['BaseMaterial'],
                               'GlobalNormal': GlobalNormal, 'MultilayerMask': MultilayerMask,
                               'DiffuseMap': DiffuseMap}
         else:
             print(m.keys())
 
+    MatImportList = list(validmats)
+    mat_index_by_name = {m['Name']: i for i, m in enumerate(mats) if 'Name' in m}
     Builder = MaterialBuilder(mats, DepotPath, str(image_format), BasePath)
     counter = 0
     bpy_mats = bpy.data.materials
@@ -436,15 +418,21 @@ def import_mats(BasePath, DepotPath, exclude_unused_mats, existingMeshes, gltf_i
         obj.data.name for obj in excluded_objects
         if getattr(obj, "type", "") == 'MESH' and obj.data
         }
-    # existingMeshes may be a plain keys() view/list; hoist to a set once so the
-    # membership test below is O(1) instead of O(n) per name.
     existing_mesh_names = set(existingMeshes)
-    names=[key for key in bpy.data.meshes.keys() if key not in existing_mesh_names and key not in excluded_mesh_names]
+    names = [
+        mesh.name for mesh in bpy.data.meshes
+        if mesh.name not in existing_mesh_names and mesh.name not in excluded_mesh_names
+    ]
     if multimesh:
-        names= sorted(names, key=lambda x: int(x.partition('_')[0]))
-    for name in names:
+        names = sorted(names, key=lambda x: int(x.split('_', 1)[0]) if x.split('_', 1)[0].isdigit() else 0)
 
-        bpy.data.meshes[name].materials.clear()
+    bpy_meshes = bpy.data.meshes
+    for name in names:
+        mesh = bpy_meshes.get(name)
+        if mesh is None:
+            continue
+
+        mesh.materials.clear()
         # we're not getting the materials from the json, but from the glTF importer data
         extras = gltf_importer.data.meshes[counter].extras
 
@@ -476,7 +464,7 @@ def import_mats(BasePath, DepotPath, exclude_unused_mats, existingMeshes, gltf_i
             # Should create a list of mis that dont play nice with this and just check if the mat is using one.
             cached = bpy_mats.get(matname)
             if cached is not None and 'm' in cached and dict(cached['m']) == m:
-                bpy.data.meshes[name].materials.append(cached)
+                mesh.materials.append(cached)
                 continue
 
             index = mat_index_by_name.get(matname)
@@ -493,7 +481,7 @@ def import_mats(BasePath, DepotPath, exclude_unused_mats, existingMeshes, gltf_i
                         bpymat['DiffuseMap'] = m['DiffuseMap']
                     if 'DiffuseTexture' in m:
                         bpymat['DiffuseTexture'] = m['DiffuseTexture']
-                    bpy.data.meshes[name].materials.append(bpymat)
+                    mesh.materials.append(bpymat)
                     if bpymat.get('no_shadows'):
                         shadow_obj = bpy.data.objects.get(name)
                         if shadow_obj is not None:
@@ -518,28 +506,24 @@ def import_mats(BasePath, DepotPath, exclude_unused_mats, existingMeshes, gltf_i
     for name, index in mat_index_by_name.items():
         if name in bpy.data.materials:
             continue
-        if validmats and name not in validmats:
+        if MatImportList and name not in MatImportList:
             continue
         Builder.create(mats, index)
 
 
-def blender_4_scale_armature_bones():
+def blender_4_scale_armature_bones(imported_objects):
     vers = bpy.app.version
     if vers[0] >= 4:
-        arms = [obj for obj in bpy.data.objects if obj.type == 'ARMATURE' and 'Armature' in obj.name]
-        for arm in arms:
+        for arm in (obj for obj in imported_objects if obj.type == 'ARMATURE'):
             for pb in arm.pose.bones:
-                pb.custom_shape_scale_xyz[0] = .0175
-                pb.custom_shape_scale_xyz[1] = .0175
-                pb.custom_shape_scale_xyz[2] = .0175
+                pb.custom_shape_scale_xyz = (.0175, .0175, .0175)
                 pb.use_custom_shape_bone_size = True
 
 
-def import_meshes_and_anims(collection, gltf_importer, hide_armatures, o, filename, oldanims, import_tracks, verbose=None):
+def import_meshes_and_anims(collection, gltf_importer, hide_armatures, o, filename, oldanims, import_tracks):
     # TODO: check if this is a Cyberpunk import or something else entirely
-    if verbose is None:
-        cp77_addon_prefs = bpy.context.preferences.addons['i_scene_cp77_gltf'].preferences
-        verbose = not cp77_addon_prefs.non_verbose
+    cp77_addon_prefs = bpy.context.preferences.addons['i_scene_cp77_gltf'].preferences
+    verbose = not cp77_addon_prefs.non_verbose
 
     for parent in o.users_collection:
         parent.objects.unlink(o)

--- a/i_scene_cp77_gltf/importers/import_with_materials.py
+++ b/i_scene_cp77_gltf/importers/import_with_materials.py
@@ -73,13 +73,16 @@ def get_anim_info(animations, oldanims, import_tracks):
                     print("No action found for", animation.name)
 
 def objs_in_col(top_coll, objtype):
-    return sum([len([o for o in col.objects if o.type==objtype]) for col in top_coll.children_recursive])+len([o for o in top_coll.objects if o.type==objtype])
+    nested = sum(1 for col in top_coll.children_recursive for o in col.objects if o.type == objtype)
+    direct = sum(1 for o in top_coll.objects if o.type == objtype)
+    return nested + direct
 
 # will collapse glTF_not_exported collection in the outliner
 def disable_collection_by_name(collection_name):
+    target = collection_name.lower()
     for vl in bpy.context.scene.view_layers:
         for l in vl.layer_collection.children:
-             if l.name.lower() == collection_name.lower():
+             if l.name.lower() == target:
                 l.exclude = True
 
 
@@ -177,23 +180,26 @@ def CP77GLBimport( with_materials=False, remap_depot=False, exclude_unused_mats=
 
         # if we're not importing a Cyberpunk mesh, not all submesh names will start with submesh_00, and they will be nested weirdly.
         # we want to clean this up.
-        imported_meshes = [obj for obj in imported if obj.type == "MESH"]
-        imported_empties = [obj for obj in imported if obj.type == "EMPTY"]
-        isExternalImport = len(imported_empties) > 0 or len([mesh.name for mesh in imported_meshes if mesh.name.startswith("submesh")]) != len(imported_meshes)
-
-        multimesh=False
-        meshcount=0
-        # check if we have a multimesh object, and if so, set the flag
+        # Single pass over `imported` for both the external-import heuristic and the
+        # multimesh flag; these were previously two separate loops over the same list.
+        multimesh = False
+        meshcount = 0
+        submesh_count = 0
+        imported_empties_present = False
         for obj in imported:
-            if obj.type == 'MESH' and obj.name.startswith(str(meshcount)+"_"):
-                multimesh = True
-                meshcount += 1
-            elif obj.type == 'MESH' :
-                multimesh = False
+            obj_type = obj.type
+            if obj_type == "EMPTY":
+                imported_empties_present = True
+            if obj_type == 'MESH':
+                if obj.name.startswith("submesh"):
+                    submesh_count += 1
+                multimesh = obj.name.startswith(str(meshcount)+"_")
                 meshcount += 1
             else:
                 multimesh = False
                 exclude_unused_mats = False
+
+        isExternalImport = imported_empties_present or submesh_count != meshcount
 
         if multimesh:
             isExternalImport = False
@@ -210,7 +216,7 @@ def CP77GLBimport( with_materials=False, remap_depot=False, exclude_unused_mats=
         collection = bpy.data.collections.new(filename)
         bpy.context.scene.collection.children.link(collection)
         for o in imported:
-            import_meshes_and_anims(collection, gltf_importer, hide_armatures, o, filename, oldanims, import_tracks)
+            import_meshes_and_anims(collection, gltf_importer, hide_armatures, o, filename, oldanims, import_tracks, verbose)
 
         collection['orig_filepath']=filepath
         collection['numMeshChildren']=objs_in_col(collection, 'MESH')
@@ -390,11 +396,13 @@ def import_mats(BasePath, DepotPath, exclude_unused_mats, existingMeshes, gltf_i
     verbose = not cp77_addon_prefs.non_verbose
     start_time = time.time()
     validmats = {}
-    for m in mats: #obj['Materials']:
+    mat_index_by_name = {}
+    for i, m in enumerate(mats): #obj['Materials']:
         if 'Name' not in m:
             # Sometimes a material has no name, for now we continue out, but we should figure out why
             continue
         mat = m['Name']
+        mat_index_by_name[mat] = i
         if mat not in validmatnames:
             continue
         if 'BaseMaterial' in m:
@@ -421,8 +429,6 @@ def import_mats(BasePath, DepotPath, exclude_unused_mats, existingMeshes, gltf_i
         else:
             print(m.keys())
 
-    MatImportList = list(validmats)
-    mat_index_by_name = {m['Name']: i for i, m in enumerate(mats) if 'Name' in m}
     Builder = MaterialBuilder(mats, DepotPath, str(image_format), BasePath)
     counter = 0
     bpy_mats = bpy.data.materials
@@ -430,9 +436,12 @@ def import_mats(BasePath, DepotPath, exclude_unused_mats, existingMeshes, gltf_i
         obj.data.name for obj in excluded_objects
         if getattr(obj, "type", "") == 'MESH' and obj.data
         }
-    names=[key for key in bpy.data.meshes.keys() if key not in existingMeshes and key not in excluded_mesh_names]
+    # existingMeshes may be a plain keys() view/list; hoist to a set once so the
+    # membership test below is O(1) instead of O(n) per name.
+    existing_mesh_names = set(existingMeshes)
+    names=[key for key in bpy.data.meshes.keys() if key not in existing_mesh_names and key not in excluded_mesh_names]
     if multimesh:
-        names= sorted(list(names), key=lambda x: int(x.split('_')[0]))
+        names= sorted(names, key=lambda x: int(x.partition('_')[0]))
     for name in names:
 
         bpy.data.meshes[name].materials.clear()
@@ -509,7 +518,7 @@ def import_mats(BasePath, DepotPath, exclude_unused_mats, existingMeshes, gltf_i
     for name, index in mat_index_by_name.items():
         if name in bpy.data.materials:
             continue
-        if MatImportList and name not in MatImportList:
+        if validmats and name not in validmats:
             continue
         Builder.create(mats, index)
 
@@ -526,10 +535,11 @@ def blender_4_scale_armature_bones():
                 pb.use_custom_shape_bone_size = True
 
 
-def import_meshes_and_anims(collection, gltf_importer, hide_armatures, o, filename, oldanims, import_tracks):
+def import_meshes_and_anims(collection, gltf_importer, hide_armatures, o, filename, oldanims, import_tracks, verbose=None):
     # TODO: check if this is a Cyberpunk import or something else entirely
-    cp77_addon_prefs = bpy.context.preferences.addons['i_scene_cp77_gltf'].preferences
-    verbose = not cp77_addon_prefs.non_verbose
+    if verbose is None:
+        cp77_addon_prefs = bpy.context.preferences.addons['i_scene_cp77_gltf'].preferences
+        verbose = not cp77_addon_prefs.non_verbose
 
     for parent in o.users_collection:
         parent.objects.unlink(o)

--- a/i_scene_cp77_gltf/importers/read_rig.py
+++ b/i_scene_cp77_gltf/importers/read_rig.py
@@ -140,7 +140,7 @@ def read_rig(filepath: str) -> RigData:
         ls_t=t,
         ls_s=s,
         rig_name=rig_name,
-        disable_connect=rig_name.startswith("v_"),
+        disable_connect=True,
         apose_ms=root.get("aPoseMS", []),
         apose_ls=root.get("aPoseLS", []),
         bone_transforms=trs,
@@ -357,7 +357,7 @@ def apply_bone_from_matrix(bone_index: int, mat: Matrix, edit_bones: dict[int, b
 
 def create_armature_from_data(filepath: str, bind_pose: str, create_debug: bool = False):
     start_time = time.time()
-
+    rig_col = None
     rig_data = read_rig(filepath)
     if not rig_data:
         show_message(f"Failed to load rig data from {filepath} ERROR")
@@ -366,8 +366,16 @@ def create_armature_from_data(filepath: str, bind_pose: str, create_debug: bool 
     print(f'Beginning Import of: {rig_data.rig_name} from: {filepath} Bind Pose: {bind_pose}')
     context = bpy.context
     safe_mode_switch('OBJECT')
+    coll_scene = context.scene.collection
+    if not bpy.data.collections.get(rig_data.rig_name):
+        rig_col=bpy.data.collections.new(rig_data.rig_name)
+        coll_scene.children.link(rig_col)
+    else:
+        rig_col = bpy.data.collections.get(rig_data.rig_name)      
     bpy.ops.object.add(type='ARMATURE', enter_editmode=True, location=(0, 0, 0))
     arm_obj = context.object
+    rig_col.objects.link(arm_obj)
+
     arm_data = arm_obj.data
     arm_obj.name = rig_data.rig_name
     arm_data.name = f"{rig_data.rig_name}_Data"

--- a/i_scene_cp77_gltf/importers/sector_import.py
+++ b/i_scene_cp77_gltf/importers/sector_import.py
@@ -16,7 +16,6 @@
 # 4) Run it
 from ..main.common import *
 from ..jsontool import JSONTool
-import glob
 import os
 import bpy
 import math
@@ -34,10 +33,41 @@ import bmesh
 from .entity_import import importEnt
 from .import_with_materials import *
 from .import_common import *
+from ..datakrash import DepotAssetIndex
 from bpy_extras import anim_utils
 
 VERBOSE=True
 scale_factor=1
+
+SECTOR_INDEX_EXTENSIONS = (
+    '.streamingsector.json',
+    '.ent.json',
+    '.app.json',
+    '.mesh.json',
+    '.glb',
+    '.anims.glb',
+    '.rig.json',
+    '.mi.json',
+)
+
+
+def _indexed_files(asset_index, extension):
+    return asset_index.get_files_by_extension(extension)
+
+
+def _resolve_indexed_json(asset_index, depot_path, extension):
+    if not depot_path:
+        return None
+    return asset_index.resolve_expected(f'{depot_path}.json', extension)
+
+
+def _project_sector_path(raw_root, project_name):
+    return os.path.normcase(os.path.normpath(os.path.join(raw_root, 'base', f'{project_name}.streamingsector.json')))
+
+
+def _same_path(left, right):
+    return os.path.normcase(os.path.normpath(left)) == os.path.normcase(os.path.normpath(right))
+
 
 def assign_custom_properties(obj, data, sectorName, i, **kwargs ):
     ntype=data['$type']
@@ -231,9 +261,11 @@ def importSectors( filepath, with_mats, remap_depot, want_collisions, am_modding
     #import_types=['worldEntityNode'    ]
     wkit_proj_name=os.path.basename(filepath)
     # Enter the path to your projects source\raw\base folder below, needs double slashes between folder names.
-    path = os.path.join( os.path.dirname(filepath),'source','raw')
-    print('path is ',path)
-    project=os.path.dirname(filepath)
+    raw_root = os.path.join(os.path.dirname(filepath), 'source', 'raw')
+    print('path is ', raw_root)
+    project = os.path.dirname(filepath)
+    project_name = os.path.basename(project)
+    asset_index = DepotAssetIndex.cached(raw_root, SECTOR_INDEX_EXTENSIONS)
     # If your importing to edit the sectors and want to add stuff then set the am_modding to True and it will auto create the _new collectors
     # want_collisions when True will import/generate the box and capsule collisions
 
@@ -244,25 +276,24 @@ def importSectors( filepath, with_mats, remap_depot, want_collisions, am_modding
                 for s in a.spaces:
                     if s.type == 'VIEW_3D':
                         s.clip_end = 50000
-    props = bpy.context.scene.cp77_panel_props 
-    escaped_path = glob.escape(path)    
-    jsonpath = glob.glob(os.path.join(escaped_path, "**", "*.streamingsector.json"), recursive = True)
-    mesh_jsons =  glob.glob(os.path.join(escaped_path,"**","*mesh.json"), recursive = True)
-    anim_files = glob.glob(os.path.join(escaped_path,"**","*anims.glb"), recursive = True)
-    app_path = glob.glob(os.path.join(escaped_path,"**","*.app.json"), recursive = True)
-    rigjsons = glob.glob(os.path.join(escaped_path,"**","*.rig.json"), recursive = True)
-    glbs =  glob.glob(os.path.join(escaped_path,"**","*.glb"), recursive = True)
-    path = os.path.join( os.path.dirname(filepath),'source','raw','base')
+    props = bpy.context.scene.cp77_panel_props
+    sector_jsons = _indexed_files(asset_index, '.streamingsector.json')
+    mesh_jsons = _indexed_files(asset_index, '.mesh.json')
+    anim_files = _indexed_files(asset_index, '.anims.glb')
+    app_path = _indexed_files(asset_index, '.app.json')
+    rigjsons = _indexed_files(asset_index, '.rig.json')
+    glbs = _indexed_files(asset_index, '.glb')
+    path = os.path.join(raw_root, 'base')
     meshes={}
     C = bpy.context
     I_want_to_break_free=False
     # Use object wireframe colors not theme - doesnt work need to find hte viewport as the context doesnt return that for this call
     # bpy.context.space_data.shading.wireframe_color_type = 'OBJECT'
-    for filepath in jsonpath:
-        if filepath==os.path.join(path,os.path.basename(project)+'.streamingsector.json'):
+    for filepath in sector_jsons:
+        if _same_path(filepath, os.path.join(path, project_name + '.streamingsector.json')):
             continue
         if VERBOSE:
-            print(os.path.join(path,os.path.basename(project)+'.streamingsector.json'))
+            print(os.path.join(path,project_name + '.streamingsector.json'))
         t, nodes = JSONTool.jsonload(filepath)
         sectorName=os.path.basename(filepath)[:-5]
         #print(len(nodes))
@@ -385,7 +416,7 @@ def importSectors( filepath, with_mats, remap_depot, want_collisions, am_modding
     from_mesh_no=0
     to_mesh_no=100000
 
-    meshes_from_mesheswapps( meshes_w_apps,path, from_mesh_no=from_mesh_no, to_mesh_no=to_mesh_no, with_mats=with_mats, glbs=glbs, mesh_jsons=mesh_jsons,Masters=Masters)
+    meshes_from_mesheswapps( meshes_w_apps,path, from_mesh_no=from_mesh_no, to_mesh_no=to_mesh_no, with_mats=with_mats, glbs=glbs, mesh_jsons=mesh_jsons,Masters=Masters, asset_index=asset_index)
 
     empty=[]
     for child in Masters.children:
@@ -399,10 +430,10 @@ def importSectors( filepath, with_mats, remap_depot, want_collisions, am_modding
     inst_scale =Vector((1,1,1))
     inst_m=Matrix.LocRotScale(inst_pos,inst_rot,inst_scale)
     roads=[]
-    no_sectors=len(jsonpath)
-    for fpn,filepath in enumerate(jsonpath):
-        projectjson=os.path.join(path,os.path.basename(project)+'.streamingsector.json')
-        if filepath==projectjson:
+    no_sectors=len(sector_jsons)
+    for fpn,filepath in enumerate(sector_jsons):
+        projectjson=os.path.join(path,project_name + '.streamingsector.json')
+        if _same_path(filepath, projectjson):
             continue
 
         if 'sim_' in filepath:
@@ -467,7 +498,11 @@ def importSectors( filepath, with_mats, remap_depot, want_collisions, am_modding
                         #print('worldEntityNode',i)
                         
                         app=data['appearanceName']["$value"]
-                        entpath=os.path.join(path,data['entityTemplate']['DepotPath']['$value']).replace('\\', os.sep)+'.json'
+                        ent_depot = data['entityTemplate']['DepotPath']['$value']
+                        entpath = _resolve_indexed_json(asset_index, ent_depot, '.ent.json')
+                        if not entpath:
+                            print(f"Entity template not indexed: {ent_depot}")
+                            continue
                         ent_groupname=os.path.basename(entpath).split('.')[0]+'_'+app
                         if 'door' in ent_groupname:
                             print('Door entity found, pausing')
@@ -481,7 +516,7 @@ def importSectors( filepath, with_mats, remap_depot, want_collisions, am_modding
                             try:
                                 #print('Importing ',entpath, ' using app ',app)
                                 incoll='MasterInstances'
-                                importEnt(with_mats, filepath=entpath, appearances=[app], inColl=incoll,meshes=glbs,mesh_jsons=mesh_jsons, escaped_path=escaped_path, app_path=app_path, anim_files=anim_files, rigjsons=rigjsons)
+                                importEnt(with_mats, filepath=entpath, appearances=[app], inColl=incoll,meshes=glbs,mesh_jsons=mesh_jsons, app_path=app_path, anim_files=anim_files, rigjsons=rigjsons)
                                 move_coll=Masters.children.get(ent_groupname)
                                 imported=True
                             except:
@@ -787,22 +822,17 @@ def importSectors( filepath, with_mats, remap_depot, want_collisions, am_modding
                             o.rotation_mode = "QUATERNION"
                             o.rotation_quaternion = get_rot(inst)
                             o.scale = get_scale(inst)
-                            
-                            h_flip = bool(data.get('horizontalFlip', False))
-                            v_flip = bool(data.get('verticalFlip', False))
-
-                            if h_flip:
-                                o.scale.x = -abs(o.scale.x)
-                            if v_flip:
-                                o.scale.y = -abs(o.scale.y)
 
                             #o.empty_display_size = 0.002
                             #o.empty_display_type = 'IMAGE'
                             if with_mats:
                                 mipath = o['decal']
-                                jsonpath = os.path.join(path,mipath)+".json"
+                                expected_jsonpath = os.path.join(path, mipath) + ".json"
+                                jsonpath = _resolve_indexed_json(asset_index, mipath, '.mi.json')
                                 #print(jsonpath)
                                 try:
+                                    if not jsonpath:
+                                        raise FileNotFoundError(expected_jsonpath)
                                     obj=JSONTool.jsonload(jsonpath)
                                     if obj:
                                         index = 0
@@ -822,8 +852,9 @@ def importSectors( filepath, with_mats, remap_depot, want_collisions, am_modding
                                             o.show_wire = True
                                             o.display.show_shadows = False
                                 except FileNotFoundError:
-                                    name = os.path.basename(jsonpath)
-                                    print(f'File not found {name} ({jsonpath}), you need to export .mi files')
+                                    missing_path = jsonpath or expected_jsonpath
+                                    name = os.path.basename(missing_path)
+                                    print(f'File not found {name} ({missing_path}), you need to export .mi files')
                                     o.display_type = 'WIRE'
                                     o.color = (1.0, 0.905, .062, 1)
                                     o.show_wire = True

--- a/i_scene_cp77_gltf/importers/sector_import.py
+++ b/i_scene_cp77_gltf/importers/sector_import.py
@@ -22,6 +22,7 @@ import math
 import traceback
 from mathutils import Vector, Matrix , Quaternion
 from pathlib import Path
+from collections import defaultdict
 import time
 import traceback
 from pprint import pprint
@@ -41,6 +42,7 @@ scale_factor=1
 
 SECTOR_INDEX_EXTENSIONS = (
     '.streamingsector.json',
+    '.streamingsector_inplace.json',
     '.ent.json',
     '.app.json',
     '.mesh.json',
@@ -48,6 +50,7 @@ SECTOR_INDEX_EXTENSIONS = (
     '.anims.glb',
     '.rig.json',
     '.mi.json',
+    '.cfoliage.json',
 )
 
 
@@ -67,6 +70,114 @@ def _project_sector_path(raw_root, project_name):
 
 def _same_path(left, right):
     return os.path.normcase(os.path.normpath(left)) == os.path.normcase(os.path.normpath(right))
+
+
+def _trim_name(name, max_len=63):
+    return name[:max_len]
+
+
+def _node_instances(node_data):
+    instances = defaultdict(list)
+    for index, item in enumerate(node_data or []):
+        item['nodeDataIndex'] = index
+        instances[item.get('NodeIndex')].append(item)
+    return instances
+
+
+def _node_handle_lookup(nodes):
+    return {node.get('HandleId'): node for node in nodes or [] if isinstance(node, dict)}
+
+
+def _load_sector_entry(filepath):
+    node_data, nodes = JSONTool.jsonload(filepath)
+    return {
+        'filepath': filepath,
+        'sectorName': os.path.basename(filepath)[:-5],
+        'nodeData': node_data,
+        'nodes': nodes,
+        'instances_by_node': _node_instances(node_data),
+        'nodes_by_handle': _node_handle_lookup(nodes),
+    }
+
+
+def _sector_entries(sector_jsons, base_path, project_name):
+    project_sector = os.path.join(base_path, project_name + '.streamingsector.json')
+    entries = []
+    for sector_path in sorted(sector_jsons):
+        if _same_path(sector_path, project_sector) or 'sim_' in sector_path:
+            continue
+        entries.append(_load_sector_entry(sector_path))
+    return entries
+
+
+def _first_instance(instances_by_node, node_index):
+    instances = instances_by_node.get(node_index)
+    return instances[0] if instances else None
+
+
+def _instance_matrix(inst, scale=1):
+    pos = Vector(get_pos(inst))
+    rot = Quaternion(get_rot(inst))
+    scl = Vector((1 / scale, 1 / scale, 1 / scale))
+    return Matrix.LocRotScale(pos, rot, scl)
+
+
+def _set_collection_props(collection, data, sector_name, node_index, inst=None, **kwargs):
+    if inst is None:
+        assign_custom_properties(collection, data, sector_name, node_index, **kwargs)
+    else:
+        assign_custom_properties(collection, data, sector_name, node_index, ndi=inst.get('nodeDataIndex'), pivot=inst.get('Pivot'), **kwargs)
+
+
+def _copy_object(old_obj, color=None, hide_armature=True):
+    obj = old_obj.copy()
+    if color is not None:
+        obj.color = color
+    if hide_armature and 'Armature' in obj.name:
+        obj.hide_viewport = True
+        obj.hide_render = True
+    return obj
+
+
+def _copy_collection_tree(src_collection, name, transform=None, color=None, hide_armatures=True):
+    dst_root = bpy.data.collections.new(_trim_name(name))
+    copy_map = {}
+
+    def copy_into(src, dst):
+        for child in src.children:
+            child_dst = bpy.data.collections.new(child.name)
+            dst.children.link(child_dst)
+            copy_into(child, child_dst)
+        for old_obj in src.objects:
+            obj = _copy_object(old_obj, color=color, hide_armature=hide_armatures)
+            copy_map[old_obj] = obj
+            dst.objects.link(obj)
+
+    copy_into(src_collection, dst_root)
+
+    for old_obj, obj in copy_map.items():
+        if old_obj.parent in copy_map:
+            obj.parent = copy_map[old_obj.parent]
+            obj.matrix_parent_inverse = old_obj.matrix_parent_inverse.copy()
+            obj.matrix_local = old_obj.matrix_local.copy()
+
+    if transform is not None:
+        for old_obj, obj in copy_map.items():
+            if old_obj.parent not in copy_map:
+                obj.matrix_world = transform @ old_obj.matrix_world
+
+    return dst_root
+
+
+def _shared_transform_buffer(data, nodes_by_handle, node, buffer_key):
+    buffer_data = data[buffer_key]['sharedDataBuffer']
+    if 'Data' in buffer_data:
+        return buffer_data['Data']['buffer']['Data']['Transforms']
+    if 'HandleRefId' in buffer_data:
+        buffer_id = int(buffer_data['HandleRefId'])
+        ref = nodes_by_handle.get(str(buffer_id - 1), node)
+        return ref['Data'][buffer_key]['sharedDataBuffer']['Data']['buffer']['Data']['Transforms']
+    return []
 
 
 def assign_custom_properties(obj, data, sectorName, i, **kwargs ):
@@ -287,15 +398,15 @@ def importSectors( filepath, with_mats, remap_depot, want_collisions, am_modding
     meshes={}
     C = bpy.context
     I_want_to_break_free=False
+    sector_entries = _sector_entries(sector_jsons, path, project_name)
     # Use object wireframe colors not theme - doesnt work need to find hte viewport as the context doesnt return that for this call
     # bpy.context.space_data.shading.wireframe_color_type = 'OBJECT'
-    for filepath in sector_jsons:
-        if _same_path(filepath, os.path.join(path, project_name + '.streamingsector.json')):
-            continue
+    for sector_entry in sector_entries:
+        filepath = sector_entry['filepath']
+        nodes = sector_entry['nodes']
+        sectorName = sector_entry['sectorName']
         if VERBOSE:
-            print(os.path.join(path,project_name + '.streamingsector.json'))
-        t, nodes = JSONTool.jsonload(filepath)
-        sectorName=os.path.basename(filepath)[:-5]
+            print(os.path.join(path, project_name + '.streamingsector.json'))
         #print(len(nodes))
         #nodes=[]
 
@@ -430,24 +541,20 @@ def importSectors( filepath, with_mats, remap_depot, want_collisions, am_modding
     inst_scale =Vector((1,1,1))
     inst_m=Matrix.LocRotScale(inst_pos,inst_rot,inst_scale)
     roads=[]
-    no_sectors=len(sector_jsons)
-    for fpn,filepath in enumerate(sector_jsons):
+    no_sectors=len(sector_entries)
+    for fpn, sector_entry in enumerate(sector_entries):
+        filepath = sector_entry['filepath']
+        t = sector_entry['nodeData']
+        nodes = sector_entry['nodes']
+        instances_by_node = sector_entry['instances_by_node']
+        nodes_by_handle = sector_entry['nodes_by_handle']
         projectjson=os.path.join(path,project_name + '.streamingsector.json')
-        if _same_path(filepath, projectjson):
-            continue
-
-        if 'sim_' in filepath:
-            continue
         if VERBOSE:
             print(projectjson)
             print(filepath)
-        # add nodeDataIndex props to all the nodes in t
-        t, nodes = JSONTool.jsonload(filepath)
-        for index, obj in enumerate(t):
-            obj['nodeDataIndex']=index
 
         numExpectedNodes = len(t)
-        sectorName=os.path.basename(filepath)[:-5]
+        sectorName=sector_entry['sectorName']
 
         if sectorName in coll_scene.children.keys():
             Sector_coll=bpy.data.collections.get(sectorName)
@@ -478,7 +585,7 @@ def importSectors( filepath, with_mats, remap_depot, want_collisions, am_modding
             if  (limittypes and ntype in import_types) or limittypes==False: #or type=='worldCableMeshNode': # can add a filter for dev here
                 match ntype:
                     case 'worldAISpotNode':
-                        instances = [x for x in t if x['NodeIndex'] == i]
+                        instances = instances_by_node.get(i, [])
 
                         print('worldAISpotNode',i)
                         if instances:
@@ -523,7 +630,7 @@ def importSectors( filepath, with_mats, remap_depot, want_collisions, am_modding
                                 print(traceback.format_exc())
                                 print(f"Failed during Entity import on {entpath} from app {app}")
                         if imported:
-                            instances = [x for x in t if x['NodeIndex'] == i]
+                            instances = instances_by_node.get(i, [])
                             for idx,inst in enumerate(instances):
                                 #print(inst)
                                 group=move_coll
@@ -532,50 +639,22 @@ def importSectors( filepath, with_mats, remap_depot, want_collisions, am_modding
                                     move_coll['meshpath']='fake'
                                     move_coll['appearance']='fake'
                                     #print('Group found for ',groupname)
-                                    new=bpy.data.collections.new(groupname)
-                                    Sector_coll.children.link(new)
-                                    assign_custom_properties(new, data,sectorName,i,ndi=inst['nodeDataIndex'],idx=idx,HandleId=e['HandleId'],pivot=inst['Pivot'])                                    
                                     pos = Vector(get_pos(inst))
-                                    rot=[0,0,0,0]
-                                    scale =Vector((1/scale_factor,1/scale_factor,1/scale_factor))
-                                    rot =Quaternion(get_rot(inst))
+                                    rot = Quaternion(get_rot(inst))
+                                    scale = Vector((1/scale_factor, 1/scale_factor, 1/scale_factor))
+                                    inst_trans_mat = Matrix.LocRotScale(pos, rot, scale)
+                                    new = _copy_collection_tree(group, groupname, inst_trans_mat, color=(0.567942, 0.0247339, 0.600028, 1), hide_armatures=True)
+                                    assign_custom_properties(new, data,sectorName,i,ndi=inst['nodeDataIndex'],idx=idx,HandleId=e['HandleId'],pivot=inst['Pivot'])
                                     new['ent_rot']=rot.to_euler('XYZ')
                                     new['ent_pos']=pos
-                                    inst_trans_mat=Matrix.LocRotScale(pos,rot,scale)
-                                    #print('Entity transform matrix:', inst_trans_mat)
-                                    for child in group.children:
-                                        newchild=bpy.data.collections.new(child.name)
-                                        new.children.link(newchild)
-                                        for old_obj in child.objects:
-                                            obj=old_obj.copy()
-                                            obj.color = (0.567942, 0.0247339, 0.600028, 1)
-                                            newchild.objects.link(obj)
-                                            #print(obj.name, 'applying transform')
-                                            #print("Before:", obj.matrix_local)
-                                            if obj.parent:
-                                                # Apply in local space relative to parent
-                                                obj.matrix_local = inst_trans_mat @ obj.matrix_local
-                                            else:
-                                                # No parent, apply in world space
-                                                obj.matrix_world = inst_trans_mat @ obj.matrix_world
-                                            #print("After:", obj.matrix_local)
-                                            if 'Armature' in obj.name:
-                                                obj.hide_set(True)
-                                        bpy.context.view_layer.update()
-                                    for old_obj in group.objects:
-                                        obj=old_obj.copy()
-                                        obj.color = (0.567942, 0.0247339, 0.600028, 1)
-                                        new.objects.link(obj)
-                                        obj.matrix_local=  inst_trans_mat @ obj.matrix_local
-                                        if 'Armature' in obj.name:
-                                            obj.hide_set(True)
-                                    if len(group.all_objects)>0:
-                                        new['matrix']=group.all_objects[0].matrix_world
+                                    if len(new.all_objects)>0:
+                                        new['matrix']=new.all_objects[0].matrix_world
+                                    Sector_coll.children.link(new)
 
                     case 'worldBendedMeshNode' | 'worldCableMeshNode' :
                         #print(ntype)
                         meshname = data['mesh']['DepotPath']['$value'].replace('\\', os.sep)
-                        instances = [x for x in t if x['NodeIndex'] == i]
+                        instances = instances_by_node.get(i, [])
                         #if len(instances)>1:
                         #    print('Multiple Instances of node ',i)
 
@@ -669,7 +748,7 @@ def importSectors( filepath, with_mats, remap_depot, want_collisions, am_modding
 
                     case 'worldInstancedMeshNode' :
                         #print('worldInstancedMeshNode')
-                        instances = [x for x in t if x['NodeIndex'] == i]
+                        instances = instances_by_node.get(i, [])
                         for idx,inst in enumerate(instances):
                             meshname = data['mesh']['DepotPath']['$value'].replace('\\', os.sep)
                             num=data['worldTransformsBuffer']['numElements']
@@ -706,10 +785,7 @@ def importSectors( filepath, with_mats, remap_depot, want_collisions, am_modding
                                             elif 'HandleRefId' in data['worldTransformsBuffer']['sharedDataBuffer'].keys():
                                                 bufferID = int(data['worldTransformsBuffer']['sharedDataBuffer']['HandleRefId'])
                                                 new['bufferID']=bufferID
-                                                ref=e
-                                                for n in nodes:
-                                                    if n['HandleId']==str(bufferID-1):
-                                                        ref=n
+                                                ref = nodes_by_handle.get(str(bufferID - 1), e)
                                                 inst_trans = ref['Data']['worldTransformsBuffer']['sharedDataBuffer']['Data']['buffer']['Data']['Transforms'][El_idx]
                                             else :
                                                 print(e)
@@ -727,12 +803,13 @@ def importSectors( filepath, with_mats, remap_depot, want_collisions, am_modding
 
                     case 'worldFoliageNode' :
                         #print('worldFoliageNode')
-                        instances = [x for x in t if x['NodeIndex'] == i]
+                        instances = instances_by_node.get(i, [])
                         for idx,inst in enumerate(instances):
                             meshname = data['mesh']['DepotPath']['$value'].replace('\\', os.sep)
-                            foliageResource=data['foliageResource']['DepotPath']['$value'].replace('\\', os.sep)+'.json'
-                            if os.path.exists(os.path.join(path,foliageResource)):
-                                frjson=JSONTool.jsonload(os.path.join(path,foliageResource))
+                            foliageResource=data['foliageResource']['DepotPath']['$value'].replace('\\', os.sep)
+                            foliage_json = _resolve_indexed_json(asset_index, foliageResource, '.cfoliage.json')
+                            if foliage_json:
+                                frjson=JSONTool.jsonload(foliage_json)
                                 inst_pos=get_pos(inst)
                                 Bucketnum=data['populationSpanInfo']['cketCount']
                                 Bucketstart=data['populationSpanInfo']['cketBegin']
@@ -799,7 +876,7 @@ def importSectors( filepath, with_mats, remap_depot, want_collisions, am_modding
                     case 'worldStaticDecalNode':
                         #print('worldStaticDecalNode')
                         # decals are imported as planes tagged with the material details so you can see what they are and move them.
-                        instances = [x for x in t if x['NodeIndex'] == i]
+                        instances = instances_by_node.get(i, [])
                         for idx,inst in enumerate(instances):
                             #print( inst)
                             #o = bpy.data.objects.new( "empty", None )
@@ -867,7 +944,7 @@ def importSectors( filepath, with_mats, remap_depot, want_collisions, am_modding
 
                     case 'worldSplineNode':
                         #print('worldSplineNode',i)
-                        instances = [x for x in t if x['NodeIndex'] == i]
+                        instances = instances_by_node.get(i, [])
                         if len(instances)>0:
                             spline_node=e
                             spline_ndata=instances[0]
@@ -895,9 +972,9 @@ def importSectors( filepath, with_mats, remap_depot, want_collisions, am_modding
                     case 'worldRoadProxyMeshNode' :
                         if isinstance(e, dict) and 'mesh' in data.keys():
                             meshname = data['mesh']['DepotPath']['$value'].replace('\\', os.sep)
-                            #meshpath=os.path.join(path, meshname[:-4]+'glb')
-                            meshpath=os.path.join(path, meshname[:-1*len(os.path.splitext(meshname)[1])]+'.glb').replace('\\', os.sep)
-                            print(os.path.exists(meshpath))
+                            meshpath = asset_index.resolve_expected(meshname[:-1*len(os.path.splitext(meshname)[1])] + '.glb', '.glb')
+                            if not meshpath:
+                                print(f"Road proxy mesh not indexed: {meshname}")
                             #print('Mesh path is - ',meshpath, e['HandleId'])
                             if(meshname != 0):
                                         #print('Mesh - ',meshname, ' - ',i, e['HandleId'])
@@ -917,8 +994,8 @@ def importSectors( filepath, with_mats, remap_depot, want_collisions, am_modding
 
                                         if (imported):
                                             #print('Group found for ',groupname)
-                                            instances = [x for x in t if x['NodeIndex'] == i]
-                                            for inst in instances:
+                                            instances = instances_by_node.get(i, [])
+                                            for idx, inst in enumerate(instances):
                                                 new=bpy.data.collections.new(groupname)
                                                 Sector_coll.children.link(new)
                                                 assign_custom_properties(new, data,sectorName,i,
@@ -973,18 +1050,17 @@ def importSectors( filepath, with_mats, remap_depot, want_collisions, am_modding
                                                 rot_time=data['fullRotationTime']
                                                 reverse=data['reverseDirection']
 
-                                            instances = [x for x in t if x['NodeIndex'] == i]
+                                            instances = instances_by_node.get(i, [])
                                             for idx,inst in enumerate(instances):
-                                                new=bpy.data.collections.new(groupname)
-                                                Sector_coll.children.link(new)
+                                                inst_trans_mat = _instance_matrix(inst, scale_factor)
+                                                new = _copy_collection_tree(group, groupname, inst_trans_mat, color=(0.3, 0.3, 0.3, 1), hide_armatures=True)
                                                 assign_custom_properties(new, data,sectorName,i,
                                                 nodeDataIndex=inst['nodeDataIndex'], instance_idx=idx,
                                                 mesh=meshname, pivot=inst['Pivot'],
                                                 meshAppearance=meshAppearance,
                                                 appearanceName=meshAppearance)
-                                                if ntype=='worldClothMeshNode':
-                                                    if 'windImpulseEnabled' in inst.keys():
-                                                        new['windImpulseEnabled']= inst['windImpulseEnabled']
+                                                if ntype=='worldClothMeshNode' and 'windImpulseEnabled' in inst.keys():
+                                                    new['windImpulseEnabled']= inst['windImpulseEnabled']
                                                 if ntype=='worldRotatingMeshNode':
                                                     if 'rotationAxis' in data.keys():
                                                         new['rot_axis']=data['rotationAxis']
@@ -992,26 +1068,13 @@ def importSectors( filepath, with_mats, remap_depot, want_collisions, am_modding
                                                         new['reverseDirection']=data['reverseDirection']
                                                     if 'fullRotationTime' in data.keys():
                                                         new['fullRotationTime']=data['fullRotationTime']
-
-                                                #print(new['nodeDataIndex'])
-                                                # Should do something with the Advertisements lightData  bits here
                                                 if ntype=='worldAdvertisingNode' or ntype=='worldAdvertisementNode':
                                                     if 'lightData' in data.keys():
                                                         new['lightData']=data['lightData']
-
-                                                for old_obj in group.all_objects:
-                                                    obj=old_obj.copy()
-                                                    new.objects.link(obj)
-
-                                                    obj.location = get_pos(inst)
-                                                    obj.rotation_quaternion = get_rot(inst)
-                                                    obj.scale = get_scale(inst)
-                                                    obj.color = (0.3, 0.3, 0.3, 1)
-
-                                                    if 'Armature' in obj.name:
-                                                        obj.hide_set(True)
-                                                    if ntype=='worldRotatingMeshNode':
-                                                        orig_rot= obj.rotation_quaternion
+                                                if ntype=='worldRotatingMeshNode':
+                                                    for obj in new.all_objects:
+                                                        if obj.type != 'MESH':
+                                                            continue
                                                         obj.rotation_mode='YXZ'
                                                         obj.keyframe_insert('rotation_euler', index=axis_no ,frame=1)
                                                         obj.rotation_euler[axis_no] = obj.rotation_euler[axis_no] +math.radians(360)
@@ -1023,6 +1086,7 @@ def importSectors( filepath, with_mats, remap_depot, want_collisions, am_modding
                                                             obj_fcu = channelbag.fcurves[0]
                                                             for pt in obj_fcu.keyframe_points:
                                                                 pt.interpolation = 'LINEAR'
+                                                Sector_coll.children.link(new)
 
 
 
@@ -1031,7 +1095,7 @@ def importSectors( filepath, with_mats, remap_depot, want_collisions, am_modding
 
                     case 'worldInstancedDestructibleMeshNode':
                         #print('worldInstancedDestructibleMeshNode',i)
-                        instances = [x for x in t if x['NodeIndex'] == i]
+                        instances = instances_by_node.get(i, [])
                         for instidx,inst in enumerate(instances):
                             if isinstance(e, dict) and 'mesh' in data.keys():
                                 meshname = data['mesh']['DepotPath']['$value'].replace('\\', os.sep)
@@ -1079,10 +1143,7 @@ def importSectors( filepath, with_mats, remap_depot, want_collisions, am_modding
                                                     elif 'HandleRefId' in data['cookedInstanceTransforms']['sharedDataBuffer'].keys():
                                                         bufferID = int(data['cookedInstanceTransforms']['sharedDataBuffer']['HandleRefId'])
                                                         new['bufferID']=bufferID
-                                                        ref=e
-                                                        for n in nodes:
-                                                            if n['HandleId']==str(bufferID-1):
-                                                                ref=n
+                                                        ref = nodes_by_handle.get(str(bufferID - 1), e)
                                                         inst_trans = ref['Data']['cookedInstanceTransforms']['sharedDataBuffer']['Data']['buffer']['Data']['Transforms'][idx]
 
                                                     else :
@@ -1113,14 +1174,15 @@ def importSectors( filepath, with_mats, remap_depot, want_collisions, am_modding
                                                         obj.matrix_local= tm
                                                         obj.scale=get_scale(inst)
                                                         if 'Armature' in obj.name:
-                                                            obj.hide_set(True)
+                                                            obj.hide_viewport = True
+                                                            obj.hide_render = True
                                             else:
                                                 print('Mesh not found in masters - ',meshname, ' - ',i, e['HandleId'])
 
                     case 'worldStaticLightNode':
                         #print('worldStaticLightNode',i)
                         if with_lights:
-                            instances = [x for x in t if x['NodeIndex'] == i]
+                            instances = instances_by_node.get(i, [])
                             for inst in instances:
                                 light_node=e['Data']
                                 light_name=e['Data']['debugName']['$value']
@@ -1164,7 +1226,7 @@ def importSectors( filepath, with_mats, remap_depot, want_collisions, am_modding
 
                     case 'worldStaticParticleNode'|'worldEffectNode'|'worldPopulationSpawnerNode':
                         #print('worldStaticParticleNode',i)
-                        instances = [x for x in t if x['NodeIndex'] == i]
+                        instances = instances_by_node.get(i, [])
                         for idx,inst in enumerate(instances):
                             o = bpy.data.objects.new( "empty", None )
                             o.name=ntype+'_'+e['Data']['debugName']['$value']
@@ -1196,7 +1258,7 @@ def importSectors( filepath, with_mats, remap_depot, want_collisions, am_modding
 
                     case 'worldStaticSoundEmitterNode':
                         #print(ntype)
-                        instances = [x for x in t if x['NodeIndex'] == i]
+                        instances = instances_by_node.get(i, [])
                         for idx,inst in enumerate(instances):
                             o = bpy.data.objects.new( "empty", None )
                             o.empty_display_type = 'SPHERE'
@@ -1231,7 +1293,9 @@ def importSectors( filepath, with_mats, remap_depot, want_collisions, am_modding
                             else:
                                 sector_Collisions_coll=bpy.data.collections.new(sector_Collisions)
                                 coll_scene.children.link(sector_Collisions_coll)
-                            inst = [x for x in t if x['NodeIndex'] == i][0]
+                            inst = _first_instance(instances_by_node, i)
+                            if inst is None:
+                                continue
                             Actors=e['Data']['compiledData']['Data']['Actors']
                             for idx,act in enumerate(Actors):
                                 #print(len(act['Shapes']))

--- a/i_scene_cp77_gltf/jsontool.py
+++ b/i_scene_cp77_gltf/jsontool.py
@@ -2,8 +2,10 @@ import bpy
 import json
 import os
 import re
+from dataclasses import dataclass
 from pathlib import Path
 from .main.common import show_message, load_zip
+from .main.datashards import ParsedApp, ParsedEntity, ParsedComponent
 
 
 # Error messages for different file types
@@ -21,11 +23,125 @@ MIN_WOLVENKIT_VERSION = (8, 17)
 MIN_MATERIAL_JSON_VERSION = (1, 0)
 
 
+
+def _cname_value(value, default=''):
+    if type(value) is dict:
+        return value.get('$value', default)
+    return value if value is not None else default
+
+
+def _component_name(component, default=''):
+    if type(component) is not dict:
+        return default
+    return _cname_value(component.get('name'), default)
+
+
+def _depot_path_value(component, key):
+    if type(component) is not dict:
+        return ''
+    resource = component.get(key)
+    if type(resource) is not dict:
+        return ''
+    return _cname_value(resource.get('DepotPath'))
+
+
+def _mesh_component_depot(component):
+    return _depot_path_value(component, 'mesh') or _depot_path_value(component, 'graphicsMesh')
+
+
+def _mesh_appearance_value(component):
+    if type(component) is not dict:
+        return 'default'
+    return _cname_value(component.get('meshAppearance'), 'default')
+
+
+def _is_component_enabled(component):
+    return component.get('isEnabled', 1) != 0 if type(component) is dict else True
+
+
+def _build_component_lookup(components):
+    lookup = {}
+    for component in components or ():
+        name = _component_name(component)
+        if name:
+            lookup[name] = component
+    return lookup
+
+
+def _build_app_lookup(appearances):
+    by_appearance = {}
+    by_name = {}
+    appearance_names = []
+    for index, app in enumerate(appearances or ()): 
+        if type(app) is not dict:
+            continue
+        appearance = _cname_value(app.get('appearanceName'))
+        if appearance:
+            by_appearance[appearance] = index
+            appearance_names.append(appearance)
+        name = _cname_value(app.get('name'))
+        if name:
+            by_name[name] = index
+    return appearance_names, by_appearance, by_name
+
+
+def _build_chunk_lookup(chunks, target_key, handle_key='HandleId'):
+    lookup = {}
+    for chunk in chunks or ():
+        if type(chunk) is not dict:
+            continue
+        target = chunk.get(target_key)
+        if type(target) is dict and handle_key in target:
+            lookup[target[handle_key]] = target
+    return lookup
+
+
+def _build_slot_lookup(slots):
+    lookup = {}
+    for slot in slots or ():
+        if type(slot) is not dict:
+            continue
+        name = _cname_value(slot.get('slotName'))
+        if name:
+            lookup[name] = slot
+    return lookup
+
+
+def _build_slot_component_lookups(components):
+    lookups = {}
+    for component in components or ():
+        if type(component) is not dict:
+            continue
+        name = _component_name(component)
+        slots = component.get('slots')
+        if name and type(slots) is list:
+            lookups[name] = _build_slot_lookup(slots)
+    return lookups
+
+
+def _components_by_type(components, type_name):
+    return [component for component in components or () if type(component) is dict and component.get('$type') == type_name]
+
+
+def _normalize_default_appearance(default_appearance, appearances, by_appearance, by_name):
+    if not default_appearance or default_appearance == 'None':
+        return ''
+    if default_appearance in by_appearance or default_appearance == 'random':
+        return default_appearance
+    by_name_idx = by_name.get(default_appearance, -1)
+    if by_name_idx >= 0:
+        return _cname_value(appearances[by_name_idx].get('appearanceName'), default_appearance)
+    return default_appearance
+
+
 class JSONTool:
     _json_cache = {}
+    _entity_cache = {}
+    _app_cache = {}
     _use_cache = False
 
     cachable_types = {
+        '.ent.json',
         '.anims.json',
         '.app.json',
         '.streamingblock.json',
@@ -139,6 +255,8 @@ class JSONTool:
     def stop_caching():
         JSONTool._use_cache = False
         JSONTool._json_cache.clear()
+        JSONTool._entity_cache.clear()
+        JSONTool._app_cache.clear()
 
     @staticmethod
     def create_error(suppress_verbose, base_name, file_extension, specific_error, error_Messages=None):
@@ -187,6 +305,191 @@ class JSONTool:
             data['lattice_interpolation_v'],
             data['lattice_interpolation_w'],
         )
+
+
+    @staticmethod
+    def _parsed_cache_key(filepath):
+        abs_path = os.path.abspath(filepath)
+        try:
+            stat_result = os.stat(abs_path)
+        except OSError:
+            return abs_path, 0
+
+        mtime_ns = getattr(stat_result, 'st_mtime_ns', None)
+        if mtime_ns is None:
+            mtime_ns = int(stat_result.st_mtime * 1_000_000_000)
+        return abs_path, mtime_ns
+
+    @staticmethod
+    def _load_raw_json(filepath, errorMessages=None):
+        if not os.path.isfile(filepath):
+            print(f"File does not exist: {filepath}")
+            return None
+
+        if not filepath.endswith(('.json', '.zip')):
+            raise ValueError(f"{filepath} is not a json, what are you doing?")
+
+        cp77_addon_prefs = bpy.context.preferences.addons['i_scene_cp77_gltf'].preferences
+        suppress_verbose = cp77_addon_prefs.non_verbose
+        base_name = os.path.basename(filepath)
+        file_extension = ''.join(Path(base_name).suffixes)
+        cache_key = os.path.abspath(filepath)
+        is_refitter = base_name.endswith('.refitter.zip')
+        is_cacheable = file_extension in JSONTool.cachable_types
+        is_cached = is_cacheable and JSONTool._use_cache and cache_key in JSONTool._json_cache
+
+        if is_cached:
+            data = JSONTool._json_cache[cache_key]
+        else:
+            if not suppress_verbose:
+                print(f"  Parsing json file {base_name}")
+            data = JSONTool.jsonloads(load_zip(filepath)) if is_refitter else JSONTool.load_json(filepath)
+            if data is None:
+                return None
+            if is_cacheable and JSONTool._use_cache:
+                JSONTool._json_cache[cache_key] = data
+
+        has_error = not is_cached and not is_refitter and not JSONTool.json_ver_validate(data)
+        specific_error = JSONTool.passthrough_errors.get(file_extension, invalid_json_error)
+        JSONTool._create_error_if_needed(has_error, suppress_verbose, base_name, file_extension, specific_error, errorMessages)
+        return data
+
+    @staticmethod
+    def _parsed_component(component):
+        mesh_depot = _depot_path_value(component, 'mesh')
+        graphics_mesh_depot = _depot_path_value(component, 'graphicsMesh')
+        parent_transform = component.get('parentTransform') if type(component) is dict else None
+        skinning = component.get('skinning') if type(component) is dict else None
+        return ParsedComponent(
+            raw=component,
+            type=component.get('$type', '') if type(component) is dict else '',
+            name=_component_name(component),
+            mesh_depot=mesh_depot or graphics_mesh_depot,
+            graphics_mesh_depot=graphics_mesh_depot,
+            mesh_appearance=_mesh_appearance_value(component),
+            rig_depot=_depot_path_value(component, 'rig'),
+            enabled=_is_component_enabled(component),
+            local_transform=component.get('localTransform', {}) if type(component) is dict else {},
+            visual_scale=component.get('visualScale') if type(component) is dict else None,
+            slots=component.get('slots') if type(component) is dict else None,
+            parent_transform_handle=parent_transform.get('HandleRefId') if type(parent_transform) is dict else None,
+            skinning_handle=skinning.get('HandleRefId') if type(skinning) is dict else None,
+        )
+
+    @staticmethod
+    def load_entity(filepath, errorMessages=None):
+        cache_key = JSONTool._parsed_cache_key(filepath)
+        if JSONTool._use_cache and cache_key in JSONTool._entity_cache:
+            return JSONTool._entity_cache[cache_key]
+
+        data = JSONTool._load_raw_json(filepath, errorMessages)
+        if data is None:
+            return None
+
+        root = data['Data']['RootChunk']
+        compiled_data = root.get('compiledData')
+        appearances = root.get('appearances') or []
+        components = root.get('components') or []
+        component_data = compiled_data.get('Data', {}).get('Chunks', []) if type(compiled_data) is dict else []
+        appearance_names, by_appearance, by_name = _build_app_lookup(appearances)
+        default_appearance = _normalize_default_appearance(_cname_value(root.get('defaultAppearance')), appearances, by_appearance, by_name)
+        parsed_components = [JSONTool._parsed_component(component) for component in components]
+        components_by_name = _build_component_lookup(components)
+        component_ids = {id(component) for component in components}
+        component_data_ids = {id(component) for component in component_data}
+        rig_components = {component.name: component.raw for component in parsed_components if component.rig_depot and component.name}
+        vehicle_slot_component = next((component for component in components if _component_name(component) in ('vehicle_slots', 'slots')), None)
+
+        parsed = ParsedEntity(
+            filepath=filepath,
+            name=os.path.basename(filepath)[:-9],
+            raw=data,
+            root=root,
+            appearances=appearances,
+            appearance_names=appearance_names,
+            appearance_index_by_name={name: index for index, name in enumerate(appearance_names) if name},
+            appearances_by_appearance=by_appearance,
+            appearances_by_name=by_name,
+            default_appearance=default_appearance,
+            component_dicts=components,
+            component_data=component_data,
+            parsed_components=parsed_components,
+            components_by_name=components_by_name,
+            components_by_id={id(component): component for component in components},
+            component_ids=component_ids,
+            component_data_ids=component_data_ids,
+            parent_transform_lookup=_build_chunk_lookup(component_data, 'parentTransform'),
+            skinning_lookup=_build_chunk_lookup(component_data, 'skinning'),
+            shape_lookup=_build_chunk_lookup(component_data, 'shape'),
+            slot_component_lookups=_build_slot_component_lookups(components),
+            collider_components=_components_by_type(component_data, 'entColliderComponent'),
+            simple_collider_components=_components_by_type(component_data, 'entSimpleColliderComponent'),
+            light_channel_components=_components_by_type(component_data, 'entLightChannelComponent') + _components_by_type(components, 'entLightChannelComponent'),
+            rig_components=rig_components,
+            resolved_dependencies=root.get('resolvedDependencies') or [],
+            vehicle_slot_component=vehicle_slot_component,
+        )
+
+        if JSONTool._use_cache:
+            JSONTool._entity_cache[cache_key] = parsed
+        return parsed
+
+    @staticmethod
+    def load_app(filepath, errorMessages=None):
+        cache_key = JSONTool._parsed_cache_key(filepath)
+        if JSONTool._use_cache and cache_key in JSONTool._app_cache:
+            return JSONTool._app_cache[cache_key]
+
+        data = JSONTool._load_raw_json(filepath, errorMessages)
+        if data is None:
+            return None
+
+        root = data['Data']['RootChunk']
+        appearances = root.get('appearances') or []
+        names = []
+        by_name = {}
+        components_by_name = {}
+        chunks_by_name = {}
+        parent_by_name = {}
+        skinning_by_name = {}
+        shape_by_name = {}
+        light_by_name = {}
+
+        for index, appearance in enumerate(appearances):
+            if type(appearance) is not dict:
+                continue
+            app_data = appearance.get('Data') if type(appearance.get('Data')) is dict else {}
+            name = _cname_value(app_data.get('name'), str(index))
+            names.append(name)
+            by_name[name] = index
+            components = app_data.get('components') or []
+            compiled_data = app_data.get('compiledData')
+            chunks = compiled_data.get('Data', {}).get('Chunks', []) if type(compiled_data) is dict else []
+            components_by_name[name] = components
+            chunks_by_name[name] = chunks
+            parent_by_name[name] = _build_chunk_lookup(chunks, 'parentTransform')
+            skinning_by_name[name] = _build_chunk_lookup(chunks, 'skinning')
+            shape_by_name[name] = _build_chunk_lookup(chunks, 'shape')
+            light_by_name[name] = _components_by_type(chunks, 'entLightChannelComponent') + _components_by_type(components, 'entLightChannelComponent')
+
+        parsed = ParsedApp(
+            filepath=filepath,
+            raw=data,
+            root=root,
+            appearances=appearances,
+            appearance_names=names,
+            appearances_by_name=by_name,
+            components_by_appearance_name=components_by_name,
+            chunks_by_appearance_name=chunks_by_name,
+            parent_transform_lookup_by_appearance_name=parent_by_name,
+            skinning_lookup_by_appearance_name=skinning_by_name,
+            shape_lookup_by_appearance_name=shape_by_name,
+            light_channels_by_appearance_name=light_by_name,
+        )
+
+        if JSONTool._use_cache:
+            JSONTool._app_cache[cache_key] = parsed
+        return parsed
 
     @staticmethod
     def jsonload(filepath, errorMessages=None):

--- a/i_scene_cp77_gltf/main/datashards.py
+++ b/i_scene_cp77_gltf/main/datashards.py
@@ -16,49 +16,69 @@ class MeshReference:
     material_overrides: List[MaterialOverride] = field(default_factory=list)
 
 
-@dataclass
-class AppearanceComponent:
-    name: str
+@dataclass(slots=True)
+class ParsedComponent:
+    raw: dict
     type: str
-    mesh: Optional[MeshReference] = None
-    transform: Optional[Dict[str, List[float]]] = None  # {'position': [...], 'orientation': [...], 'scale': [...]}
-    parent_transform_ref_id: Optional[int] = None
-    parent_transform_data: Optional[Dict] = None
-    extra_data: Dict = field(default_factory=dict)
-
-
-@dataclass
-class AppearanceData:
     name: str
-    components: List[AppearanceComponent]
+    mesh_depot: str
+    graphics_mesh_depot: str
+    mesh_appearance: str
+    rig_depot: str
+    enabled: bool
+    local_transform: dict
+    visual_scale: dict | None
+    slots: list | None
+    parent_transform_handle: object
+    skinning_handle: object
 
 
-@dataclass
-class EntityComponent:
+@dataclass(slots=True)
+class ParsedEntity:
+    filepath: str
     name: str
-    type: str
-    mesh_path: Optional[str] = None
-    graphics_mesh_path: Optional[str] = None
-    mesh_appearance: Optional[str] = None
-    transform: Optional[Dict[str, List[float]]] = None
-    parent_transform_ref_id: Optional[int] = None
-    parent_transform_data: Optional[Dict] = None
-    extra_data: Dict = field(default_factory=dict)
+    raw: dict
+    root: dict
+    appearances: list
+    appearance_names: list
+    appearance_index_by_name: dict
+    appearances_by_appearance: dict
+    appearances_by_name: dict
+    default_appearance: str
+    component_dicts: list
+    component_data: list
+    parsed_components: list
+    components_by_name: dict
+    components_by_id: dict
+    component_ids: set
+    component_data_ids: set
+    parent_transform_lookup: dict
+    skinning_lookup: dict
+    shape_lookup: dict
+    slot_component_lookups: dict
+    collider_components: list
+    simple_collider_components: list
+    light_channel_components: list
+    rig_components: dict
+    resolved_dependencies: list
+    vehicle_slot_component: dict | None
 
 
-@dataclass
-class ResolvedDependency:
-    path: str
-
-
-@dataclass
-class EntityData:
-    name: str
-    default_appearance: Optional[str]
-    global_components: List[EntityComponent] = field(default_factory=list)
-    appearances: List[AppearanceData] = field(default_factory=list)
-    resolved_dependencies: List[ResolvedDependency] = field(default_factory=list)
-
+@dataclass(slots=True)
+class ParsedApp:
+    filepath: str
+    raw: dict
+    root: dict
+    appearances: list
+    appearance_names: list
+    appearances_by_name: dict
+    components_by_appearance_name: dict
+    chunks_by_appearance_name: dict
+    parent_transform_lookup_by_appearance_name: dict
+    skinning_lookup_by_appearance_name: dict
+    shape_lookup_by_appearance_name: dict
+    light_channels_by_appearance_name: dict
+    
 @dataclass(slots=True)
 class BoneTransformCache:
     location: mathutils.Vector

--- a/i_scene_cp77_gltf/material_types/multilayered.py
+++ b/i_scene_cp77_gltf/material_types/multilayered.py
@@ -1,16 +1,125 @@
 import bpy
 import os
+import hashlib
 from ..main.common import *
 from ..jsontool import JSONTool
+from ..datakrash import DepotAssetIndex
 import numpy as np
 
 def np_array_from_image(img_name):
     img = bpy.data.images[img_name]
-    return np.array(img.pixels[:])
+    # foreach_get reads the pixel buffer directly instead of boxing every
+    # component into a Python float via pixels[:] first; cast back to
+    # float64 so the returned dtype/values match np.array(img.pixels[:]) exactly.
+    pixels = np.empty(len(img.pixels), dtype=np.float32)
+    img.pixels.foreach_get(pixels)
+    return pixels.astype(np.float64)
+
+
+def get_cased(data, key, default=None):
+    if type(data) is not dict:
+        return default
+    lower_key = key[:1].lower() + key[1:]
+    value = data.get(lower_key)
+    if value is not None:
+        return value
+    upper_key = key[:1].upper() + key[1:]
+    value = data.get(upper_key)
+    return default if value is None else value
+
+
+def get_cased_value(data, key, default=None):
+    value = get_cased(data, key)
+    if type(value) is dict:
+        resolved = value.get('$value')
+        return default if resolved is None else resolved
+    return default if value is None else value
+
+
+def get_cased_depot_path(data, key, default=None):
+    value = get_cased(data, key)
+    if type(value) is not dict:
+        return default if value is None else value
+    depot = value.get('DepotPath')
+    if type(depot) is dict:
+        resolved = depot.get('$value')
+        return default if resolved is None else resolved
+    if depot is not None:
+        return depot
+    resolved = value.get('$value')
+    return default if resolved is None else resolved
+
+
+def input_socket(inputs, socket_name):
+    try:
+        return inputs[socket_name]
+    except Exception:
+        return None
+
+
+def normalize_socket_default(socket, value):
+    current = getattr(socket, 'default_value', None)
+    if isinstance(value, (list, tuple)) and hasattr(current, '__len__'):
+        target_len = len(current)
+        value_len = len(value)
+        if value_len == target_len:
+            return value
+        if value_len < target_len:
+            return tuple(value) + tuple(0 for _ in range(target_len - value_len))
+        return tuple(value[:target_len])
+    return value
+
+
+def set_socket_default(inputs, socket_name, value):
+    socket = input_socket(inputs, socket_name)
+    if socket is not None:
+        socket.default_value = normalize_socket_default(socket, value)
+
+
+def set_socket_range(inputs, socket_name, minimum=None, maximum=None):
+    socket = input_socket(inputs, socket_name)
+    if socket is None:
+        return
+    if minimum is not None:
+        socket.min_value = minimum
+    if maximum is not None:
+        socket.max_value = maximum
+
+
+def set_socket_dimensions(inputs, socket_name, dimensions):
+    socket = input_socket(inputs, socket_name)
+    if socket is not None:
+        socket.dimensions = dimensions
+
+
+def float_or_default(value, default):
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def apply_override(inputs, socket_name, key_val, override_dict, default_val):
+    if key_val is not None and key_val in override_dict:
+        set_socket_default(inputs, socket_name, override_dict[key_val])
+        return True
+    set_socket_default(inputs, socket_name, default_val)
+    return False
+
+
+def safe_layer_group_name(prefix, version_major, material_path, microblend_path):
+    source = f'{version_major}|{material_path}|{microblend_path}'
+    digest = hashlib.blake2s(source.encode('utf-8', 'ignore'), digest_size=8).hexdigest()
+    return f'{prefix}_LayerTemplate_{version_major}_{digest}'
 
 def mask_mixer_node_group(Mat):
-    if "Mask Mixer 1.6.7" in bpy.data.node_groups:
-        return bpy.data.node_groups["Mask Mixer 1.6.7"]
+    # .get() avoids the redundant second scan of bpy.data.node_groups that
+    # an `in` check followed by `[]` lookup would otherwise perform.
+    existing = bpy.data.node_groups.get("Mask Mixer 1.6.7")
+    if existing:
+        return existing
     mask_mixer = bpy.data.node_groups.new(type = 'ShaderNodeTree', name = "Mask Mixer 1.6.7")
     mask_mixer['AddonVersion'] = Mat.get('AddonVersion')
 
@@ -116,8 +225,9 @@ def mask_mixer_node_group(Mat):
     return mask_mixer
 
 def levels_node_group(Mat):
-    if "Levels 2077 1.6.7" in bpy.data.node_groups:
-        return bpy.data.node_groups["Levels 2077 1.6.7"]
+    existing = bpy.data.node_groups.get("Levels 2077 1.6.7")
+    if existing:
+        return existing
     levels = bpy.data.node_groups.new(type = 'ShaderNodeTree', name = "Levels 2077 1.6.7")
     # Write addonversion from material where group is created
     levels['AddonVersion'] = Mat.get('AddonVersion')
@@ -151,8 +261,9 @@ def levels_node_group(Mat):
     return levels
 
 def _getOrCreateLayerBlend(Mat):
-    if "Layer Blend 1.6.7" in bpy.data.node_groups:
-        return bpy.data.node_groups["Layer Blend 1.6.7"]
+    existing = bpy.data.node_groups.get("Layer Blend 1.6.7")
+    if existing:
+        return existing
 
     NG = bpy.data.node_groups.new("Layer Blend 1.6.7","ShaderNodeTree")#create layer's node group
     # Write addonversion from material where group is created
@@ -241,8 +352,9 @@ def _getOrCreateLayerBlend(Mat):
 
 def _getOrCreateLayerBlend5(Mat):
     ng_name = "Layer Blend 1.8.0"
-    if ng_name in bpy.data.node_groups:
-        return bpy.data.node_groups[ng_name]
+    existing = bpy.data.node_groups.get(ng_name)
+    if existing:
+        return existing
 
     NG = bpy.data.node_groups.new(ng_name,"ShaderNodeTree")
     # Write addonversion from material where group is created
@@ -301,9 +413,6 @@ def _getOrCreateLayerBlend5(Mat):
     NG.links.new(GroupInN.outputs['Bundle A'],GroupSeparateBundle1.inputs[0])
     NG.links.new(GroupInN.outputs['Bundle B'],GroupSeparateBundle2.inputs[0])
 
-    # Is this necessary?
-    GroupSeparateBundle1.update()
-
     NG.links.new(GroupSeparateBundle1.outputs[0],ColorMixN.inputs[6])
     NG.links.new(GroupSeparateBundle1.outputs[1],MetalMixN.inputs[2])
     NG.links.new(GroupSeparateBundle1.outputs[2],RoughMixN.inputs[2])
@@ -333,8 +442,9 @@ def _getOrCreateLayerBlend5(Mat):
 # JATO: This function wraps a pbsdf node inside a nodegroup with bundle sockets for blender 5+
 def ml_pbsdf_node_group(Mat):
     ng_name = "Multilayered 1.8.0"
-    if ng_name in bpy.data.node_groups:
-        return bpy.data.node_groups[ng_name]
+    existing = bpy.data.node_groups.get(ng_name)
+    if existing:
+        return existing
     ml_bsdf = bpy.data.node_groups.new(type = 'ShaderNodeTree', name = ng_name)
     # Write addonversion from material where group is created
     ml_bsdf['AddonVersion'] = Mat.get('AddonVersion')
@@ -434,6 +544,7 @@ class Multilayered:
         self.BasePath = str(BasePath)
         self.image_format = image_format
         self.ProjPath = str(ProjPath)
+        self._asset_index_cache = {}
 
 
     def createMLTemplateGroup(self,matTemplateObj,mltemplate):
@@ -554,592 +665,465 @@ class Multilayered:
         NG.links.new(combineOffUV.outputs[0],MapN.inputs[1])
         NG.links.new(ColorRampOut.outputs[0],colorScaleMix.inputs[0])
 
-        return
+        # Returning NG lets callers use the freshly built group directly
+        # instead of re-scanning bpy.data.node_groups for it right after creation.
+        return NG
 
 
-    def setupMaterial(self,LayerName,LayerCount,CurMat,mlmaskpath,normalimgpath):
-        vers=bpy.app.version
-        if vers[0]<5.0:
+
+    def _asset_index(self, root, extension):
+        if not root:
+            return None
+        root = os.path.abspath(os.path.normpath(root))
+        cache_key = (root, extension)
+        cached = self._asset_index_cache.get(cache_key)
+        if cached is not None:
+            return cached
+        cached = DepotAssetIndex.cached(root, (extension,), warn_missing=False)
+        self._asset_index_cache[cache_key] = cached
+        return cached
+
+    def _indexed_asset_path(self, root, filepath):
+        if not filepath:
+            return None
+        extension = os.path.splitext(filepath)[1].lower()
+        if not extension:
+            return None
+        index = self._asset_index(root, extension)
+        return index.resolve_expected(filepath, extension, warn=False) if index is not None else None
+
+    def _resolve_mask_layer_path(self, mlmaskpath, layer_index):
+        mask_stem = os.path.split(mlmaskpath)[-1:][0][:-7]
+        mask_filename = f'{mask_stem}_{layer_index}.png'
+        for root in (self.ProjPath, self.BasePath):
+            mask_dir = os.path.splitext(os.path.join(root, mlmaskpath))[0] + '_layers'
+            resolved = self._indexed_asset_path(root, os.path.join(mask_dir, mask_filename))
+            if resolved:
+                return resolved
+        return None
+
+    def _configure_layer_tree_sockets(self, inputs, is_legacy_nodes, layer_index):
+        if is_legacy_nodes:
+            set_socket_range(inputs, 'NormalStrength', 0, 10)
+            set_socket_dimensions(inputs, 'MetalLevelsIn', 2)
+            set_socket_dimensions(inputs, 'MetalLevelsOut', 2)
+            set_socket_dimensions(inputs, 'RoughLevelsIn', 2)
+            set_socket_dimensions(inputs, 'RoughLevelsOut', 2)
+            set_socket_range(inputs, 'MicroblendContrast', 0, 1)
+            set_socket_range(inputs, 'Opacity', 0, 1)
+        else:
+            set_socket_range(inputs, 'NormalStrength', 0, 10)
+            set_socket_dimensions(inputs, 'MetalLevelsIn', 2)
+            set_socket_dimensions(inputs, 'MetalLevelsOut', 2)
+            set_socket_dimensions(inputs, 'RoughLevelsIn', 2)
+            set_socket_dimensions(inputs, 'RoughLevelsOut', 2)
+            set_socket_range(inputs, 'MicroblendContrast', 0, 1)
+            set_socket_range(inputs, 'Opacity', 0, 1)
+
+    def _configure_layer_group_inputs(self, layer_node, layer_index, values, override_table):
+        inputs = layer_node.inputs
+        set_socket_default(inputs, 'Mask', 1 if layer_index == 0 else 0)
+        if apply_override(inputs, 'ColorScale', values['colorScale'], override_table['ColorScale'], (1.0, 1.0, 1.0, 1)):
+            layer_node['colorScale'] = values['colorScale']
+        set_socket_default(inputs, 'MatTile', float_or_default(values['MatTile'], 1))
+        set_socket_default(inputs, 'OffsetU', float_or_default(values['OffsetU'], 0))
+        set_socket_default(inputs, 'OffsetV', float_or_default(values['OffsetV'], 0))
+        apply_override(inputs, 'NormalStrength', values['normalStrength'], override_table['NormalStrength'], 1)
+        set_socket_default(inputs, 'MicroblendNormalStrength', float_or_default(values['microblendNormalStrength'], 1))
+        set_socket_default(inputs, 'MicroblendContrast', float_or_default(values['MicroblendContrast'], 1))
+        set_socket_default(inputs, 'MbTile', float_or_default(values['MbScale'], 1))
+        set_socket_default(inputs, 'MicroblendOffsetU', float_or_default(values['MicroblendOffsetU'], 0))
+        set_socket_default(inputs, 'MicroblendOffsetV', float_or_default(values['MicroblendOffsetV'], 0))
+        set_socket_default(inputs, 'Opacity', float_or_default(values['opacity'], 1))
+        apply_override(inputs, 'MetalLevelsIn', values['metalLevelsIn'], override_table['MetalLevelsIn'], (1, 0))
+        apply_override(inputs, 'MetalLevelsOut', values['metalLevelsOut'], override_table['MetalLevelsOut'], (1, 0))
+        apply_override(inputs, 'RoughLevelsIn', values['roughLevelsIn'], override_table['RoughLevelsIn'], (1, 0))
+        apply_override(inputs, 'RoughLevelsOut', values['roughLevelsOut'], override_table['RoughLevelsOut'], (1, 0))
+
+    def _get_or_create_layer_node_tree(self, Mat, group_name, BaseMat, MBI, vers):
+        existing = bpy.data.node_groups.get(group_name)
+        if existing:
+            return existing
+
+        NG = bpy.data.node_groups.new(group_name, "ShaderNodeTree")
+        is_legacy_nodes = vers[0] < 5
+        if vers[0] < 4:
+            NG.inputs.new('NodeSocketColor', 'Color')
+            NG.inputs.new('NodeSocketFloat', 'Metalness')
+            NG.inputs.new('NodeSocketFloat', 'Roughness')
+            NG.inputs.new('NodeSocketVector', 'Normal')
+            NG.inputs.new('NodeSocketVector', 'Microblend')
+            NG.inputs.new('NodeSocketFloat', 'Mask')
+            NG.inputs.new('NodeSocketColor', 'ColorScale')
+            NG.inputs.new('NodeSocketFloat', 'MatTile')
+            NG.inputs.new('NodeSocketFloat', 'OffsetU')
+            NG.inputs.new('NodeSocketFloat', 'OffsetV')
+            NG.inputs.new('NodeSocketFloat', 'NormalStrength')
+            NG.inputs.new('NodeSocketFloat', 'MicroblendNormalStrength')
+            NG.inputs.new('NodeSocketFloat', 'MicroblendContrast')
+            NG.inputs.new('NodeSocketFloat', 'MbTile')
+            NG.inputs.new('NodeSocketFloat', 'MicroblendOffsetU')
+            NG.inputs.new('NodeSocketFloat', 'MicroblendOffsetV')
+            NG.inputs.new('NodeSocketFloat', 'Opacity')
+            NG.outputs.new('NodeSocketColor', 'Color')
+            NG.outputs.new('NodeSocketFloat', 'Metalness')
+            NG.outputs.new('NodeSocketFloat', 'Roughness')
+            NG.outputs.new('NodeSocketVector', 'Normal')
+            NG.outputs.new('NodeSocketVector', 'Microblend')
+            NG.outputs.new('NodeSocketFloat', 'Layer Mask')
+            NG_inputs = NG.inputs
+        else:
+            ioPanel = NG.interface.new_panel(name='Input/Output')
+            ioPanel.default_closed = True
+            overridesPanel = NG.interface.new_panel(name='Overrides')
+            overridesPanel.default_closed = True
+            levelsPanel = NG.interface.new_panel(name='Levels')
+            levelsPanel.default_closed = True
+            NG.interface.move_to_parent(item=levelsPanel, parent=overridesPanel, to_position=2)
+            paramsPanel = NG.interface.new_panel(name='Parameters')
+            if is_legacy_nodes:
+                NG.interface.new_socket(name="Color", socket_type='NodeSocketColor', parent=ioPanel, in_out='INPUT')
+                NG.interface.new_socket(name="Metalness", socket_type='NodeSocketFloat', parent=ioPanel, in_out='INPUT')
+                NG.interface.new_socket(name="Roughness", socket_type='NodeSocketFloat', parent=ioPanel, in_out='INPUT')
+                NG.interface.new_socket(name="Normal", socket_type='NodeSocketVector', parent=ioPanel, in_out='INPUT')
+                NG.interface.new_socket(name="Microblend", socket_type='NodeSocketVector', parent=ioPanel, in_out='INPUT')
+            NG.interface.new_socket(name="Mask", socket_type='NodeSocketFloat', parent=ioPanel, in_out='INPUT')
+            NG.interface.new_socket(name="ColorScale", socket_type='NodeSocketColor', parent=overridesPanel, in_out='INPUT')
+            NG.interface.new_socket(name="NormalStrength", socket_type='NodeSocketFloat', parent=overridesPanel, in_out='INPUT')
+            NG.interface.new_socket(name="MetalLevelsIn", socket_type='NodeSocketVector', parent=levelsPanel, in_out='INPUT')
+            NG.interface.new_socket(name="MetalLevelsOut", socket_type='NodeSocketVector', parent=levelsPanel, in_out='INPUT')
+            NG.interface.new_socket(name="RoughLevelsIn", socket_type='NodeSocketVector', parent=levelsPanel, in_out='INPUT')
+            NG.interface.new_socket(name="RoughLevelsOut", socket_type='NodeSocketVector', parent=levelsPanel, in_out='INPUT')
+            NG.interface.new_socket(name="MatTile", socket_type='NodeSocketFloat', parent=paramsPanel, in_out='INPUT')
+            NG.interface.new_socket(name="OffsetU", socket_type='NodeSocketFloat', parent=paramsPanel, in_out='INPUT')
+            NG.interface.new_socket(name="OffsetV", socket_type='NodeSocketFloat', parent=paramsPanel, in_out='INPUT')
+            NG.interface.new_socket(name="MicroblendNormalStrength", socket_type='NodeSocketFloat', parent=paramsPanel, in_out='INPUT')
+            NG.interface.new_socket(name="MicroblendContrast", socket_type='NodeSocketFloat', parent=paramsPanel, in_out='INPUT')
+            NG.interface.new_socket(name="MbTile", socket_type='NodeSocketFloat', parent=paramsPanel, in_out='INPUT')
+            NG.interface.new_socket(name="MicroblendOffsetU", socket_type='NodeSocketFloat', parent=paramsPanel, in_out='INPUT')
+            NG.interface.new_socket(name="MicroblendOffsetV", socket_type='NodeSocketFloat', parent=paramsPanel, in_out='INPUT')
+            NG.interface.new_socket(name="Opacity", socket_type='NodeSocketFloat', parent=paramsPanel, in_out='INPUT')
+            NG.interface.new_socket(name="Color", socket_type='NodeSocketColor', parent=ioPanel, in_out='OUTPUT')
+            NG.interface.new_socket(name="Metalness", socket_type='NodeSocketFloat', parent=ioPanel, in_out='OUTPUT')
+            NG.interface.new_socket(name="Roughness", socket_type='NodeSocketFloat', parent=ioPanel, in_out='OUTPUT')
+            NG.interface.new_socket(name="Normal", socket_type='NodeSocketVector', parent=ioPanel, in_out='OUTPUT')
+            NG.interface.new_socket(name="Microblend", socket_type='NodeSocketVector', parent=ioPanel, in_out='OUTPUT')
+            NG.interface.new_socket(name="Layer Mask", socket_type='NodeSocketFloat', parent=ioPanel, in_out='OUTPUT')
+            if not is_legacy_nodes:
+                NG.interface.new_socket(name="Layer", socket_type='NodeSocketBundle', in_out='OUTPUT')
+            NG_inputs = get_inputs(NG)
+
+        self._configure_layer_tree_sockets(NG_inputs, is_legacy_nodes, 0)
+
+        GroupInN = create_node(NG.nodes, "NodeGroupInput", (-2600, 100))
+        GroupInN.hide = False
+        GroupOutN = create_node(NG.nodes, "NodeGroupOutput", (0, 100))
+        GroupOutN.hide = False
+
+        BMN = create_node(NG.nodes, "ShaderNodeGroup", (-1800, -150))
+        BMN.width = 300
+        BMN.hide = False
+        BMN.node_tree = BaseMat
+
+        colorReroute = NG.nodes.new("NodeReroute")
+        colorReroute.location = (-1100, 25)
+
+        MBN = create_node(NG.nodes, "ShaderNodeTexImage", (-2300, -600), image=MBI, label="Microblend")
+        MBN.hide = False
+        MBMapping = create_node(NG.nodes, "ShaderNodeMapping", (-2300, -550))
+        MBUVCombine = create_node(NG.nodes, "ShaderNodeCombineXYZ", (-2300, -500))
+        MBTexCord = create_node(NG.nodes, "ShaderNodeTexCoord", (-2300, -450))
+
+        shared_levels_ng = levels_node_group(Mat)
+        rLevelsInGroup = NG.nodes.new("ShaderNodeGroup")
+        rLevelsInGroup.node_tree = shared_levels_ng
+        rLevelsInGroup.location = (-1100, -150)
+        rLevelsInGroup.label = "R Levels In"
+        rLevelsInGroup.inputs[1].default_value = (1, 0)
+
+        rLevelsOutGroup = NG.nodes.new("ShaderNodeGroup")
+        rLevelsOutGroup.node_tree = shared_levels_ng
+        rLevelsOutGroup.location = (-850, -150)
+        rLevelsOutGroup.label = "R Levels Out"
+        rLevelsOutGroup.inputs[1].default_value = (1, 0)
+
+        mLevelsInGroup = NG.nodes.new("ShaderNodeGroup")
+        mLevelsInGroup.node_tree = shared_levels_ng
+        mLevelsInGroup.location = (-1100, 0)
+        mLevelsInGroup.label = "M Levels In"
+        mLevelsInGroup.inputs[1].default_value = (1, 0)
+
+        mLevelsOutGroup = NG.nodes.new("ShaderNodeGroup")
+        mLevelsOutGroup.node_tree = shared_levels_ng
+        mLevelsOutGroup.location = (-850, 0)
+        mLevelsOutGroup.label = "M Levels Out"
+        mLevelsOutGroup.inputs[1].default_value = (1, 0)
+
+        mask_mixer = mask_mixer_node_group(Mat)
+        mask_mixergroup = NG.nodes.new("ShaderNodeGroup")
+        mask_mixergroup.name = "Group"
+        mask_mixergroup.node_tree = mask_mixer
+        mask_mixergroup.location = (-1800, -400)
+        mask_mixergroup.width = 300
+
+        if is_legacy_nodes:
+            BLND = _getOrCreateLayerBlend(Mat)
+            LayerGroupBLND = NG.nodes.new("ShaderNodeGroup")
+            LayerGroupBLND.location = (-500, 300)
+            LayerGroupBLND.node_tree = BLND
+        else:
+            bundlecombine = create_node(NG.nodes, "NodeCombineBundle", (-500, 300))
+            bundlecombine.hide = False
+            bundlecombine.bundle_items.new(socket_type='RGBA', name='Color')
+            bundlecombine.bundle_items.new(socket_type='FLOAT', name='Metalness')
+            bundlecombine.bundle_items.new(socket_type='FLOAT', name='Roughness')
+            bundlecombine.bundle_items.new(socket_type='VECTOR', name='Normal')
+            bundlecombine.bundle_items.new(socket_type='VECTOR', name='Microblend')
+            bundlecombine.bundle_items.new(socket_type='FLOAT', name='Layer Mask')
+
+        mLevelsInReroute = NG.nodes.new("NodeReroute")
+        mLevelsInReroute.location = (-1350, -10)
+        mLevelsOutReroute = NG.nodes.new("NodeReroute")
+        mLevelsOutReroute.location = (-1350, -35)
+        rLevelsInReroute = NG.nodes.new("NodeReroute")
+        rLevelsInReroute.location = (-1350, -60)
+        rLevelsOutReroute = NG.nodes.new("NodeReroute")
+        rLevelsOutReroute.location = (-1350, -85)
+        normalReroute = NG.nodes.new("NodeReroute")
+        normalReroute.location = (-700, -350)
+        microblendReroute = NG.nodes.new("NodeReroute")
+        microblendReroute.location = (-700, -425)
+        layerMaskReroute = NG.nodes.new("NodeReroute")
+        layerMaskReroute.location = (-700, -450)
+
+        if is_legacy_nodes:
+            NG.links.new(GroupInN.outputs['Color'], LayerGroupBLND.inputs['Color A'])
+            NG.links.new(GroupInN.outputs['Metalness'], LayerGroupBLND.inputs['Metalness A'])
+            NG.links.new(GroupInN.outputs['Roughness'], LayerGroupBLND.inputs['Roughness A'])
+            NG.links.new(GroupInN.outputs['Normal'], LayerGroupBLND.inputs['Normal A'])
+            NG.links.new(GroupInN.outputs['Microblend'], LayerGroupBLND.inputs['Microblend A'])
+            NG.links.new(colorReroute.outputs[0], LayerGroupBLND.inputs['Color B'])
+            NG.links.new(mLevelsOutGroup.outputs[0], LayerGroupBLND.inputs['Metalness B'])
+            NG.links.new(rLevelsOutGroup.outputs[0], LayerGroupBLND.inputs['Roughness B'])
+            NG.links.new(BMN.outputs[3], normalReroute.inputs[0])
+            NG.links.new(normalReroute.outputs[0], LayerGroupBLND.inputs['Normal B'])
+            NG.links.new(mask_mixergroup.outputs[0], microblendReroute.inputs[0])
+            NG.links.new(microblendReroute.outputs[0], LayerGroupBLND.inputs['Microblend B'])
+            NG.links.new(mask_mixergroup.outputs[1], layerMaskReroute.inputs[0])
+            NG.links.new(layerMaskReroute.outputs[0], LayerGroupBLND.inputs['Layer Mask'])
+            NG.links.new(LayerGroupBLND.outputs['Color'], GroupOutN.inputs['Color'])
+            NG.links.new(LayerGroupBLND.outputs['Metalness'], GroupOutN.inputs['Metalness'])
+            NG.links.new(LayerGroupBLND.outputs['Roughness'], GroupOutN.inputs['Roughness'])
+            NG.links.new(LayerGroupBLND.outputs['Normal'], GroupOutN.inputs['Normal'])
+            NG.links.new(LayerGroupBLND.outputs['Microblend'], GroupOutN.inputs['Microblend'])
+        else:
+            NG.links.new(colorReroute.outputs[0], bundlecombine.inputs['Color'])
+            NG.links.new(mLevelsOutGroup.outputs[0], bundlecombine.inputs['Metalness'])
+            NG.links.new(rLevelsOutGroup.outputs[0], bundlecombine.inputs['Roughness'])
+            NG.links.new(normalReroute.outputs[0], bundlecombine.inputs['Normal'])
+            NG.links.new(mask_mixergroup.outputs[0], microblendReroute.inputs[0])
+            NG.links.new(microblendReroute.outputs[0], bundlecombine.inputs['Microblend'])
+            NG.links.new(layerMaskReroute.outputs[0], bundlecombine.inputs['Layer Mask'])
+            NG.links.new(bundlecombine.outputs[0], GroupOutN.inputs['Layer'])
+            NG.links.new(colorReroute.outputs[0], GroupOutN.inputs['Color'])
+            NG.links.new(mLevelsOutGroup.outputs[0], GroupOutN.inputs['Metalness'])
+            NG.links.new(rLevelsOutGroup.outputs[0], GroupOutN.inputs['Roughness'])
+            NG.links.new(BMN.outputs[3], normalReroute.inputs[0])
+            NG.links.new(normalReroute.outputs[0], GroupOutN.inputs['Normal'])
+            NG.links.new(mask_mixergroup.outputs[0], microblendReroute.inputs[0])
+            NG.links.new(microblendReroute.outputs[0], GroupOutN.inputs['Microblend'])
+            NG.links.new(mask_mixergroup.outputs[1], layerMaskReroute.inputs[0])
+            NG.links.new(layerMaskReroute.outputs[0], GroupOutN.inputs['Layer Mask'])
+
+        NG.links.new(GroupInN.outputs['ColorScale'], BMN.inputs[0])
+        NG.links.new(GroupInN.outputs['NormalStrength'], BMN.inputs[4])
+        NG.links.new(GroupInN.outputs['MetalLevelsIn'], mLevelsInReroute.inputs[0])
+        NG.links.new(mLevelsInReroute.outputs[0], mLevelsInGroup.inputs[1])
+        NG.links.new(GroupInN.outputs['MetalLevelsOut'], mLevelsOutReroute.inputs[0])
+        NG.links.new(mLevelsOutReroute.outputs[0], mLevelsOutGroup.inputs[1])
+        NG.links.new(GroupInN.outputs['RoughLevelsIn'], rLevelsInReroute.inputs[0])
+        NG.links.new(rLevelsInReroute.outputs[0], rLevelsInGroup.inputs[1])
+        NG.links.new(GroupInN.outputs['RoughLevelsOut'], rLevelsOutReroute.inputs[0])
+        NG.links.new(rLevelsOutReroute.outputs[0], rLevelsOutGroup.inputs[1])
+        NG.links.new(GroupInN.outputs['MatTile'], BMN.inputs[1])
+        if len(BMN.inputs) > 1:
+            NG.links.new(GroupInN.outputs['OffsetU'], BMN.inputs[2])
+            if len(BMN.inputs) > 2:
+                NG.links.new(GroupInN.outputs['OffsetV'], BMN.inputs[3])
+        NG.links.new(GroupInN.outputs['MicroblendNormalStrength'], mask_mixergroup.inputs['MicroblendNormalStrength'])
+        NG.links.new(GroupInN.outputs['MicroblendContrast'], mask_mixergroup.inputs['MicroblendContrast'])
+        NG.links.new(GroupInN.outputs['MbTile'], MBMapping.inputs[3])
+        NG.links.new(GroupInN.outputs['MicroblendOffsetU'], MBUVCombine.inputs[0])
+        NG.links.new(GroupInN.outputs['MicroblendOffsetV'], MBUVCombine.inputs[1])
+        NG.links.new(GroupInN.outputs['Opacity'], mask_mixergroup.inputs['Opacity'])
+        NG.links.new(GroupInN.outputs['Mask'], mask_mixergroup.inputs['Mask'])
+        NG.links.new(MBTexCord.outputs[2], MBMapping.inputs[0])
+        NG.links.new(MBUVCombine.outputs[0], MBMapping.inputs[1])
+        NG.links.new(MBMapping.outputs[0], MBN.inputs[0])
+        NG.links.new(BMN.outputs[0], colorReroute.inputs[0])
+        NG.links.new(BMN.outputs[1], mLevelsInGroup.inputs[0])
+        NG.links.new(mLevelsInGroup.outputs[0], mLevelsOutGroup.inputs[0])
+        NG.links.new(BMN.outputs[2], rLevelsInGroup.inputs[0])
+        NG.links.new(rLevelsInGroup.outputs[0], rLevelsOutGroup.inputs[0])
+        NG.links.new(MBN.outputs[0], mask_mixergroup.inputs['Microblend'])
+        NG.links.new(MBN.outputs[1], mask_mixergroup.inputs['Microblend Alpha'])
+        return NG
+
+    def setupMaterial(self, LayerName, LayerCount, CurMat, mlmaskpath, normalimgpath):
+        vers = bpy.app.version
+        is_legacy_nodes = vers[0] < 5
+        node_lookup = {n.name: n for n in CurMat.nodes}
+
+        if is_legacy_nodes:
             LayerCount = LayerCount - 1
-
             normalVectorize = CurMat.nodes.new("ShaderNodeVectorMath")
-            normalVectorize.operation='MULTIPLY_ADD'
-            normalVectorize.location = (-900,0)
+            normalVectorize.operation = 'MULTIPLY_ADD'
+            normalVectorize.location = (-900, 0)
             normalVectorize.hide = True
             normalVectorize.inputs[1].default_value = 2, 2, 0
             normalVectorize.inputs[2].default_value = -1, -1, 0
-
-            normalMicroBAdd = create_node(CurMat.nodes, "ShaderNodeVectorMath",(-700,-75),operation='ADD')
-
-            normalAdd = create_node(CurMat.nodes, "ShaderNodeVectorMath",(-700,0),operation='ADD')
-
-            normalCreateVecZGroup = CreateCalculateVecNormalZ(CurMat,-500,0)
-            normalMap = create_node(CurMat.nodes, "ShaderNodeNormalMap",(-500,-75))
-
+            normalMicroBAdd = create_node(CurMat.nodes, "ShaderNodeVectorMath", (-700, -75), operation='ADD')
+            normalAdd = create_node(CurMat.nodes, "ShaderNodeVectorMath", (-700, 0), operation='ADD')
+            normalCreateVecZGroup = CreateCalculateVecNormalZ(CurMat, -500, 0)
+            normalMap = create_node(CurMat.nodes, "ShaderNodeNormalMap", (-500, -75))
             CurMat.links.new(normalVectorize.outputs[0], normalAdd.inputs[0])
             CurMat.links.new(normalMicroBAdd.outputs[0], normalAdd.inputs[1])
             CurMat.links.new(normalAdd.outputs[0], normalCreateVecZGroup.inputs[0])
             CurMat.links.new(normalCreateVecZGroup.outputs[0], normalMap.inputs[1])
-            CurMat.links.new(normalMap.outputs[0], CurMat.nodes[loc('Principled BSDF')].inputs['Normal'])
+            CurMat.links.new(normalMap.outputs[0], node_lookup[loc('Principled BSDF')].inputs['Normal'])
         else:
-            orig_pbsdf = CurMat.nodes['Principled BSDF']
+            orig_pbsdf = node_lookup['Principled BSDF']
             if orig_pbsdf:
                 CurMat.nodes.remove(orig_pbsdf)
             ml_main_ng = ml_pbsdf_node_group(CurMat)
             ml_main_ng.color_tag = 'SHADER'
             mlShaderNG = CurMat.nodes.new("ShaderNodeGroup")
-            # JATO: should we be setting node name? maybe ml-editing stuff should look for node tree name instead?
             mlShaderNG.name = "Multilayered 1.8.0"
             mlShaderNG.location = (-50, 100)
             mlShaderNG.node_tree = ml_main_ng
             mlShaderNG.show_options = False
-            CurMat.links.new(mlShaderNG.outputs['BSDF'],CurMat.nodes['Material Output'].inputs[0])
+            CurMat.links.new(mlShaderNG.outputs['BSDF'], node_lookup['Material Output'].inputs[0])
 
         for x in range(LayerCount):
-            MaskTexture=None
-            projpath = os.path.join(os.path.splitext(os.path.join(self.ProjPath, mlmaskpath))[0] + '_layers', os.path.split(mlmaskpath)[-1:][0][:-7] + "_" + str(x + 1) + ".png")
-            basepath = os.path.join(os.path.splitext(os.path.join(self.BasePath, mlmaskpath))[0] + '_layers', os.path.split(mlmaskpath)[-1:][0][:-7] + "_" + str(x + 1) + ".png")
-            if os.path.exists(projpath):
-                MaskTexture = imageFromPath(projpath, self.image_format, isNormal = True)
-            elif os.path.exists(basepath):
-                MaskTexture = imageFromPath(basepath, self.image_format, isNormal = True)
-            # else:
-                # if 'AppData' in basepath:
-                    # print('Mask image not found for layer ',x+1,' DepotPath appears to be in Appdata, this is known to cause issues')
-                # else:
-                    # print('Mask image not found for layer ',x+1)
-
-            MaskN=None
+            mask_path = self._resolve_mask_layer_path(mlmaskpath, x + 1)
+            MaskTexture = imageFromPath(mask_path, self.image_format, isNormal=True) if mask_path else None
+            MaskN = None
             if MaskTexture:
-                if vers[0]<5.0:
-                    MaskN = create_node(CurMat.nodes,"ShaderNodeTexImage",(-2400,-400*x), hide=False, image = MaskTexture)
+                if is_legacy_nodes:
+                    MaskN = create_node(CurMat.nodes, "ShaderNodeTexImage", (-2400, -400 * x), hide=False, image=MaskTexture)
                 else:
-                    MaskN = create_node(CurMat.nodes,"ShaderNodeTexImage",(-1200,-400*x), hide=False, image = MaskTexture)
+                    MaskN = create_node(CurMat.nodes, "ShaderNodeTexImage", (-1200, -400 * x), hide=False, image=MaskTexture)
                 MaskN.width = 300
 
-            #if self.flipMaskY:
-            # Mask flip deprecated in WolvenKit deveolpment build 8.7+
-            #MaskN.texture_mapping.scale[1] = -1 #flip mask if needed
-
-            if vers[0]<5.0:
-                CurMat.links.new(CurMat.nodes["Mat_Mod_Layer_"+str(x)].outputs['Color'],CurMat.nodes["Mat_Mod_Layer_"+str(x+1)].inputs['Color'])
-                CurMat.links.new(CurMat.nodes["Mat_Mod_Layer_"+str(x)].outputs['Metalness'],CurMat.nodes["Mat_Mod_Layer_"+str(x+1)].inputs['Metalness'])
-                CurMat.links.new(CurMat.nodes["Mat_Mod_Layer_"+str(x)].outputs['Roughness'],CurMat.nodes["Mat_Mod_Layer_"+str(x+1)].inputs['Roughness'])
-                CurMat.links.new(CurMat.nodes["Mat_Mod_Layer_"+str(x)].outputs['Normal'],CurMat.nodes["Mat_Mod_Layer_"+str(x+1)].inputs['Normal'])
-                CurMat.links.new(CurMat.nodes["Mat_Mod_Layer_"+str(x)].outputs['Microblend'],CurMat.nodes["Mat_Mod_Layer_"+str(x+1)].inputs['Microblend'])
-            else:
-                # JATO: Check for mlsetup with more than 20 layers (probably only ml-resources wk-project)
-                if x<=19:
-                    CurMat.links.new(CurMat.nodes["Mat_Mod_Layer_"+str(x)].outputs['Layer'],mlShaderNG.inputs[x + 1])
+            if is_legacy_nodes:
+                current_layer = node_lookup["Mat_Mod_Layer_" + str(x)]
+                next_layer = node_lookup["Mat_Mod_Layer_" + str(x + 1)]
+                CurMat.links.new(current_layer.outputs['Color'], next_layer.inputs['Color'])
+                CurMat.links.new(current_layer.outputs['Metalness'], next_layer.inputs['Metalness'])
+                CurMat.links.new(current_layer.outputs['Roughness'], next_layer.inputs['Roughness'])
+                CurMat.links.new(current_layer.outputs['Normal'], next_layer.inputs['Normal'])
+                CurMat.links.new(current_layer.outputs['Microblend'], next_layer.inputs['Microblend'])
+            elif x <= 19:
+                CurMat.links.new(node_lookup["Mat_Mod_Layer_" + str(x)].outputs['Layer'], mlShaderNG.inputs[x + 1])
 
             if MaskN:
                 try:
-                    CurMat.links.new(MaskN.outputs[0],CurMat.nodes["Mat_Mod_Layer_"+str(x+1)].inputs['Mask'])
-                except:
+                    CurMat.links.new(MaskN.outputs[0], node_lookup["Mat_Mod_Layer_" + str(x + 1)].inputs['Mask'])
+                except Exception:
                     pass
 
-        if vers[0]<5.0:
-            if LayerCount>1:
-                targetLayer="Mat_Mod_Layer_"+str(LayerCount-1)
-            else:
-                targetLayer="Mat_Mod_Layer_0"
-
-            targetLayer="Mat_Mod_Layer_"+str(LayerCount)
-            CurMat.links.new(CurMat.nodes[targetLayer].outputs['Color'],CurMat.nodes[loc('Principled BSDF')].inputs['Base Color'])
-            CurMat.links.new(CurMat.nodes[targetLayer].outputs['Metalness'],CurMat.nodes[loc('Principled BSDF')].inputs['Metallic'])
-            CurMat.links.new(CurMat.nodes[targetLayer].outputs['Roughness'],CurMat.nodes[loc('Principled BSDF')].inputs['Roughness'])
-            CurMat.links.new(CurMat.nodes[targetLayer].outputs['Normal'],normalMicroBAdd.inputs[0])
-            CurMat.links.new(CurMat.nodes[targetLayer].outputs['Microblend'],normalMicroBAdd.inputs[1])
+        if is_legacy_nodes:
+            targetLayer = "Mat_Mod_Layer_" + str(LayerCount)
+            principled = node_lookup[loc('Principled BSDF')]
+            CurMat.links.new(node_lookup[targetLayer].outputs['Color'], principled.inputs['Base Color'])
+            CurMat.links.new(node_lookup[targetLayer].outputs['Metalness'], principled.inputs['Metallic'])
+            CurMat.links.new(node_lookup[targetLayer].outputs['Roughness'], principled.inputs['Roughness'])
+            CurMat.links.new(node_lookup[targetLayer].outputs['Normal'], normalMicroBAdd.inputs[0])
+            CurMat.links.new(node_lookup[targetLayer].outputs['Microblend'], normalMicroBAdd.inputs[1])
 
         if normalimgpath:
-            GNMap = CreateShaderNodeGlobalNormalMap(CurMat,self.BasePath + normalimgpath,-350,800,'GlobalNormal',self.image_format)
-            if vers[0]<5.0:
-                CurMat.links.new(GNMap.outputs[0],normalVectorize.inputs[0])
+            GNMap = CreateShaderNodeGlobalNormalMap(CurMat, self.BasePath + normalimgpath, -350, 800, 'GlobalNormal', self.image_format)
+            if is_legacy_nodes:
+                CurMat.links.new(GNMap.outputs[0], normalVectorize.inputs[0])
             else:
-                CurMat.links.new(GNMap.outputs[0],mlShaderNG.inputs[0])
+                CurMat.links.new(GNMap.outputs[0], mlShaderNG.inputs[0])
 
-
-    def create(self,Data,Mat):
-        # JATO: We have to clear gpencil palette to prevent add-on from immediately changing color of layer 1 on import
-        # TODO: Should probably clear palette when material-panel is drawn
+    def create(self, Data, Mat):
         bpy.context.tool_settings.gpencil_paint.palette = None
-
-        Mat['MLSetup']= Data["MultilayerSetup"]
-        mlsetup = JSONTool.openJSON( Data["MultilayerSetup"] + ".json",mode='r',DepotPath=self.BasePath, ProjPath=self.ProjPath)
+        Mat['MLSetup'] = Data["MultilayerSetup"]
+        mlsetup = JSONTool.openJSON(Data["MultilayerSetup"] + ".json", mode='r', DepotPath=self.BasePath, ProjPath=self.ProjPath)
         mlsetup = mlsetup["Data"]["RootChunk"]
         xllay = mlsetup.get("layers")
         if xllay is None:
             xllay = mlsetup.get("Layers")
         LayerCount = len(xllay)
-
         LayerIndex = 0
         CurMat = Mat.node_tree
+        vers = bpy.app.version
+        is_legacy_nodes = vers[0] < 5
+        template_cache = {}
+        file_name = os.path.basename(Data["MultilayerSetup"].replace('\\', os.sep))[:-8]
 
-        file_name = os.path.basename(Data["MultilayerSetup"].replace('\\',os.sep))[:-8]
+        for idx, x in enumerate(xllay):
+            MatTile = get_cased(x, "matTile")
+            MbTile = get_cased(x, "mbTile")
+            MbScale = float_or_default(MbTile if MbTile is not None else MatTile, 1)
+            Microblend = get_cased_depot_path(x, "microblend")
+            material = get_cased_depot_path(x, "material")
+            values = {
+                'opacity': get_cased(x, "opacity"),
+                'MatTile': MatTile,
+                'MbScale': MbScale,
+                'MicroblendContrast': get_cased(x, "microblendContrast", 1),
+                'microblendNormalStrength': get_cased(x, "microblendNormalStrength"),
+                'MicroblendOffsetU': get_cased(x, "microblendOffsetU"),
+                'MicroblendOffsetV': get_cased(x, "microblendOffsetV"),
+                'OffsetU': get_cased(x, "offsetU"),
+                'OffsetV': get_cased(x, "offsetV"),
+                'colorScale': get_cased_value(x, "colorScale"),
+                'normalStrength': get_cased_value(x, "normalStrength"),
+                'roughLevelsIn': get_cased_value(x, "roughLevelsIn"),
+                'roughLevelsOut': get_cased_value(x, "roughLevelsOut"),
+                'metalLevelsIn': get_cased_value(x, "metalLevelsIn"),
+                'metalLevelsOut': get_cased_value(x, "metalLevelsOut"),
+            }
 
-        for idx,x  in enumerate(xllay):
-            opacity = x.get("opacity")
-            if opacity is None:
-                opacity = x.get("Opacity")
+            MBI = None
+            if Microblend and Microblend != "null":
+                MBI = imageFromPath(self.BasePath + Microblend, self.image_format, True)
 
-            MatTile = x.get("matTile")
-            if MatTile is None:
-                MatTile = x.get("MatTile")
-            MbTile = x.get("mbTile")
-            if MbTile is None:
-                MbTile = x.get("MbTile")
-
-            MbScale = 1
-            if MatTile != None:
-                MbScale = float(MatTile)
-            if MbTile != None:
-                MbScale = float(MbTile)
-
-            Microblend = x["microblend"]["DepotPath"].get("$value")
-            if Microblend is None:
-                Microblend = x["Microblend"].get("$value")
-
-            MicroblendContrast = x.get("microblendContrast")
-            if MicroblendContrast is None:
-                MicroblendContrast = x.get("Microblend",1)
-
-            microblendNormalStrength = x.get("microblendNormalStrength")
-            if microblendNormalStrength is None:
-                microblendNormalStrength = x.get("MicroblendNormalStrength")
-
-            MicroblendOffsetU = x.get("microblendOffsetU")
-            if MicroblendOffsetU is None:
-                MicroblendOffsetU = x.get("MicroblendOffsetU")
-
-            MicroblendOffsetV = x.get("microblendOffsetV")
-            if MicroblendOffsetV is None:
-                MicroblendOffsetV = x.get("MicroblendOffsetV")
-
-            OffsetU = x.get("offsetU")
-            if OffsetU is None:
-                OffsetU = x.get("OffsetU")
-
-            OffsetV = x.get("offsetV")
-            if OffsetV is None:
-                OffsetV = x.get("OffsetV")
-
-            material = x["material"]["DepotPath"].get("$value")
-            if material is None:
-                material = x["Material"]["DepotPath"].get("$value")
-
-            colorScale = x["colorScale"].get("$value")
-            if colorScale is None:
-                colorScale = x["ColorScale"].get("$value")
-
-            normalStrength = x["normalStrength"].get("$value")
-            if normalStrength is None:
-                normalStrength = x["NormalStrength"].get("$value")
-
-            roughLevelsIn = x["roughLevelsIn"].get("$value")
-            if roughLevelsIn is None:
-                roughLevelsIn = x["RoughLevelsIn"].get("$value")
-
-            roughLevelsOut = x["roughLevelsOut"].get("$value")
-            if roughLevelsOut is None:
-                roughLevelsOut = x["RoughLevelsOut"].get("$value")
-
-            metalLevelsIn = x["metalLevelsIn"].get("$value")
-            if metalLevelsIn is None:
-                metalLevelsIn = x["MetalLevelsIn"].get("$value")
-
-            metalLevelsOut = x["metalLevelsOut"].get("$value")
-            if metalLevelsOut is None:
-                metalLevelsOut = x["MetalLevelsOut"].get("$value")
-
-            if Microblend != "null":
-                MBI = imageFromPath(self.BasePath+Microblend,self.image_format,True)
-
-            mltemplate = JSONTool.openJSON( material + ".json",mode='r',DepotPath=self.BasePath, ProjPath=self.ProjPath)
-            mltemplate = mltemplate["Data"]["RootChunk"]
-            OverrideTable = createOverrideTable(mltemplate)#get override info for colors and what not
-           # Mat[os.path.basename(material).split('.')[0]+'_cols']=OverrideTable["ColorScale"]
-
-            layerName = file_name+"_Layer_"+str(LayerIndex)
-            NG = bpy.data.node_groups.new(layerName,"ShaderNodeTree")#crLAer's node group
-            vers=bpy.app.version
-            if vers[0]<4:
-                NG.inputs.new('NodeSocketColor','Color')
-                NG.inputs.new('NodeSocketFloat','Metalness')
-                NG.inputs.new('NodeSocketFloat','Roughness')
-                NG.inputs.new('NodeSocketVector','Normal')
-                NG.inputs.new('NodeSocketVector','Microblend')
-                NG.inputs.new('NodeSocketFloat','Mask')
-                NG.inputs.new('NodeSocketColor','ColorScale')
-                NG.inputs.new('NodeSocketFloat','MatTile')
-                NG.inputs.new('NodeSocketFloat','OffsetU')
-                NG.inputs.new('NodeSocketFloat','OffsetV')
-                NG.inputs.new('NodeSocketFloat','NormalStrength')
-                NG.inputs.new('NodeSocketFloat','MicroblendNormalStrength')
-                NG.inputs.new('NodeSocketFloat','MicroblendContrast')
-                NG.inputs.new('NodeSocketFloat','MbTile')
-                NG.inputs.new('NodeSocketFloat','MicroblendOffsetU')
-                NG.inputs.new('NodeSocketFloat','MicroblendOffsetV')
-                NG.inputs.new('NodeSocketFloat','Opacity')
-
-                NG.outputs.new('NodeSocketColor','Color')
-                NG.outputs.new('NodeSocketFloat','Metalness')
-                NG.outputs.new('NodeSocketFloat','Roughness')
-                NG.outputs.new('NodeSocketVector','Normal')
-                NG.outputs.new('NodeSocketVector','Microblend')
-                NG.outputs.new('NodeSocketFloat','Layer Mask')
-                NG_inputs=NG.inputs
-
+            cached_template = template_cache.get(material)
+            if cached_template is None:
+                mltemplate = JSONTool.openJSON(material + ".json", mode='r', DepotPath=self.BasePath, ProjPath=self.ProjPath)
+                mltemplate = mltemplate["Data"]["RootChunk"]
+                OverrideTable = createOverrideTable(mltemplate)
+                template_cache[material] = (mltemplate, OverrideTable)
             else:
-                ioPanel = NG.interface.new_panel(name='Input/Output')
-                ioPanel.default_closed = True
-                overridesPanel = NG.interface.new_panel(name='Overrides')
-                overridesPanel.default_closed = True
-                levelsPanel = NG.interface.new_panel(name='Levels')
-                levelsPanel.default_closed = True
-                NG.interface.move_to_parent(item=levelsPanel, parent=overridesPanel, to_position=2)
-                paramsPanel = NG.interface.new_panel(name='Parameters')
-                if vers[0]<5:
-                    NG.interface.new_socket(name="Color", socket_type='NodeSocketColor', parent=ioPanel, in_out='INPUT')
-                    NG.interface.new_socket(name="Metalness", socket_type='NodeSocketFloat', parent=ioPanel, in_out='INPUT')
-                    NG.interface.new_socket(name="Roughness", socket_type='NodeSocketFloat', parent=ioPanel, in_out='INPUT')
-                    NG.interface.new_socket(name="Normal", socket_type='NodeSocketVector', parent=ioPanel, in_out='INPUT')
-                    NG.interface.new_socket(name="Microblend", socket_type='NodeSocketVector', parent=ioPanel, in_out='INPUT')
-                NG.interface.new_socket(name="Mask", socket_type='NodeSocketFloat', parent=ioPanel, in_out='INPUT')
+                mltemplate, OverrideTable = cached_template
 
-                NG.interface.new_socket(name="ColorScale", socket_type='NodeSocketColor', parent=overridesPanel, in_out='INPUT')
-                NG.interface.new_socket(name="NormalStrength", socket_type='NodeSocketFloat', parent=overridesPanel, in_out='INPUT')
-                NG.interface.new_socket(name="MetalLevelsIn", socket_type='NodeSocketVector', parent=levelsPanel, in_out='INPUT')
-                NG.interface.new_socket(name="MetalLevelsOut", socket_type='NodeSocketVector', parent=levelsPanel, in_out='INPUT')
-                NG.interface.new_socket(name="RoughLevelsIn", socket_type='NodeSocketVector', parent=levelsPanel, in_out='INPUT')
-                NG.interface.new_socket(name="RoughLevelsOut", socket_type='NodeSocketVector', parent=levelsPanel, in_out='INPUT')
+            material_norm = material.replace('\\', os.sep)
+            base_mat_name = os.path.basename(material_norm).split('.')[0]
+            BaseMat = bpy.data.node_groups.get(base_mat_name)
+            if BaseMat is None:
+                BaseMat = self.createMLTemplateGroup(mltemplate, material_norm)
 
-                NG.interface.new_socket(name="MatTile", socket_type='NodeSocketFloat', parent=paramsPanel, in_out='INPUT')
-                NG.interface.new_socket(name="OffsetU", socket_type='NodeSocketFloat', parent=paramsPanel, in_out='INPUT')
-                NG.interface.new_socket(name="OffsetV", socket_type='NodeSocketFloat', parent=paramsPanel, in_out='INPUT')
-                NG.interface.new_socket(name="MicroblendNormalStrength", socket_type='NodeSocketFloat', parent=paramsPanel, in_out='INPUT')
-                NG.interface.new_socket(name="MicroblendContrast", socket_type='NodeSocketFloat', parent=paramsPanel, in_out='INPUT')
-                NG.interface.new_socket(name="MbTile", socket_type='NodeSocketFloat', parent=paramsPanel, in_out='INPUT')
-                NG.interface.new_socket(name="MicroblendOffsetU", socket_type='NodeSocketFloat', parent=paramsPanel, in_out='INPUT')
-                NG.interface.new_socket(name="MicroblendOffsetV", socket_type='NodeSocketFloat', parent=paramsPanel, in_out='INPUT')
-                NG.interface.new_socket(name="Opacity", socket_type='NodeSocketFloat', parent=paramsPanel, in_out='INPUT')
+            group_name = safe_layer_group_name(file_name, vers[0], material_norm, Microblend or '')
+            NG = self._get_or_create_layer_node_tree(Mat, group_name, BaseMat, MBI, vers)
 
-                NG.interface.new_socket(name="Color", socket_type='NodeSocketColor', parent=ioPanel, in_out='OUTPUT')
-                NG.interface.new_socket(name="Metalness", socket_type='NodeSocketFloat', parent=ioPanel, in_out='OUTPUT')
-                NG.interface.new_socket(name="Roughness", socket_type='NodeSocketFloat', parent=ioPanel, in_out='OUTPUT')
-                NG.interface.new_socket(name="Normal", socket_type='NodeSocketVector', parent=ioPanel, in_out='OUTPUT')
-                NG.interface.new_socket(name="Microblend", socket_type='NodeSocketVector', parent=ioPanel, in_out='OUTPUT')
-                NG.interface.new_socket(name="Layer Mask", socket_type='NodeSocketFloat', parent=ioPanel, in_out='OUTPUT')
-
-                if not vers[0]<5:
-                    NG.interface.new_socket(name="Layer", socket_type='NodeSocketBundle', in_out='OUTPUT')
-
-                NG_inputs=get_inputs(NG)
-
-            if vers[0]<5:
-                if LayerIndex == 0:
-                    NG_inputs[5].default_value = 1
-
-                NG_inputs[7].min_value = 0 #NormalStrength  No reason to invert these maps, not detail maps.
-                NG_inputs[7].max_value = 10 #NormalStrength This value is arbitrary, but more than adequate.
-
-                NG_inputs[8].dimensions = 2 #MetalLevelsIn  Changes from Vec3 to Vec2 TODO Can this be set on socket creation?
-                NG_inputs[9].dimensions = 2 #MetalLevelsOut  Changes from Vec3 to Vec2 TODO Can this be set on socket creation?
-                NG_inputs[10].dimensions = 2 #RoughLevelsIn  Changes from Vec3 to Vec2 TODO Can this be set on socket creation?
-                NG_inputs[11].dimensions = 2 #RoughLevelsOut  Changes from Vec3 to Vec2 TODO Can this be set on socket creation?
-
-                NG_inputs[16].min_value = 0 #MicroblendContrast
-                NG_inputs[16].max_value = 1 #MicroblendContrast
-                NG_inputs[20].min_value = 0 #Opacity
-                NG_inputs[20].max_value = 1 #Opacity
+            if is_legacy_nodes:
+                LayerGroupN = create_node(CurMat.nodes, "ShaderNodeGroup", (-2000, 450 - 400 * idx), False)
             else:
-                if LayerIndex == 0:
-                    NG_inputs[0].default_value = 1
-                NG_inputs[2].min_value = 0 #NormalStrength  No reason to invert these maps, not detail maps.
-                NG_inputs[2].max_value = 10 #NormalStrength This value is arbitrary, but more than adequate.
-                NG_inputs[3].dimensions = 2 #MetalLevelsIn  Changes from Vec3 to Vec2 TODO Can this be set on socket creation?
-                NG_inputs[4].dimensions = 2 #MetalLevelsOut  Changes from Vec3 to Vec2 TODO Can this be set on socket creation?
-                NG_inputs[5].dimensions = 2 #RoughLevelsIn  Changes from Vec3 to Vec2 TODO Can this be set on socket creation?
-                NG_inputs[6].dimensions = 2 #RoughLevelsOut  Changes from Vec3 to Vec2 TODO Can this be set on socket creation?
-                NG_inputs[11].min_value = 0 #MicroblendContrast
-                NG_inputs[11].max_value = 1 #MicroblendContrast
-                NG_inputs[15].min_value = 0 #Opacity
-                NG_inputs[15].max_value = 1 #Opacity
-
-
-            if vers[0]<5.0:
-                LayerGroupN = create_node(CurMat.nodes, "ShaderNodeGroup", (-2000,450-400*idx), False)
-            else:
-                LayerGroupN = create_node(CurMat.nodes, "ShaderNodeGroup", (-800,450-400*idx), False)
+                LayerGroupN = create_node(CurMat.nodes, "ShaderNodeGroup", (-800, 450 - 400 * idx), False)
             LayerGroupN.width = 400
             LayerGroupN.node_tree = NG
-            LayerGroupN.name = "Mat_Mod_Layer_"+str(LayerIndex)
+            LayerGroupN.name = "Mat_Mod_Layer_" + str(LayerIndex)
+            LayerGroupN['mlTemplate'] = material
+            self._configure_layer_group_inputs(LayerGroupN, LayerIndex, values, OverrideTable)
             LayerIndex += 1
 
-            GroupInN = create_node(NG.nodes, "NodeGroupInput", (-2600,100))
-            GroupInN.hide = False
-
-            GroupOutN = create_node(NG.nodes, "NodeGroupOutput", (0,100))
-            GroupOutN.hide = False
-            LayerGroupN['mlTemplate']=material
-            if not bpy.data.node_groups.get(os.path.basename(material.replace('\\',os.sep)).split('.')[0]):
-                self.createMLTemplateGroup(mltemplate,material.replace('\\',os.sep))
-
-            BaseMat = bpy.data.node_groups.get(os.path.basename(material.replace('\\',os.sep)).split('.')[0])
-            if BaseMat:
-                BMN = create_node(NG.nodes,"ShaderNodeGroup", (-1800,-150))
-                BMN.width = 300
-                BMN.hide = False
-                BMN.node_tree = BaseMat
-
-            # SET LAYER GROUP DEFAULT VALUES
-
-            if colorScale != None and colorScale in OverrideTable["ColorScale"]:
-                LayerGroupN.inputs['ColorScale'].default_value = OverrideTable["ColorScale"][colorScale]
-                LayerGroupN['colorScale']=colorScale
-            else:
-                LayerGroupN.inputs['ColorScale'].default_value = (1.0,1.0,1.0,1)
-
-            if MatTile != None:
-                LayerGroupN.inputs['MatTile'].default_value = float(MatTile)
-            else:
-                LayerGroupN.inputs['MatTile'].default_value = 1
-
-            if OffsetU !=None:
-                LayerGroupN.inputs['OffsetU'].default_value= OffsetU
-            else:
-                LayerGroupN.inputs['OffsetU'].default_value=0
-
-            if OffsetV !=None:
-                LayerGroupN.inputs['OffsetV'].default_value= OffsetV
-            else:
-                LayerGroupN.inputs['OffsetV'].default_value=0
-
-            if normalStrength != None and normalStrength in OverrideTable["NormalStrength"]:
-                LayerGroupN.inputs['NormalStrength'].default_value = OverrideTable["NormalStrength"][normalStrength]
-            else:
-                LayerGroupN.inputs['NormalStrength'].default_value = 1
-
-            if microblendNormalStrength != None:
-                LayerGroupN.inputs['MicroblendNormalStrength'].default_value = float(microblendNormalStrength)
-            else:
-                LayerGroupN.inputs['MicroblendNormalStrength'].default_value = 1
-
-            if MicroblendContrast != None:
-                LayerGroupN.inputs['MicroblendContrast'].default_value = float(MicroblendContrast)
-            else:
-                LayerGroupN.inputs['MicroblendContrast'].default_value = 1
-
-            if MbScale != None:
-                LayerGroupN.inputs['MbTile'].default_value = float(MbScale)
-            else:
-                LayerGroupN.inputs['MbTile'].default_value = 1
-
-            if MicroblendOffsetU != None:
-                LayerGroupN.inputs['MicroblendOffsetU'].default_value = float(MicroblendOffsetU)
-            else:
-                LayerGroupN.inputs['MicroblendOffsetU'].default_value = 0
-
-            if MicroblendOffsetV != None:
-                LayerGroupN.inputs['MicroblendOffsetV'].default_value = float(MicroblendOffsetV)
-            else:
-                LayerGroupN.inputs['MicroblendOffsetV'].default_value = 0
-
-            if opacity != None:
-                LayerGroupN.inputs['Opacity'].default_value = float(opacity)
-            else:
-                LayerGroupN.inputs['Opacity'].default_value = 1
-
-            if metalLevelsIn != None and metalLevelsIn in OverrideTable["MetalLevelsIn"]:
-                LayerGroupN.inputs['MetalLevelsIn'].default_value = OverrideTable["MetalLevelsIn"][metalLevelsIn]
-            else:
-                LayerGroupN.inputs['MetalLevelsIn'].default_value = (1,0)
-
-            if metalLevelsOut != None and metalLevelsOut in OverrideTable["MetalLevelsOut"]:
-                LayerGroupN.inputs['MetalLevelsOut'].default_value = OverrideTable["MetalLevelsOut"][metalLevelsOut]
-            else:
-                LayerGroupN.inputs['MetalLevelsOut'].default_value = (1,0)
-
-            if roughLevelsIn != None and roughLevelsIn in OverrideTable["RoughLevelsIn"]:
-                LayerGroupN.inputs['RoughLevelsIn'].default_value = OverrideTable["RoughLevelsIn"][roughLevelsIn]
-            else:
-                LayerGroupN.inputs['RoughLevelsIn'].default_value = (1,0)
-
-            if roughLevelsOut != None and roughLevelsOut in OverrideTable["RoughLevelsOut"]:
-                LayerGroupN.inputs['RoughLevelsOut'].default_value = OverrideTable["RoughLevelsOut"][roughLevelsOut]
-            else:
-                LayerGroupN.inputs['RoughLevelsOut'].default_value = (1,0)
-
-
-            # DEFINES MAIN MULTILAYERED PROPERTIES
-
-            colorReroute = NG.nodes.new("NodeReroute")
-            colorReroute.location = (-1100,25)
-
-            # Microblend texture node
-            MBN = create_node(NG.nodes,"ShaderNodeTexImage",(-2300,-600),image = MBI,label = "Microblend")
-            MBN.hide = False
-            MBMapping = create_node(NG.nodes,"ShaderNodeMapping", (-2300,-550))
-            MBUVCombine = create_node(NG.nodes,"ShaderNodeCombineXYZ", (-2300,-500))
-            MBTexCord = create_node(NG.nodes,"ShaderNodeTexCoord", (-2300,-450))
-
-            # Roughness
-            rLevelsIn = levels_node_group(Mat)
-            rLevelsInGroup = NG.nodes.new("ShaderNodeGroup")
-            rLevelsInGroup.node_tree = rLevelsIn
-            rLevelsInGroup.location = (-1100,-150)
-            rLevelsInGroup.label = "R Levels In"
-            rLevelsInGroup.inputs[1].default_value = (1,0)
-
-            rLevelsOut = levels_node_group(Mat)
-            rLevelsOutGroup = NG.nodes.new("ShaderNodeGroup")
-            rLevelsOutGroup.node_tree = rLevelsOut
-            rLevelsOutGroup.location = (-850,-150)
-            rLevelsOutGroup.label = "R Levels Out"
-            rLevelsOutGroup.inputs[1].default_value = (1,0)
-
-            # Metalness
-            mLevelsIn = levels_node_group(Mat)
-            mLevelsInGroup = NG.nodes.new("ShaderNodeGroup")
-            mLevelsInGroup.node_tree = mLevelsIn
-            mLevelsInGroup.location = (-1100,0)
-            mLevelsInGroup.label = "M Levels In"
-            mLevelsInGroup.inputs[1].default_value = (1,0)
-
-            mLevelsOut = levels_node_group(Mat)
-            mLevelsOutGroup = NG.nodes.new("ShaderNodeGroup")
-            mLevelsOutGroup.node_tree = mLevelsOut
-            mLevelsOutGroup.location = (-850,0)
-            mLevelsOutGroup.label = "M Levels Out"
-            mLevelsOutGroup.inputs[1].default_value = (1,0)
-
-
-            # --- Mask Layer ---
-            mask_mixer=mask_mixer_node_group(Mat)
-            mask_mixergroup = NG.nodes.new("ShaderNodeGroup")
-            mask_mixergroup.name = "Group"
-            mask_mixergroup.node_tree = mask_mixer
-            mask_mixergroup.location = (-1800, -400)
-            mask_mixergroup.width = 300
-
-            if vers[0]<5:
-                BLND = _getOrCreateLayerBlend(Mat)
-                LayerGroupBLND = NG.nodes.new("ShaderNodeGroup")
-                LayerGroupBLND.location = (-500, 300)
-                LayerGroupBLND.node_tree = BLND
-            else:
-                bundlecombine = create_node(NG.nodes, "NodeCombineBundle",(-500,300))
-                bundlecombine.hide = False
-                bundlecombineColor = bundlecombine.bundle_items.new(socket_type='RGBA', name='Color')
-                bundlecombineMetal = bundlecombine.bundle_items.new(socket_type='FLOAT', name='Metalness')
-                bundlecombineRough = bundlecombine.bundle_items.new(socket_type='FLOAT', name='Roughness')
-                bundlecombineNormal = bundlecombine.bundle_items.new(socket_type='VECTOR', name='Normal')
-                bundlecombineMicroblend = bundlecombine.bundle_items.new(socket_type='VECTOR', name='Microblend')
-                bundlecombineMask = bundlecombine.bundle_items.new(socket_type='FLOAT', name='Layer Mask')
-
-            mLevelsInReroute = NG.nodes.new("NodeReroute")
-            mLevelsInReroute.location = (-1350,-10)
-            mLevelsOutReroute = NG.nodes.new("NodeReroute")
-            mLevelsOutReroute.location = (-1350,-35)
-            rLevelsInReroute = NG.nodes.new("NodeReroute")
-            rLevelsInReroute.location = (-1350,-60)
-            rLevelsOutReroute = NG.nodes.new("NodeReroute")
-            rLevelsOutReroute.location = (-1350,-85)
-
-            normalReroute = NG.nodes.new("NodeReroute")
-            normalReroute.location = (-700,-350)
-
-            microblendReroute = NG.nodes.new("NodeReroute")
-            microblendReroute.location = (-700,-425)
-
-            layerMaskReroute = NG.nodes.new("NodeReroute")
-            layerMaskReroute.location = (-700,-450)
-
-            # CREATE FINAL LINKS
-            if vers[0]<5:
-                NG.links.new(GroupInN.outputs['Color'],LayerGroupBLND.inputs['Color A'])
-                NG.links.new(GroupInN.outputs['Metalness'],LayerGroupBLND.inputs['Metalness A'])
-                NG.links.new(GroupInN.outputs['Roughness'],LayerGroupBLND.inputs['Roughness A'])
-                NG.links.new(GroupInN.outputs['Normal'],LayerGroupBLND.inputs['Normal A'])
-                NG.links.new(GroupInN.outputs['Microblend'],LayerGroupBLND.inputs['Microblend A'])
-
-                NG.links.new(colorReroute.outputs[0],LayerGroupBLND.inputs['Color B'])
-                NG.links.new(mLevelsOutGroup.outputs[0],LayerGroupBLND.inputs['Metalness B'])
-                NG.links.new(rLevelsOutGroup.outputs[0],LayerGroupBLND.inputs['Roughness B'])
-                NG.links.new(BMN.outputs[3],normalReroute.inputs[0])
-                NG.links.new(normalReroute.outputs[0],LayerGroupBLND.inputs['Normal B'])
-                NG.links.new(mask_mixergroup.outputs[0],microblendReroute.inputs[0])
-                NG.links.new(microblendReroute.outputs[0],LayerGroupBLND.inputs['Microblend B'])
-                NG.links.new(mask_mixergroup.outputs[1],layerMaskReroute.inputs[0])
-                NG.links.new(layerMaskReroute.outputs[0],LayerGroupBLND.inputs['Layer Mask'])
-
-                NG.links.new(LayerGroupBLND.outputs['Color'],GroupOutN.inputs['Color'])
-                NG.links.new(LayerGroupBLND.outputs['Metalness'],GroupOutN.inputs['Metalness'])
-                NG.links.new(LayerGroupBLND.outputs['Roughness'],GroupOutN.inputs['Roughness'])
-                NG.links.new(LayerGroupBLND.outputs['Normal'],GroupOutN.inputs['Normal'])
-                NG.links.new(LayerGroupBLND.outputs['Microblend'],GroupOutN.inputs['Microblend'])
-            else:
-                NG.links.new(colorReroute.outputs[0],bundlecombine.inputs['Color'])
-                NG.links.new(mLevelsOutGroup.outputs[0],bundlecombine.inputs['Metalness'])
-                NG.links.new(rLevelsOutGroup.outputs[0],bundlecombine.inputs['Roughness'])
-                NG.links.new(normalReroute.outputs[0],bundlecombine.inputs['Normal'])
-                NG.links.new(mask_mixergroup.outputs[0],microblendReroute.inputs[0])
-                NG.links.new(microblendReroute.outputs[0],bundlecombine.inputs['Microblend'])
-                NG.links.new(layerMaskReroute.outputs[0],bundlecombine.inputs['Layer Mask'])
-                NG.links.new(bundlecombine.outputs[0],GroupOutN.inputs['Layer'])
-
-                NG.links.new(colorReroute.outputs[0],GroupOutN.inputs['Color'])
-                NG.links.new(mLevelsOutGroup.outputs[0],GroupOutN.inputs['Metalness'])
-                NG.links.new(rLevelsOutGroup.outputs[0],GroupOutN.inputs['Roughness'])
-                NG.links.new(BMN.outputs[3],normalReroute.inputs[0])
-                NG.links.new(normalReroute.outputs[0],GroupOutN.inputs['Normal'])
-                NG.links.new(mask_mixergroup.outputs[0],microblendReroute.inputs[0])
-                NG.links.new(microblendReroute.outputs[0],GroupOutN.inputs['Microblend'])
-                NG.links.new(mask_mixergroup.outputs[1],layerMaskReroute.inputs[0])
-                NG.links.new(layerMaskReroute.outputs[0],GroupOutN.inputs['Layer Mask'])
-
-            NG.links.new(GroupInN.outputs['ColorScale'],BMN.inputs[0])
-            NG.links.new(GroupInN.outputs['NormalStrength'],BMN.inputs[4])
-            NG.links.new(GroupInN.outputs['MetalLevelsIn'],mLevelsInReroute.inputs[0])
-            NG.links.new(mLevelsInReroute.outputs[0],mLevelsInGroup.inputs[1])
-            NG.links.new(GroupInN.outputs['MetalLevelsOut'],mLevelsOutReroute.inputs[0])
-            NG.links.new(mLevelsOutReroute.outputs[0],mLevelsOutGroup.inputs[1])
-            NG.links.new(GroupInN.outputs['RoughLevelsIn'],rLevelsInReroute.inputs[0])
-            NG.links.new(rLevelsInReroute.outputs[0],rLevelsInGroup.inputs[1])
-            NG.links.new(GroupInN.outputs['RoughLevelsOut'],rLevelsOutReroute.inputs[0])
-            NG.links.new(rLevelsOutReroute.outputs[0],rLevelsOutGroup.inputs[1])
-
-            NG.links.new(GroupInN.outputs['MatTile'],BMN.inputs[1])
-            if len(BMN.inputs) > 1:
-              NG.links.new(GroupInN.outputs['OffsetU'],BMN.inputs[2])
-              if len(BMN.inputs) > 2:
-                NG.links.new(GroupInN.outputs['OffsetV'],BMN.inputs[3])
-            NG.links.new(GroupInN.outputs['MicroblendNormalStrength'],mask_mixergroup.inputs['MicroblendNormalStrength'])
-            NG.links.new(GroupInN.outputs['MicroblendContrast'],mask_mixergroup.inputs['MicroblendContrast'])
-            NG.links.new(GroupInN.outputs['MbTile'],MBMapping.inputs[3])
-            NG.links.new(GroupInN.outputs['MicroblendOffsetU'],MBUVCombine.inputs[0])
-            NG.links.new(GroupInN.outputs['MicroblendOffsetV'],MBUVCombine.inputs[1])
-            NG.links.new(GroupInN.outputs['Opacity'],mask_mixergroup.inputs['Opacity'])
-            NG.links.new(GroupInN.outputs['Mask'],mask_mixergroup.inputs['Mask'])
-            NG.links.new(MBTexCord.outputs[2],MBMapping.inputs[0])
-            NG.links.new(MBUVCombine.outputs[0],MBMapping.inputs[1])
-            NG.links.new(MBMapping.outputs[0],MBN.inputs[0])
-            NG.links.new(BMN.outputs[0],colorReroute.inputs[0])
-            NG.links.new(BMN.outputs[1],mLevelsInGroup.inputs[0])
-            NG.links.new(mLevelsInGroup.outputs[0],mLevelsOutGroup.inputs[0])
-            NG.links.new(BMN.outputs[2],rLevelsInGroup.inputs[0])
-            NG.links.new(rLevelsInGroup.outputs[0],rLevelsOutGroup.inputs[0])
-            NG.links.new(MBN.outputs[0],mask_mixergroup.inputs['Microblend'])
-            NG.links.new(MBN.outputs[1],mask_mixergroup.inputs['Microblend Alpha'])
-
-
-        #layer group input node output names
-        #['ColorScale', 'MatTile', 'MbTile', 'MicroblendNormalStrength', 'MicroblendContrast', 'MicroblendOffsetU', 'MicroblendOffsetV', 'NormalStrength', 'Opacity', 'Mask', 'OffsetU', 'OffsetV', '']
-        # Data for vehicledestrblendshape.mt
-        # Instead of maintaining two material py files we should setup the main multilayered shader to handle variants such as the vehicle material
         if "BakedNormal" in Data.keys():
-            LayerNormal=Data["BakedNormal"]
+            LayerNormal = Data["BakedNormal"]
         else:
-            LayerNormal=Data["GlobalNormal"]
+            LayerNormal = Data["GlobalNormal"]
 
-        self.setupMaterial(file_name+"_Layer_", LayerCount, CurMat, Data["MultilayerMask"], LayerNormal)
-
+        self.setupMaterial(file_name + "_Layer_", LayerCount, CurMat, Data["MultilayerMask"], LayerNormal)


### PR DESCRIPTION
moves to datakrash based file indexing for entity import and sector import. 

## entity_import.py: 
* Replaced glob asset searches with DepotAssetIndex from datakrash
* Added indexed app/mesh/rig/anim/phys resolution
* Added parsed ENT/APP loading through JSONToolload_entity() and JSONToolload_app()
* Added cached component, appearance, parent-transform, skinning, shape, collider, and slot lookups
* Added EntityTransformResolver for centralized transform placement
* Moved most component placement logic out of the main mesh-copy loop
* Added source-aware HandleRefId resolution for ENT vs APP chunks
* Added rig JSON fallback armature creation
* Improved hard-component placement
* Improved vehicle slot and component slot placement
* Added no-base animated slot handling
* Reworked light channel import to use resolver-based placement\
* Optimized excluded-mesh checks
* Cached normalized path keys
* Cached submesh index lookups
* Cached armature bone sets
* Cached rig bone indices and matrices
* Cached Child Of inverse matrices
* Cached master collection object lists
* Replaced repeated childof_set_inverse operator usage with direct inverse assignment
* Added direct F-Curve creation for transform animator rotations
* Reduced repeated per-appearance lookup building
* Now configures copied objects before linking them to the scene where ever possible
* Used collectionchildrenget() instead of manual child collection loops
* Added flattened coordinate extraction
* Fixed default appearance handling

## multilayered.py: 
* Added cached multilayer node-tree topologies:
  * layer node groups are now reused by `material template + microblend path + Blender major version`.
  * this avoids generating a unique `ShaderNodeTree` for every layer when the internal topology is identical.
  * per-layer defaults are now applied to the `ShaderNodeGroup` instance, not the shared node tree, so cached groups do not leak mask/default values between layers.

* Added cased dictionary helpers:
  * `get_cased()`
  * `get_cased_value()`
  * `get_cased_depot_path()`

* Collapsed repeated override assignment with:
  * `apply_override()`
  * `set_socket_default()`
  * `float_or_default()`

* Reworked layer value extraction:
  * removed the repeated `x.get("foo") / x.get("Foo")` blocks.
  * material, microblend, color scale, roughness/metal levels, offsets, tile, opacity, and strengths now use the shared helpers.

* Removed the unnecessary `GroupSeparateBundle1.update()` call.

* Replaced mask `os.path.exists()` checks with datakrash-backed indexed path resolution:
  * imports `DepotAssetIndex`
  * caches image indices per root/extension
  * resolves mask layer PNGs through the index instead of sequential filesystem checks.

* Cached Blender version branch once per relevant function:
  * `is_legacy_nodes = vers[0] < 5`
  * removed repeated `vers[0] < 5` hot-loop checks.